### PR TITLE
Fixed aes-gcm IV usage, all random now PDCN-210 

### DIFF
--- a/eservice/lib/libpdo_enclave/contract_enclave.cpp
+++ b/eservice/lib/libpdo_enclave/contract_enclave.cpp
@@ -149,14 +149,13 @@ pdo_err_t ecall_HandleContractRequest(const uint8_t* inSealedSignupData,
         ByteArray encrypted_key(
             inEncryptedSessionKey, inEncryptedSessionKey + inEncryptedSessionKeySize);
         ByteArray session_key = enclaveData.decrypt_message(encrypted_key);
-        ByteArray session_iv = pdo::crypto::skenc::GenerateIV(enclaveData.get_enclave_id());
 
         ByteArray encrypted_request(
             inSerializedRequest, inSerializedRequest + inSerializedRequestSize);
-        ContractRequest request(session_key, session_iv, encrypted_request);
+        ContractRequest request(session_key, encrypted_request);
 
         ContractResponse response(request.process_request());
-        last_result = response.SerializeAndEncrypt(session_key, session_iv, enclaveData);
+        last_result = response.SerializeAndEncrypt(session_key, enclaveData);
 
         // save the response and return the size of the buffer required for it
         (*outSerializedResponseSize) = last_result.size();

--- a/eservice/lib/libpdo_enclave/contract_request.cpp
+++ b/eservice/lib/libpdo_enclave/contract_request.cpp
@@ -64,12 +64,12 @@
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ContractRequest::ContractRequest(
-    const ByteArray& session_key, const ByteArray& session_iv, const ByteArray& encrypted_request)
+    const ByteArray& session_key, const ByteArray& encrypted_request)
 {
     JSON_Object* ovalue = nullptr;
 
     ByteArray decrypted_request =
-        pdo::crypto::skenc::DecryptMessage(session_key, session_iv, encrypted_request);
+        pdo::crypto::skenc::DecryptMessage(session_key, encrypted_request);
     std::string request = ByteArrayToString(decrypted_request);
 
     // Parse the contract request

--- a/eservice/lib/libpdo_enclave/contract_request.h
+++ b/eservice/lib/libpdo_enclave/contract_request.h
@@ -51,9 +51,7 @@ public:
     ContractCode contract_code_; /*  */
     ContractMessage contract_message_;
 
-    ContractRequest(const ByteArray& session_key,
-        const ByteArray& session_iv,
-        const ByteArray& encrypted_request);
+    ContractRequest(const ByteArray& session_key, const ByteArray& encrypted_request);
 
     bool is_initialize(void) const { return operation_ == op_initialize; };
     bool is_update(void) const { return operation_ == op_update; };

--- a/eservice/lib/libpdo_enclave/contract_response.cpp
+++ b/eservice/lib/libpdo_enclave/contract_response.cpp
@@ -115,9 +115,8 @@ ByteArray ContractResponse::ComputeSignature(const EnclaveData& enclave_data) co
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-ByteArray ContractResponse::SerializeAndEncrypt(const ByteArray& session_key,
-    const ByteArray& session_iv,
-    const EnclaveData& enclave_data) const
+ByteArray ContractResponse::SerializeAndEncrypt(
+    const ByteArray& session_key, const EnclaveData& enclave_data) const
 {
     // Create the response structure
     JsonValue contract_response_value(json_value_init_object());
@@ -193,7 +192,7 @@ ByteArray ContractResponse::SerializeAndEncrypt(const ByteArray& session_key,
         jret != JSONSuccess, "contract response serialization failed");
 
     ByteArray encrypted_response =
-        pdo::crypto::skenc::EncryptMessage(session_key, session_iv, serialized_response);
+        pdo::crypto::skenc::EncryptMessage(session_key, serialized_response);
 
     return encrypted_response;
 }

--- a/eservice/lib/libpdo_enclave/contract_response.h
+++ b/eservice/lib/libpdo_enclave/contract_response.h
@@ -51,7 +51,6 @@ public:
         const ByteArray& state,
         const std::string& result);
 
