### PR TITLE
Handle "cleanly" errors that occur in the contract interpreter during method evaluation

### DIFF
--- a/__tools__/build/Makefile
+++ b/__tools__/build/Makefile
@@ -68,6 +68,7 @@ conf :
 	. $(abspath $(DSTDIR)/bin/activate) ; \
 		$(CNFGEN) --template pservice.toml --template-directory $(SRCDIR)/opt/pdo/etc/template \
 		--node-base pservice --http-base 7000 --output $(DSTDIR)/opt/pdo/etc --count 5
+	cp $(SRCDIR)/opt/pdo/etc/template/pcontract.toml $(DSTDIR)/opt/pdo/etc
 
 template :
 	mkdir -p $(DSTDIR)/opt/pdo/data

--- a/__tools__/build/opt/pdo/etc/template/pcontract.toml
+++ b/__tools__/build/opt/pdo/etc/template/pcontract.toml
@@ -1,0 +1,74 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# --------------------------------------------------
+# Client -- Contract owner configuration
+# --------------------------------------------------
+[Client]
+Identity = "${identity}"
+
+# --------------------------------------------------
+# Sawtooth -- sawtooth ledger configuration
+# --------------------------------------------------
+[Sawtooth]
+LedgerURL = "http://127.0.0.1:8008"
+
+# --------------------------------------------------
+# Service -- Information about enclave/provisioning services
+# --------------------------------------------------
+[Service]
+
+PreferredEnclaveService = "http://127.0.0.1:7101"
+
+EnclaveServiceURLs = [
+    "http://127.0.0.1:7101",
+    "http://127.0.0.1:7102",
+    "http://127.0.0.1:7103"
+]
+
+ProvisioningServiceURLs = [
+    "http://127.0.0.1:7001",
+    "http://127.0.0.1:7002",
+    "http://127.0.0.1:7003"
+]
+
+# --------------------------------------------------
+# Contract -- Contract configuration
+# --------------------------------------------------
+[Contract]
+# Name is the basename of the file where contract
+# information is stored; this may be a full path
+# with or without the pdo extension
+Name = "${contract}"
+DataDirectory = "${data}"
+
+SourceFile = "_${contract}.scm"
+SourceSearchPath = [ ".", "./contracts", "${home}/contracts" ]
+
+SaveFile = "${contract}.pdo"
+
+# --------------------------------------------------
+# Logging -- configuration of service logging
+# --------------------------------------------------
+[Logging]
+LogLevel = "INFO"
+LogFile  = "__screen__"
+
+# --------------------------------------------------
+# Key -- configuration for owner's signing key
+# --------------------------------------------------
+[Key]
+# This key is the contract owner's private elliptic curve PEM key
+SearchPath = [ ".", "./keys", "${keys}" ]
+FileName = "${identity}_private.pem"

--- a/__tools__/rebuild.sh
+++ b/__tools__/rebuild.sh
@@ -54,7 +54,7 @@ make build
 make install
 
 # --------------- CLIENT ---------------
-cd $SRCDIR/clean
+cd $SRCDIR/client
 make clean
 make all
 make install

--- a/__tools__/run-tests.sh
+++ b/__tools__/run-tests.sh
@@ -38,18 +38,32 @@ try() {
     "$@" || die "test failed: $*"
 }
 
+# check for existing enclave and provisioning services
+pgrep eservice
+if [ $? == 0 ] ; then
+    die existing enclave services detected, please shutdown
+fi
+
+pgrep pservice
+if [ $? == 0 ] ; then
+    die existing provisioning services detected, please shutdown
+fi
+
+SAVE_FILE=$(mktemp /tmp/pdo-test.XXXXXXXXX)
+
 function cleanup {
     yell "shutdown services"
-    ${VIRTUAL_ENV}/opt/pdo/bin/ps-stop.sh --count 3 > /dev/null
-    ${VIRTUAL_ENV}/opt/pdo/bin/es-stop.sh --count 3 > /dev/null
+    ${VIRTUAL_ENV}/opt/pdo/bin/ps-stop.sh --count 5 > /dev/null
+    ${VIRTUAL_ENV}/opt/pdo/bin/es-stop.sh --count 5 > /dev/null
+    rm -f ${SAVE_FILE}
 }
 
 trap cleanup EXIT
 
 # start the provisioning and enclave services
 yell start enclave and provisioning services
-try ${VIRTUAL_ENV}/opt/pdo/bin/ps-start.sh --count 3 --ledger ${LEDGER_URL} > /dev/null
-try ${VIRTUAL_ENV}/opt/pdo/bin/es-start.sh --count 1 --ledger ${LEDGER_URL} --clean > /dev/null
+try ${VIRTUAL_ENV}/opt/pdo/bin/ps-start.sh --count 5 --ledger ${LEDGER_URL} > /dev/null
+try ${VIRTUAL_ENV}/opt/pdo/bin/es-start.sh --count 5 --ledger ${LEDGER_URL} --clean > /dev/null
 
 cd ${SRCDIR}/eservice/tests
 yell start secrets test
@@ -68,6 +82,19 @@ yell start simple mock-contract contract test
 try python test-contract.py --no-ledger --contract mock-contract \
      --logfile __screen__ --loglevel warn
 
+yell start broken contract test, this should fail
+python test-contract.py --no-ledger --contract mock-contract-bad \
+       --expressions contracts/mock-contract.exp \
+       --logfile __screen__ --loglevel warn
+if [ $? == 0 ]; then
+    die mock contract test succeeded though it should have failed
+fi
+
+yell start mock-contract contract with bad input, this should succeed
+try python test-contract.py --no-ledger --contract mock-contract \
+    --expressions contracts/mock-contract-bad-expressions.exp \
+    --logfile __screen__ --loglevel warn
+
 yell start request test with provisioning and enclave services
 try python test-request.py --ledger ${LEDGER_URL} \
     --pservice http://localhost:7001/ http://localhost:7002 http://localhost:7003 \
@@ -83,6 +110,81 @@ try python test-contract.py --ledger ${LEDGER_URL} --contract integer-key \
 yell start mock contract test with ledger, this should fail dependency check
 python test-contract.py --ledger ${LEDGER_URL} --contract mock-contract \
        --logfile __screen__ --loglevel warn
+if [ $? == 0 ]; then
+    die mock contract test succeeded though it should have failed
+fi
+
+## -----------------------------------------------------------------
+yell ---------- start pdo-create and pdo-update tests ----------
+## -----------------------------------------------------------------
+
+# make sure we have the necessary files in place
+CONFIG_FILE=${VIRTUAL_ENV}/opt/pdo/etc/pcontract.toml
+if [ ! -f ${CONFIG_FILE} ]; then
+    die missing client configuration file, ${CONFIG_FILE}
+fi
+
+CONTRACT_FILE=${VIRTUAL_ENV}/opt/pdo/contracts/_mock-contract.scm
+if [ ! -f ${CONTRACT_FILE} ]; then
+    die missing contract source file, ${CONTRACT_FILE}
+fi
+
+yell create the contract
+try pdo-create --config ${CONFIG_FILE} --ledger ${LEDGER_URL} \
+     --logfile __screen__ --loglevel warn \
+    --identity user1 --save-file ${SAVE_FILE} \
+    --contract mock-contract --source _mock-contract.scm
+
+yell increment the value with a simple expression
+value=$(pdo-update --config ${CONFIG_FILE} --ledger ${LEDGER_URL} \
+                   --logfile __screen__ --loglevel warn \
+                   --identity user1 --save-file ${SAVE_FILE} \
+                   "'(inc-value)")
+if [ $value != "1" ]; then
+    die contract has the wrong value
+fi
+
+yell increment the value with a evaluated expression
+value=$(pdo-update --config ${CONFIG_FILE} --ledger ${LEDGER_URL} \
+                   --logfile __screen__ --loglevel warn \
+                   --identity user1 --save-file ${SAVE_FILE} \
+                   "(list 'inc-value)")
+if [ $value != "2" ]; then
+    die contract has the wrong value
+fi
+
+yell get the value and check it
+value=$(pdo-update --config ${CONFIG_FILE} --ledger ${LEDGER_URL} \
+                   --logfile __screen__ --loglevel warn \
+                   --identity user1 --save-file ${SAVE_FILE} \
+                   "'(get-value)")
+if [ $value != "2" ]; then
+    die contract has the wrong value
+fi
+
+yell invalid method, this should fail
+pdo-update --config ${CONFIG_FILE} --ledger ${LEDGER_URL} \
+           --logfile __screen__ --loglevel warn \
+           --identity user1 --save-file ${SAVE_FILE} \
+           "'(no-such-method)" > /dev/null
+if [ $? == 0 ]; then
+    die mock contract test succeeded though it should have failed
+fi
+
+yell invalid expression, this should fail
+pdo-update --config ${CONFIG_FILE} --ledger ${LEDGER_URL} \
+           --logfile __screen__ --loglevel warn \
+           --identity user1 --save-file ${SAVE_FILE} \
+           "'(no-such-method"
+if [ $? == 0 ]; then
+    die mock contract test succeeded though it should have failed
+fi
+
+yell policy violation with identity, this should fail
+pdo-update --config ${CONFIG_FILE} --ledger ${LEDGER_URL} \
+           --logfile __screen__ --loglevel warn \
+           --identity user2 --save-file ${SAVE_FILE} \
+           "'(get-value)"
 if [ $? == 0 ]; then
     die mock contract test succeeded though it should have failed
 fi