-    ByteArray SerializeAndEncrypt(const ByteArray& session_key,
-        const ByteArray& session_iv,
-        const EnclaveData& enclave_data) const;
+    ByteArray SerializeAndEncrypt(
+        const ByteArray& session_key, const EnclaveData& enclave_data) const;
 };

--- a/eservice/lib/libpdo_enclave/contract_secrets.cpp
+++ b/eservice/lib/libpdo_enclave/contract_secrets.cpp
@@ -168,10 +168,9 @@ ByteArray EncryptStateEncryptionKey(
     const std::string& inContractId, const ByteArray& inContractStateEncryptionKey)
 {
     ByteArray key_encryption_key = CreateKeyEncryptionKey(inContractId);
-    ByteArray key_encryption_iv = pdo::crypto::skenc::GenerateIV(inContractId);
 
-    ByteArray encrypted_state_encryption_key = pdo::crypto::skenc::EncryptMessage(
-        key_encryption_key, key_encryption_iv, inContractStateEncryptionKey);
+    ByteArray encrypted_state_encryption_key =
+        pdo::crypto::skenc::EncryptMessage(key_encryption_key, inContractStateEncryptionKey);
 
     return encrypted_state_encryption_key;
 }
@@ -190,10 +189,9 @@ ByteArray DecryptStateEncryptionKey(
     const std::string& inContractId, const ByteArray& inEncryptedStateEncryptionKey)
 {
     ByteArray key_encryption_key = CreateKeyEncryptionKey(inContractId);
-    ByteArray key_encryption_iv = pdo::crypto::skenc::GenerateIV(inContractId);
 
-    ByteArray decrypted_state_encryption_key = pdo::crypto::skenc::DecryptMessage(
-        key_encryption_key, key_encryption_iv, inEncryptedStateEncryptionKey);
+    ByteArray decrypted_state_encryption_key =
+        pdo::crypto::skenc::DecryptMessage(key_encryption_key, inEncryptedStateEncryptionKey);
 
     return decrypted_state_encryption_key;
 }

--- a/eservice/pdo/eservice/enclave/enclave/contract.cpp
+++ b/eservice/pdo/eservice/enclave/enclave/contract.cpp
@@ -31,7 +31,7 @@ size_t pdo::enclave_api::contract::ContractKeySize(void)
 {
     // this is somewhat lucky because we currently fit precisely
     // in the AES block; will need to pad if
-    return pdo::crypto::constants::SYM_KEY_LEN + pdo::crypto::constants::TAG_LEN;
+    return pdo::crypto::constants::IV_LEN + pdo::crypto::constants::SYM_KEY_LEN + pdo::crypto::constants::TAG_LEN;
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/python/pdo/contract/request.py
+++ b/python/pdo/contract/request.py
@@ -51,10 +51,6 @@ class ContractRequest(object) :
     def enclave_keys(self) :
         return self.enclave_service.enclave_keys
 
-    @property
-    def session_iv(self) :
-        return crypto.SKENC_GenerateIV(self.enclave_keys.identity)
-
     def __serialize_for_encryption(self) :
         result = dict()
         result['Operation'] = self.operation
@@ -74,13 +70,13 @@ class ContractRequest(object) :
 
     def __encrypt_request(self) :
         serialized_byte_array = crypto.string_to_byte_array(self.__serialize_for_encryption())
-        encrypted_request = crypto.SKENC_EncryptMessage(self.session_key, self.session_iv, serialized_byte_array)
+        encrypted_request = crypto.SKENC_EncryptMessage(self.session_key, serialized_byte_array)
         return crypto.byte_array_to_base64(encrypted_request)
 
     # response -- base64 encode, response encrypted with session key
     def __decrypt_response(self, response) :
         decoded_response = crypto.base64_to_byte_array(response)
-        return crypto.SKENC_DecryptMessage(self.session_key, self.session_iv, decoded_response)
+        return crypto.SKENC_DecryptMessage(self.session_key, decoded_response)
 
     # enclave_service -- enclave service wrapper object
     def evaluate(self) :


### PR DESCRIPTION
Replace all usages of EncryptMessage with user provided IV for AES-GCM encryption with calls to EncryptMessage  with no input IV and internally generated random IV.