--- a/__tools__/run-tests.sh
+++ b/__tools__/run-tests.sh
@@ -119,12 +119,12 @@ yell ---------- start pdo-create and pdo-update tests ----------
 ## -----------------------------------------------------------------
 
 # make sure we have the necessary files in place
-CONFIG_FILE=${VIRTUAL_ENV}/opt/pdo/etc/pcontract.toml
+CONFIG_FILE=${CONTRACTHOME}/etc/pcontract.toml
 if [ ! -f ${CONFIG_FILE} ]; then
     die missing client configuration file, ${CONFIG_FILE}
 fi
 
-CONTRACT_FILE=${VIRTUAL_ENV}/opt/pdo/contracts/_mock-contract.scm
+CONTRACT_FILE=${CONTRACTHOME}/contracts/_mock-contract.scm
 if [ ! -f ${CONTRACT_FILE} ]; then
     die missing contract source file, ${CONTRACT_FILE}
 fi

--- a/client/pdo/client/scripts/UpdateCLI.py
+++ b/client/pdo/client/scripts/UpdateCLI.py
@@ -128,7 +128,16 @@ def LocalMain(config, message) :
         try :
             update_request = contract.create_update_request(contract_invoker_keys, enclave_client, msg)
             update_response = update_request.evaluate()
-            print(update_response.result)
+            if update_response.status :
+                print(update_response.result)
+            else :
+                print('ERROR: {}'.format(update_response.result))
+                # continue if this is an interactive session, fail
+                # if we are processing command line messages
+                if message :
+                    sys.exit(-1)
+                else :
+                    continue
         except Exception as e:
             logger.error('enclave failed to evaluation expression; %s', str(e))
             sys.exit(-1)

--- a/common/interpreter/gipsy_scheme/GipsyInterpreter.cpp
+++ b/common/interpreter/gipsy_scheme/GipsyInterpreter.cpp
@@ -105,7 +105,7 @@ static void copy_output_buffer(
     size_t s = pt->rep.string.curr - pt->rep.string.start;
 
     output.resize(pt->rep.string.curr - pt->rep.string.start + 1, 0);
-    memcpy(output.data(), pt->rep.string.start, s);
+    memcpy_s(output.data(), output.size(), pt->rep.string.start, s);
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/common/interpreter/gipsy_scheme/GipsyInterpreter.h
+++ b/common/interpreter/gipsy_scheme/GipsyInterpreter.h
@@ -31,6 +31,7 @@ namespace pc = pdo::contracts;
 class GipsyInterpreter : public pc::ContractInterpreter
 {
 private:
+    std::string error_msg_;
     scheme interpreter;
 
     // load functions with throw errors when unsuccessful

--- a/common/interpreter/gipsy_scheme/packages/oops-package.scm
+++ b/common/interpreter/gipsy_scheme/packages/oops-package.scm
@@ -63,11 +63,11 @@
 
    (define (_check-class sym c)
      (if (not (class? c))
-         (error sym "argument is not a class")))
+         (error "argument is not a class")))
 
    (define (_check-instance sym i)
      (if (not (instance? i))
-         (error sym "argument is not an instance")))
+         (error "argument is not an instance")))
 
    ;; Convert a class variable spec into a binding suitable for a `let'.
 
@@ -84,7 +84,7 @@
          (if (not (or (symbol? (car vars))
                       (and (pair? (car vars)) (= (length (car vars)) 2)
                            (symbol? (caar vars)))))
-             (error 'define-class "bad variable spec: " (car vars))
+             (error "bad variable specification:" (car vars))
              (_check-vars (cdr vars)))))
 
    ;; Check whether the class var spec `v' is already a member of
@@ -96,7 +96,7 @@
       ((null? l) #f)
       ((eq? (caar l) (car v))
        (if (not (equal? (cdar l) (cdr v)))
-           (error 'define-class "initializer mismatch: " (car l) " and " v)
+           (error "initializer mismatch:" (car l) " and " v)
            #t))
       (else (_find-matching-var (cdr l) v))))
 
@@ -131,7 +131,7 @@
        (do ((a args (cdr a))) ((null? a))
          (cond
           ((not (pair? (car a)))
-           (error 'define-class "bad argument: " (car a)))
+           (error "bad argument:" (car a)))
           ((eq? (caar a) 'class-vars)
            (oops::_check-vars (cdar a))
            (set! class-vars (cdar a)))
@@ -141,10 +141,10 @@
                                        (map oops::_make-binding (cdar a)))))
           ((eq? (caar a) 'super-class)
            (if (> (length (cdar a)) 1)
-               (error 'define-class "only one super-class allowed"))
+               (error "only one super-class allowed"))
            (set! super (cadar a)))
           (else
-           (error 'define-class "bad keyword: " (caar a)))))
+           (error "bad keyword:" (caar a)))))
        (if (not (null? super))
            (let ((class (eval super)))
              (set! super-class-env (class-env class))
@@ -165,7 +165,7 @@
    ;; -----------------------------------------------------------------
    (define-macro (define-method class lambda-list . body)
      (if (not (pair? lambda-list))
-         (error 'define-method "bad lambda list"))
+         (error "bad lambda list"))
      `(begin
         (oops::_check-class 'define-method ,class)
         (let ((env (oops::class-env ,class))
@@ -267,7 +267,7 @@
      (_check-instance 'send instance)
      (let ((class (eval (class-name instance))))
        (if (not (_method-known? msg class))
-           (error 'send "message not understood: " `(,msg ,@margs))
+           (error "message not understood:" `(,msg ,@margs))
            (let* ((pargs (_process-send-args margs))
                   (args (vector-ref pargs 1))
                   (tags (vector-ref pargs 0))

--- a/common/packages/tinyscheme/scheme.c
+++ b/common/packages/tinyscheme/scheme.c
@@ -4095,24 +4095,25 @@ static pointer opexe_4(scheme * sc, enum scheme_opcodes op)
     case OP_ERR0:		/* error */
 	sc->retcode = -1;
 	if (!is_string(car(sc->args))) {
-	    sc->args = cons(sc, mk_string(sc, " -- "), sc->args);
+            sc->args = cons(sc, mk_string(sc, " -- "), sc->args);
 	    setimmutable(car(sc->args));
 	}
-	putstr(sc, "Error: ");
+        if (sc->interactive_repl)
+            putstr(sc, "Error: ");
 	putstr(sc, strvalue(car(sc->args)));
 	sc->args = cdr(sc->args);
 	s_goto(sc, OP_ERR1);
 
     case OP_ERR1:		/* error */
-	putstr(sc, " ");
+        putstr(sc, " ");
 	if (sc->args != sc->NIL) {
 	    s_save(sc, OP_ERR1, cdr(sc->args), sc->NIL);
 	    sc->args = car(sc->args);
 	    sc->print_flag = 1;
 	    s_goto(sc, OP_P0LIST);
 	} else {
-	    putstr(sc, "\n");
 	    if (sc->interactive_repl) {
+                putstr(sc, "\n");
 		s_goto(sc, OP_T0LVL);
 	    } else {
 		return sc->NIL;

--- a/eservice/lib/libpdo_enclave/contract_request.cpp
+++ b/eservice/lib/libpdo_enclave/contract_request.cpp
@@ -165,17 +165,43 @@ ContractResponse ContractRequest::process_initialization_request(void)
 
         return response;
     }
+    catch (pdo::error::ValueError& e)
+    {
+        SAFE_LOG(PDO_LOG_ERROR,
+                 "failed initialization for contract %s: %s",
+                 contract_code_.name_.c_str(),
+                 e.what());
+
+        ByteArray error_state(0);
+        std::map<string, string> dependencies;
+        ContractResponse response(*this, dependencies, error_state, e.what());
+        response.operation_succeeded_ = false;
+        return response;
+    }
     catch (pdo::error::Error& e)
     {
         SAFE_LOG(PDO_LOG_ERROR,
-            "exception occured while processing contract initialization request: %04X -- %s",
-            e.error_code(), e.what());
-        throw;
+                 "exception while processing update for contract %s with message %s: %s",
+                 contract_code_.name_.c_str(),
+                 contract_message_.expression_.c_str(),
+                 e.what());
+
+        ByteArray error_state(0);
+        std::map<string, string> dependencies;
+        ContractResponse response(*this, dependencies, error_state, "internal error");
+        response.operation_succeeded_ = false;
+        return response;
     }
     catch (...)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "unknown error happened while processing contract initialization");
-        throw;
+        SAFE_LOG(PDO_LOG_ERROR,
+                 "unknown exception while processing initialization request");
+
+        ByteArray error_state(0);
+        std::map<string, string> dependencies;
+        ContractResponse response(*this, dependencies, error_state, "unknown internal error");
+        response.operation_succeeded_ = false;
+        return response;
     }
 }
 
@@ -212,17 +238,44 @@ ContractResponse ContractRequest::process_update_request(void)
         ContractResponse response(*this, dependencies, new_state, result);
         return response;
     }
+    catch (pdo::error::ValueError& e)
+    {
+        SAFE_LOG(PDO_LOG_ERROR,
+                 "failed update for contract %s with message %s: %s",
+                 contract_code_.name_.c_str(),
+                 contract_message_.expression_.c_str(),
+                 e.what());
+
+        ByteArray error_state(0);
+        std::map<string, string> dependencies;
+        ContractResponse response(*this, dependencies, error_state, e.what());
+        response.operation_succeeded_ = false;
+        return response;
+    }
     catch (pdo::error::Error& e)
     {
         SAFE_LOG(PDO_LOG_ERROR,
-            "exception occured while processing contract update request: %04X -- %s",
-            e.error_code(), e.what());
-        throw;
+                 "exception while processing update for contract %s with message %s: %s",
+                 contract_code_.name_.c_str(),
+                 contract_message_.expression_.c_str(),
+                 e.what());
+
+        ByteArray error_state(0);
+        std::map<string, string> dependencies;
+        ContractResponse response(*this, dependencies, error_state, "internal error");
+        response.operation_succeeded_ = false;
+        return response;
     }
     catch (...)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "unknown error happened while processing contract update");
-        throw;
+        SAFE_LOG(PDO_LOG_ERROR,
+                 "unknown exception while processing update request");
+
+        ByteArray error_state(0);
+        std::map<string, string> dependencies;
+        ContractResponse response(*this, dependencies, error_state, "unknown internal error");
+        response.operation_succeeded_ = false;
+        return response;
     }
 }
 

--- a/eservice/lib/libpdo_enclave/contract_response.cpp
+++ b/eservice/lib/libpdo_enclave/contract_response.cpp
@@ -185,7 +185,7 @@ ByteArray ContractResponse::SerializeAndEncrypt(const ByteArray& session_key,
             pdo::error::ThrowIfNull(dependency_value, "failed to create a dependency array");
 
             JSON_Object* dependency_object = json_value_get_object(dependency_value);
-            pdo::error::ThrowIfNull(dependency_object, "failed to create a dependency array");
+            pdo::error::ThrowIfNull(dependency_object, "failed to create a dependency value");
 
             jret = json_object_dotset_string(dependency_object, "ContractID", it->first.c_str());
             pdo::error::ThrowIf<pdo::error::RuntimeError>(

--- a/eservice/lib/libpdo_enclave/contract_response.h
+++ b/eservice/lib/libpdo_enclave/contract_response.h
@@ -45,6 +45,7 @@ public:
     std::map<std::string, std::string> dependencies_;
     ContractState contract_state_;
     std::string result_;
+    bool operation_succeeded_;
 
     ContractResponse(const ContractRequest& request,
         const std::map<std::string, std::string>& dependencies,

--- a/eservice/tests/contracts/mock-contract-bad-expressions.exp
+++ b/eservice/tests/contracts/mock-contract-bad-expressions.exp
@@ -1,0 +1,4 @@
+'(inc-value)
+'(inc-value)
+'(get-value)
+'(depends (("ea30107ad1d382dbff627746b6b337419c132559ca103a6e2bedddd5fd4d731e1bdedddcb944a65f9efa42711624ce5303c1317ed4f37355b68a0f370a985410" "9WCZbOvTilcCu97BdK9e3BrG1ElbK/ARXRpI9rKErQE=")))

--- a/eservice/tests/contracts/mock-contract-bad.scm
+++ b/eservice/tests/contracts/mock-contract-bad.scm
@@ -1,0 +1,46 @@
+;; Copyright 2018 Intel Corporation
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(define-macro (assert pred . message)
+  `(if (not ,pred) (throw ,@message))
+
+(define-class mock-contract
+  (instance-vars
+   (creator (get ':message 'originator))
+   (value 0)))
+
+(define-method mock-contract (s-value)
+  "this is a string")
+
+(define-method mock-contract (get-value)
+  (let* ((requestor (get ':message 'originator)))
+    (assert (string=? requestor creator) "only the creator can get the value"))
+  value)
+
+(define-method mock-contract (inc-value)
+  (let* ((requestor (get ':message 'originator)))
+    (assert (string=? requestor creator) "only the creator can inc the value"))
+  (instance-set! self 'value (+ value 1))
+  value)
+
+(define-method mock-contract (dec-value)
+  (let* ((requestor (get ':message 'originator)))
+    (assert (string=? requestor creator) "only the creator can inc the value"))
+  (assert (> value 0) "value must not be negative")
+  (instance-set! self 'value (- value 1))
+  value)
+
+(define-method mock-contract (depends dependencies)
+  (put ':ledger 'dependencies dependencies)
+  value)

--- a/eservice/tests/test-contract.py
+++ b/eservice/tests/test-contract.py
@@ -196,6 +196,10 @@ def CreateAndRegisterContract(config, enclave, contract_creator_keys) :
     try :
         initialize_request = contract.create_initialize_request(contract_creator_keys, enclave)
         initialize_response = initialize_request.evaluate()
+        if initialize_response.status is False :
+            logger.error('contract initialization failed: %s', initialize_response.result)
+            sys.exit(-1)
+
         contract.set_state(initialize_response.encrypted_state)
 
     except Exception as e :
@@ -246,7 +250,12 @@ def UpdateTheContract(config, enclave, contract, contract_invoker_keys) :
         try :
             update_request = contract.create_update_request(contract_invoker_keys, enclave, expression)
             update_response = update_request.evaluate()
-            logger.info('result of evaluation: %s', update_response.result)
+            if update_response.status is False :
+                logger.info('failed: {0} --> {1}'.format(expression, update_response.result))
+                continue
+
+            logger.info('{0} --> {1}'.format(expression, update_response.result))
+
         except Exception as e:
             logger.error('enclave failed to evaluation expression; %s', str(e))
             sys.exit(-1)
@@ -300,10 +309,14 @@ def LocalMain(config) :
         if use_ledger :
             logger.info('reload the contract from local file')
             contract = contract_helper.Contract.read_from_file(ledger_config, contract_name, data_dir=data_dir)
-
-        UpdateTheContract(config, enclave, contract, contract_creator_keys)
     except Exception as e :
         logger.error('failed to load the contract from a file; %s', str(e))
+        sys.exit(-1)
+
+    try :
+        UpdateTheContract(config, enclave, contract, contract_creator_keys)
+    except Exception as e :
+        logger.error('contract execution failed; %s', str(e))
         sys.exit(-1)
 
     sys.exit(0)


### PR DESCRIPTION
Modify the result from contract method invocation to pass back
a status that captures the success/failure of the method execution.
On failure, only the result field will be filled, it will contain
the error message.

Client libraries for processing requests and results were modified
to accommodate the change return value. Client scripts were updated
as well to process the results.

Added a number of additional tests for bad messages. Added some
pdo-create and pdo-update tests including ones with bad contracts
and bad method expressions.