### PR TITLE
Implement a pdo-shell that supports contract-specific plugins

### DIFF
--- a/client/contracts/contracts/integer-key.scm
+++ b/client/contracts/contracts/integer-key.scm
@@ -173,7 +173,7 @@
       (assert (send agent-keys 'verify-expression expression signature) "signature mismatch" signature)
 
       ;; this update cannot be committed unless the dependencies are committed
-      (put ':ledger 'dependencies dependencies)
+      (if (pair? dependencies) (put ':ledger 'dependencies dependencies))
       (send counter 'activate)
 
       #t)))

--- a/client/pdo/client/controller/__init__.py
+++ b/client/pdo/client/controller/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = []

--- a/client/pdo/client/controller/commands/__init__.py
+++ b/client/pdo/client/controller/commands/__init__.py
@@ -1,0 +1,30 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [ 'contract', 'create', 'eservice', 'pservice', 'send' ]
+
+import pdo.client.controller.commands.contract
+contract = contract.command_contract
+
+import pdo.client.controller.commands.create
+create = create.command_create
+
+import pdo.client.controller.commands.eservice
+eservice = eservice.command_eservice
+
+import pdo.client.controller.commands.pservice
+pservice = pservice.command_pservice
+
+import pdo.client.controller.commands.send
+send = send.command_send

--- a/client/pdo/client/controller/commands/contract.py
+++ b/client/pdo/client/controller/commands/contract.py
@@ -1,0 +1,110 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import logging
+
+logger = logging.getLogger(__name__)
+
+from pdo.contract import ContractState
+from pdo.contract import Contract
+
+__all__ = [
+    'command_contract',
+    'get_contract',
+    'load_contract',
+    'refresh_contract',
+    'save_contract'
+    ]
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def command_contract(state, bindings, pargs) :
+    """controller command to manage contracts
+    """
+
+    parser = argparse.ArgumentParser(prog='contract')
+
+    subparsers = parser.add_subparsers(dest='command')
+    load_parser = subparsers.add_parser('load')
+    load_parser.add_argument('-f', '--save-file', help='File where contract data is stored', type=str, required=True)
+    load_parser.add_argument('-r', '--refresh', help='Refresh state from ledger', action='store_true')
+
+    refresh_parser = subparsers.add_parser('refresh')
+    refresh_parser.add_argument('-f', '--save-file', help='File where contract data is stored', type=str)
+
+    options = parser.parse_args(pargs)
+
+    if options.command == 'load' :
+        contract = load_contract(state, options.save_file)
+
+        if options.refresh :
+            refresh_contract(state, contract)
+
+        save_contract(state, options.save_file, contract)
+
+    elif options.command == 'refresh' :
+        contract = get_contract(state, options.save_file)
+        refresh_contract(state, contract)
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def refresh_contract(state, contract) :
+    try :
+        data_directory = state.get(['Contract', 'DataDirectory'])
+        ledger_config = state.get(['Sawtooth'])
+
+        contract_state = ContractState.get_from_ledger(ledger_config, contract.contract_id)
+        contract_state.save_to_cache(data_dir=data_directory)
+        contract.set_state(contract_state.encrypted_state)
+    except Exception as e :
+        raise Exception('unable to refresh the state from the ledger; {0}'.format(str(e)))
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def save_contract(state, contract_file, contract) :
+    state.set(['Contract', 'SaveFile'], contract_file)
+    state.set(['Contract', 'Name'], contract.contract_code.name)
+    state.set(['Contract', 'Contract'], contract)
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def load_contract(state, contract_file) :
+    try :
+        data_directory = state.get(['Contract', 'DataDirectory'])
+        ledger_config = state.get(['Sawtooth'])
+
+        return Contract.read_from_file(ledger_config, contract_file, data_dir=data_directory)
+    except Exception as e :
+        raise Exception('unable to load the contract; {0}'.format(str(e)))
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def get_contract(state, save_file=None) :
+    """create an enclave client for the preferred enclave service; assumes
+    exception handling by the calling procedure
+    """
+
+    if save_file is not None :
+        return load_contract(state, save_file)
+
+    current_contract = state.get(['Contract', 'Contract'], None)
+    if current_contract is not None :
+        return current_contract
+
+    current_save_file = state.get(['Contract', 'SaveFile'], None)
+    if current_save_file is None :
+        raise Exception('no contract specified')
+
+    return load_contract(current_save_file)

--- a/client/pdo/client/controller/commands/create.py
+++ b/client/pdo/client/controller/commands/create.py
@@ -1,0 +1,193 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import logging
+import random
+
+logger = logging.getLogger(__name__)
+
+import pdo.common.crypto as pcrypto
+
+from pdo.common.keys import ServiceKeys
+from pdo.contract import ContractCode
+from pdo.contract import ContractState
+from pdo.contract import Contract
+from pdo.contract import register_contract
+from pdo.contract import add_enclave_to_contract
+from pdo.service_client.enclave import EnclaveServiceClient
+from pdo.service_client.provisioning import ProvisioningServiceClient
+
+__all__ = ['command_create']
+
+## -----------------------------------------------------------------
+def __add_enclave_secrets(ledger_config, contract_id, client_keys, enclaveclients, provclients) :
+    """Create and provision the encrypted secrets for each of the
+    enclaves that will be provisioned for this contract.
+    """
+
+    secrets = {}
+    encrypted_state_encryption_keys = {}
+    for enclaveclient in enclaveclients:
+        psecrets = []
+        for provclient in provclients:
+            # Get a pspk:esecret pair from the provisioning service for each enclave
+            sig_payload = pcrypto.string_to_byte_array(enclaveclient.enclave_id + contract_id)
+            secretinfo = provclient.get_secret(enclaveclient.enclave_id,
+                                               contract_id,
+                                               client_keys.verifying_key,
+                                               client_keys.sign(sig_payload))
+            logger.debug("pservice secretinfo: %s", secretinfo)
+
+            # Add this pspk:esecret pair to the list
+            psecrets.append(secretinfo)
+
+        # Print all of the secret pairs generated for this particular enclave
+        logger.debug('psecrets for enclave %s : %s', enclaveclient.enclave_id, psecrets)
+
+        # Verify those secrets with the enclave
+        esresponse = enclaveclient.verify_secrets(contract_id, client_keys.verifying_key, psecrets)
+        logger.debug("verify_secrets response: %s", esresponse)
+
+        # Store the ESEK mapping in a dictionary key'd by the enclave's public key (ID)
+        encrypted_state_encryption_keys[enclaveclient.enclave_id] = esresponse['encrypted_state_encryption_key']
+
+        # Add this spefiic enclave to the contract
+        add_enclave_to_contract(ledger_config,
+                                client_keys,
+                                contract_id,
+                                enclaveclient.enclave_id,
+                                psecrets,
+                                esresponse['encrypted_state_encryption_key'],
+                                esresponse['signature'])
+
+    return encrypted_state_encryption_keys
+
+## -----------------------------------------------------------------
+def __create_contract(ledger_config, client_keys, enclaveclients, contract) :
+    """Create the initial contract state
+    """
+
+    # Choose one enclave at random to use to create the contract
+    enclaveclient = random.choice(enclaveclients)
+
+    logger.info('Requesting that the enclave initialize the contract...')
+    initialize_request = contract.create_initialize_request(client_keys, enclaveclient)
+    initialize_response = initialize_request.evaluate()
+    contract.set_state(initialize_response.encrypted_state)
+
+    logger.info('Contract state created successfully')
+
+    logger.info('Saving the initial contract state in the ledger...')
+
+    cclinit_result = initialize_response.submit_initialize_transaction(ledger_config, wait=30.0)
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def command_create(state, bindings, pargs) :
+    """controller command to create a contract
+    """
+
+    parser = argparse.ArgumentParser(prog='create')
+    parser.add_argument('-c', '--contract-class', help='Name of the contract class', required = True, type=str)
+    parser.add_argument('-s', '--contract-source', help='File that contains contract source code', required=True, type=str)
+    parser.add_argument('-f', '--save-file', help='File where contract data is stored', type=str)
+    options = parser.parse_args(pargs)
+
+    contract_class = options.contract_class
+    contract_source = options.contract_source
+
+    contract_file = "{0}.pdo".format(contract_class)
+    if options.save_file :
+        contract_file = options.save_file
+
+    # ---------- load the invoker's keys ----------
+    try :
+        keyfile = state.get(['Key', 'FileName'])
+        keypath = state.get(['Key', 'SearchPath'])
+        client_keys = ServiceKeys.read_from_file(keyfile, keypath)
+    except Exception as e :
+        raise Exception('unable to load client keys; {0}'.format(str(e)))
+
+    # ---------- read the contract source code ----------
+    try :
+        source_path = state.get(['Contract', 'SourceSearchPath'])
+        contract_code = ContractCode.create_from_scheme_file(contract_class, contract_source, source_path)
+    except Exception as e :
+        raise Exception('unable to load contract source; {0}'.format(str(e)))
+
+    logger.info('Loaded contract code for %s', contract_class)
+
+    # ---------- set up the enclave clients ----------
+    try :
+        eservice_urls = state.get(['Service', 'EnclaveServiceURLs'], [])
+        if len(eservice_urls) == 0 :
+            raise Exception('no enclave services specified')
+
+        enclaveclients = []
+        for url in eservice_urls :
+            enclaveclients.append(EnclaveServiceClient(url))
+    except Exception as e :
+        raise Exception('unable to contact enclave services; {0}'.format(str(e)))
+
+    # ---------- set up the provisioning service clients ----------
+    # This is a dictionary of provisioning service public key : client pairs
+    try :
+        pservice_urls = state.get(['Service', 'ProvisioningServiceURLs'])
+        if len(pservice_urls) == 0 :
+            raise Exception('no provisioning services specified')
+
+        provclients = []
+        for url in pservice_urls :
+            provclients.append(ProvisioningServiceClient(url))
+    except Exception as e :
+        raise Exception('unable to contact provisioning services; {0}'.format(str(e)))
+
+    # ---------- register contract ----------
+    data_directory = state.get(['Contract', 'DataDirectory'])
+    ledger_config = state.get(['Sawtooth'])
+
+    try :
+        provisioning_service_keys = [pc.identity for pc in provclients]
+        contract_id = register_contract(
+            ledger_config, client_keys, contract_code, provisioning_service_keys)
+
+        logger.info('Registered contract with class %s and id %s', contract_class, contract_id)
+        contract_state = ContractState.create_new_state(contract_id)
+        contract = Contract(contract_code, contract_state, contract_id, client_keys.identity)
+        contract.save_to_file(contract_file, data_dir=data_directory)
+    except Exception as e :
+        raise Exception('failed to register the contract; {0}'.format(str(e)))
+
+    # provision the encryption keys to all of the enclaves
+    try :
+        encrypted_state_encryption_keys = __add_enclave_secrets(
+            ledger_config, contract.contract_id, client_keys, enclaveclients, provclients)
+
+        for enclave_id in encrypted_state_encryption_keys :
+            encrypted_key = encrypted_state_encryption_keys[enclave_id]
+            contract.set_state_encryption_key(enclave_id, encrypted_key)
+
+        contract.save_to_file(contract_file, data_dir=data_directory)
+    except Exception as e :
+        raise Exception('failed to provisioning the enclaves; {0}'.format(str(e)))
+
+    # create the initial contract state
+    try :
+        __create_contract(ledger_config, client_keys, enclaveclients, contract)
+
+        contract.contract_state.save_to_cache(data_dir = data_directory)
+        contract.save_to_file(contract_file, data_dir=data_directory)
+    except Exception as e :
+        raise Exception('failed to create the initial contract state; {0}'.format(str(e)))

--- a/client/pdo/client/controller/commands/eservice.py
+++ b/client/pdo/client/controller/commands/eservice.py
@@ -1,0 +1,108 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import logging
+
+logger = logging.getLogger(__name__)
+
+from pdo.service_client.enclave import EnclaveServiceClient
+
+__all__ = ['command_eservice']
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def command_eservice(state, bindings, pargs) :
+    """controller command to manage the list of enclave services
+    """
+    subcommands = ['add', 'remove', 'set', 'use', 'info', 'list']
+
+    parser = argparse.ArgumentParser(prog='eservice')
+    subparsers = parser.add_subparsers(dest='command')
+    add_parser = subparsers.add_parser('add')
+    add_parser.add_argument('--url', help='URLs for the enclave service', type=str, nargs='+', required=True)
+
+    remove_parser = subparsers.add_parser('remove')
+    remove_parser.add_argument('--url', help='URLs for the enclave service', type=str, nargs='+', required=True)
+
+    set_parser = subparsers.add_parser('set')
+    set_parser.add_argument('--url', help='URLs for the enclave service', type=str, nargs='+', required=True)
+
+    info_parser = subparsers.add_parser('use')
+    info_parser.add_argument('--url', help='URLs for the enclave service', type=str, required=True)
+
+    info_parser = subparsers.add_parser('info')
+    info_parser.add_argument('--url', help='URLs for the enclave service', type=str, nargs='+')
+
+    list_parser = subparsers.add_parser('list')
+
+    options = parser.parse_args(pargs)
+
+    if options.command == 'add' :
+        services = set(state.get(['Service', 'EnclaveServiceURLs'], []))
+        services = services.union(options.url)
+        state.set(['Service', 'EnclaveServiceURLs'], list(services))
+        return
+
+    if options.command == 'remove' :
+        services = set(state.get(['Service', 'EnclaveServiceURLs'], []))
+        services = services.difference(options.url)
+        state.set(['Service', 'EnclaveServiceURLs'], list(services))
+        return
+
+    if options.command == 'set' :
+        state.set(['Service', 'EnclaveServiceURLs'], options.url)
+        return
+
+    if options.command == 'use' :
+        state.set(['Service', 'PreferredEnclaveService'], options.url)
+        return
+
+    if options.command == 'info' :
+        services = state.get(['Service', 'EnclaveServiceURLs'])
+        if options.url :
+            services = options.url
+
+        for url in services :
+            try :
+                client = EnclaveServiceClient(url)
+                print("{0} --> {1}".format(url, client.verifying_key))
+            except :
+                print('unable to retreive information from {0}'.format(url))
+        return
+
+    if options.command == 'list' :
+        services = set(state.get(['Service', 'EnclaveServiceURLs'], []))
+        for service in services :
+            print(service)
+
+        return
+
+    raise Exception('unknown subcommand')
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def get_enclave_service(state, enclave_url=None) :
+    """create an enclave client for the preferred enclave service; assumes
+    exception handling by the calling procedure
+    """
+    if enclave_url is None :
+        enclave_url = state.get(['Service', 'PreferredEnclaveService'], None)
+        if enclave_url is None :
+            enclave_url = random.choice(state.get(['Service', 'EnclaveServiceURLs'], []))
+
+    if enclave_url is None :
+        raise Exception('no enclave service specified')
+
+    return EnclaveServiceClient(enclave_url)

--- a/client/pdo/client/controller/commands/pservice.py
+++ b/client/pdo/client/controller/commands/pservice.py
@@ -1,0 +1,85 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import logging
+
+logger = logging.getLogger(__name__)
+
+from pdo.service_client.provisioning import ProvisioningServiceClient
+
+__all__ = ['command_pservice']
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def command_pservice(state, bindings, pargs) :
+    """controller command to manage the list of provisioning services
+    """
+    subcommands = ['add', 'remove', 'set', 'info', 'list']
+
+    parser = argparse.ArgumentParser(prog='pservice')
+    subparsers = parser.add_subparsers(dest='command')
+
+    add_parser = subparsers.add_parser('add')
+    add_parser.add_argument('--url', help='URLs for the provisioning service', type=str, nargs='+', required=True)
+
+    remove_parser = subparsers.add_parser('remove')
+    remove_parser.add_argument('--url', help='URLs for the provisioning service', type=str, nargs='+', required=True)
+
+    set_parser = subparsers.add_parser('set')
+    set_parser.add_argument('--url', help='URLs for the provisioning service', type=str, nargs='+', required=True)
+
+    info_parser = subparsers.add_parser('info')
+    info_parser.add_argument('--url', help='URLs for the provisioning service', type=str, nargs='+')
+
+    list_parser = subparsers.add_parser('list')
+
+    options = parser.parse_args(pargs)
+
+    if options.command == 'add' :
+        services = set(state.get(['Service', 'ProvisioningServiceURLs'], []))
+        services = services.union(options.url)
+        state.set(['Service', 'ProvisioningServiceURLs'], list(services))
+        return
+
+    if options.command == 'remove' :
+        services = set(state.get(['Service', 'ProvisioningServiceURLs'], []))
+        services = services.difference(options.url)
+        state.set(['Service', 'ProvisioningServiceURLs'], list(services))
+        return
+
+    if options.command == 'set' :
+        state.set(['Service', 'ProvisioningServiceURLs'], options.url)
+        return
+
+    if options.command == 'info' :
+        services = state.get(['Service', 'ProvisioningServiceURLs'], [])
+        if options.url :
+            services = options.url
+
+        for url in services :
+            try :
+                client = ProvisioningServiceClient(url)
+                print("{0} --> {1}".format(url, client.verifying_key))
+            except :
+                print('unable to retreive information from {0}'.format(url))
+        return
+
+    if options.command == 'list' :
+        services = set(state.get(['Service', 'ProvisioningServiceURLs'], []))
+        for service in services :
+            print(service)
+        return
+
+    raise Exception('unknown subcommand')

--- a/client/pdo/client/controller/commands/send.py
+++ b/client/pdo/client/controller/commands/send.py
@@ -1,0 +1,109 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import random
+import logging
+logger = logging.getLogger(__name__)
+
+from pdo.common.keys import ServiceKeys
+from pdo.service_client.enclave import EnclaveServiceClient
+
+from pdo.client.controller.commands.contract import get_contract
+from pdo.client.controller.commands.eservice import get_enclave_service
+
+__all__ = ['command_send']
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def send_to_contract(state, save_file, enclave, message, quiet=False, wait=False, commit=True) :
+
+    # ---------- load the invoker's keys ----------
+    try :
+        keyfile = state.get(['Key', 'FileName'])
+        keypath = state.get(['Key', 'SearchPath'])
+        client_keys = ServiceKeys.read_from_file(keyfile, keypath)
+    except Exception as e :
+        raise Exception('unable to load client keys; {0}'.format(str(e)))
+
+    # ---------- read the contract ----------
+    try :
+        contract = get_contract(state, save_file)
+    except Exception as e :
+        raise Exception('unable to load the contract')
+
+    # ---------- set up the enclave service ----------
+    try :
+        enclave_client = get_enclave_service(state, enclave)
+    except Exception as e :
+        raise Exception('unable to connect to enclave service; {0}'.format(str(e)))
+
+    try :
+        # this is just a sanity check to make sure the selected enclave
+        # has actually been provisioned
+        contract.get_state_encryption_key(enclave_client.enclave_id)
+    except KeyError as ke :
+        logger.error('selected enclave is not provisioned')
+        sys.exit(-1)
+
+    # ---------- send the message to the enclave service ----------
+    try :
+        update_request = contract.create_update_request(client_keys, enclave_client, message)
+        update_response = update_request.evaluate()
+        if update_response.status :
+            if not quiet : print(update_response.result)
+        else :
+            print('ERROR: {}'.format(update_response.result))
+            return None
+    except Exception as e:
+        raise Exception('enclave failed to evaluation expression; {0}'.format(str(e)))
+
+    data_directory = state.get(['Contract', 'DataDirectory'])
+    ledger_config = state.get(['Sawtooth'])
+
+    if commit :
+        try :
+            logger.debug("send update to the ledger")
+            extraparams = {}
+            if wait :
+                extraparams['wait'] = 30
+            txnid = update_response.submit_update_transaction(ledger_config, **extraparams)
+        except Exception as e :
+            raise Exception('failed to save the new state; {0}'.format(str(e)))
+
+        contract.set_state(update_response.encrypted_state)
+        contract.contract_state.save_to_cache(data_dir = data_directory)
+
+    return update_response.result
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def command_send(state, bindings, pargs) :
+    """controller command to send a message to a contract
+    """
+
+    parser = argparse.ArgumentParser(prog='read')
+    parser.add_argument('-e', '--enclave', help='URL of the enclave service to use', type=str)
+    parser.add_argument('-f', '--save-file', help='File where contract data is stored', type=str)
+    parser.add_argument('-s', '--symbol', help='Save the result in a symbol for later use', type=str)
+    parser.add_argument('--wait', help='Wait for the transaction to commit', action = 'store_true')
+    parser.add_argument('message', help='Message to be sent to the contract', type=str)
+
+    options = parser.parse_args(pargs)
+    message = options.message
+    waitflag = options.wait
+
+    result = send_to_contract(state, options.save_file, options.enclave, options.message)
+    if options.symbol :
+        bindings.bind(options.symbol, result)

--- a/client/pdo/client/controller/contract_controller.py
+++ b/client/pdo/client/controller/contract_controller.py
@@ -1,0 +1,454 @@
+
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os, sys
+import logging
+import argparse
+
+import copy
+import cmd
+import shlex
+import time
+import random
+import re
+
+from string import Template
+
+logger = logging.getLogger(__name__)
+
+__all__ = ['ContractController']
+
+from pdo.client.controller.commands import *
+from pdo.common.utility import find_file_in_path
+
+# XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+# XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+class State(object) :
+    """
+    """
+
+    # --------------------------------------------------
+    def __init__(self, config) :
+        self.__data__ = copy.deepcopy(config)
+
+    # --------------------------------------------------
+    def set(self, keylist, value) :
+        assert keylist
+
+        current = self.__data__
+        for key in keylist[:-1] :
+            if key not in current :
+                current[key] = {}
+            current = current[key]
+
+        current[keylist[-1]] = value
+
+    # --------------------------------------------------
+    def get(self, keylist, value=None) :
+        assert keylist
+
+        current = self.__data__
+        for key in keylist :
+            if key not in current :
+                return value
+            current = current[key]
+        return current
+
+# XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+# XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+class Bindings(object) :
+    """
+    """
+
+    # --------------------------------------------------
+    def __init__(self, bindings = {}) :
+        self.__bindings__ = copy.copy(bindings)
+
+    # --------------------------------------------------
+    def bind(self, variable, value) :
+        self.__bindings__[variable] = value
+
+    # --------------------------------------------------
+    def expand(self, argstring) :
+        try :
+            template = Template(argstring)
+            return template.substitute(self.__bindings__)
+
+        except KeyError as ke :
+            print('missing index variable {0}'.format(ke))
+            return '-h'
+
+
+# XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+# CLASS: ContractController
+# XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+class ContractController(cmd.Cmd) :
+    """
+    ContractController -- base class for building contract controllers
+
+    Class defines the following variables:
+    """
+
+    # -----------------------------------------------------------------
+    @staticmethod
+    def ProcessScript(controller, filename, echo=False) :
+        """
+        ProcessScript -- process a file containing commands for the controller
+        """
+        saved = controller.echo
+        try :
+            controller.echo = echo
+            cmdlines = ContractController.ParseScriptFile(filename)
+            for cmdline in cmdlines :
+                if controller.onecmd(cmdline) :
+                    return False
+        except Exception as e :
+            controller.echo = saved
+            raise e
+
+        controller.echo = saved
+        return True
+
+    # -----------------------------------------------------------------
+    @staticmethod
+    def ParseScriptFile(filename) :
+        cpattern = re.compile('##.*$')
+
+        with open(filename) as fp :
+            lines = fp.readlines()
+
+            cmdlines = []
+            for line in lines :
+                line = re.sub(cpattern, '', line.strip())
+                if len(line) > 0 :
+                    cmdlines.append(line)
+
+        return cmdlines
+
+    # -----------------------------------------------------------------
+    def __init__(self, config) :
+        cmd.Cmd.__init__(self)
+
+        self.echo = False
+        self.bindings = Bindings(config.get('Bindings',{}))
+        self.state = State(config)
+
+        name = self.state.get(['Client', 'Identity'], "")
+        self.prompt = "{0}> ".format(name)
+
+    # -----------------------------------------------------------------
+    def precmd(self, line) :
+        if self.echo:
+            print(line)
+
+        return line
+
+    # -----------------------------------------------------------------
+    def postcmd(self, flag, line) :
+        return flag
+
+    # =================================================================
+    # STOCK COMMANDS
+    # =================================================================
+
+    # -----------------------------------------------------------------
+    def do_sleep(self, args) :
+        """
+        sleep <seconds> -- command to pause processing for a time (seconds).
+        """
+
+        pargs = shlex.split(self.bindings.expand(args))
+        if len(pargs) == 0 :
+            print('Time to sleep required: sleep <seconds>')
+            return
+
+        try :
+            tm = int(pargs[0])
+            print("Sleeping for {} seconds".format(tm))
+            time.sleep(tm)
+        except SystemExit as se :
+            if se.code > 0 : print('An error occurred processing {0}: {1}'.format(args, str(se)))
+            return
+
+        except Exception as e :
+            print('An error occurred processing {0}: {1}'.format(args, str(e)))
+            return
+
+    # -----------------------------------------------------------------
+    def do_set(self, args) :
+        """
+        set -- assign a value to a symbol that can be retrieved with a $expansion
+        """
+
+        pargs = shlex.split(self.bindings.expand(args))
+
+        try :
+            parser = argparse.ArgumentParser(prog='set')
+            parser.add_argument('-s', '--symbol', help='symbol in which to store the identifier', required=True)
+
+            eparser = parser.add_mutually_exclusive_group(required=True)
+            eparser.add_argument('-v', '--value', help='identifier')
+            eparser.add_argument('-f', '--file', help='name of the file to read for the value')
+
+            options = parser.parse_args(pargs)
+
+            value = options.value
+            if options.file :
+                with open (options.file, "r") as myfile:
+                    value = myfile.read()
+
+            self.bindings.bind(options.symbol,value)
+            print("${} = {}".format(options.symbol, value))
+            return
+        except SystemExit as se :
+            if se.code > 0 : print('An error occurred processing {0}: {1}'.format(args, str(se)))
+            return
+
+        except Exception as e :
+            print('An error occurred processing {0}: {1}'.format(args, str(e)))
+            return
+
+    # -----------------------------------------------------------------
+    def do_echo(self, args) :
+        """
+        echo -- expand local $symbols
+        """
+        print(self.bindings.expand(args))
+
+    # -----------------------------------------------------------------
+    def do_identity(self, args) :
+        """
+        identity -- set the identity and keys to use for transactions
+        """
+
+        pargs = shlex.split(self.bindings.expand(args))
+
+        try :
+            parser = argparse.ArgumentParser(prog='identity')
+            parser.add_argument('-n', '--name', help='identity to use for transactions', type=str, required=True)
+            parser.add_argument('-f', '--key-file', help='file that contains the private key used for signing', type=str)
+            options = parser.parse_args(pargs)
+
+            self.prompt = "{0}> ".format(options.name)
+            self.state.set(['Client', 'Identity'], options.name)
+            self.state.set(['Key', 'FileName'], "{0}_private.pem".format(options.name))
+
+            if options.key_file :
+                self.state.set(['Key', 'FileName'], options.key_file)
+
+            return
+        except SystemExit as se :
+            if se.code > 0 : print('An error occurred processing {0}: {1}'.format(args, str(se)))
+            return
+
+        except Exception as e :
+            print('An error occurred processing {0}: {1}'.format(args, str(e)))
+            return
+
+    # -----------------------------------------------------------------
+    def do_load_plugin(self, args) :
+        """
+        load -- load a new command processor from a file, the file should
+        define a function called load_commands
+        """
+
+        pargs = shlex.split(self.bindings.expand(args))
+
+        try :
+            parser = argparse.ArgumentParser(prog='load_plugin')
+            group = parser.add_mutually_exclusive_group(required=True)
+            group.add_argument('-c', '--contract-class', help='load contract plugin from data directory', type=str)
+            group.add_argument('-f', '--file', help='file from which to read the plugin', type=str)
+            options = parser.parse_args(pargs)
+
+            if options.file :
+                plugin_file = options.file
+
+            if options.contract_class :
+                contract_paths = self.state.get(['Contract', 'SourceSearchPath'], ['.'])
+                plugin_file = find_file_in_path(options.contract_class + '.py', contract_paths)
+
+            with open(plugin_file) as f:
+                code = compile(f.read(), plugin_file, 'exec')
+                exec(code, globals())
+            load_commands(ContractController)
+            return
+        except SystemExit as se :
+            if se.code > 0 : print('An error occurred processing {0}: {1}'.format(args, str(se)))
+            return
+
+        except Exception as e :
+            print('An error occurred processing {0}: {1}'.format(args, str(e)))
+            return
+
+    # -----------------------------------------------------------------
+    def do_script(self, args) :
+        """
+        script -- load commands from a file
+        """
+
+        pargs = shlex.split(self.bindings.expand(args))
+
+        try :
+            parser = argparse.ArgumentParser(prog='bindings')
+            parser.add_argument('-f', '--file', help='file from which to read commands', required=True)
+            parser.add_argument('-e', '--echo', help='turn on command echoing', action='store_true')
+            options = parser.parse_args(pargs)
+
+            ContractController.ProcessScript(self, options.file, options.echo)
+            return
+        except SystemExit as se :
+            if se.code > 0 : print('An error occurred processing {0}: {1}'.format(args, str(se)))
+            return
+
+        except Exception as e :
+            print('An error occurred processing {0}: {1}'.format(args, str(e)))
+            return
+
+    # =================================================================
+    # CONTRACT COMMANDS
+    # =================================================================
+
+    # -----------------------------------------------------------------
+    def do_pservice(self, args) :
+        """
+        pservice -- manage provisioning service list
+        """
+
+        pargs = shlex.split(self.bindings.expand(args))
+
+        try :
+            pservice(self.state, self.bindings, pargs)
+
+        except SystemExit as se :
+            if se.code > 0 : print('An error occurred processing {0}: {1}'.format(args, str(se)))
+            return
+
+        except Exception as e :
+            print('An error occurred processing {0}: {1}'.format(args, str(e)))
+            return
+
+    # -----------------------------------------------------------------
+    def do_eservice(self, args) :
+        """
+        eservice -- manage enclave service list
+        """
+
+        pargs = shlex.split(self.bindings.expand(args))
+
+        try :
+            eservice(self.state, self.bindings, pargs)
+
+        except SystemExit as se :
+            if se.code > 0 : print('An error occurred processing {0}: {1}'.format(args, str(se)))
+            return
+
+        except Exception as e :
+            print('An error occurred processing {0}: {1}'.format(args, str(e)))
+            return
+
+    # -----------------------------------------------------------------
+    def do_contract(self, args) :
+        """
+        contract -- load contract for use
+        """
+
+        pargs = shlex.split(self.bindings.expand(args))
+
+        try :
+            contract(self.state, self.bindings, pargs)
+
+        except SystemExit as se :
+            if se.code > 0 : print('An error occurred processing {0}: {1}'.format(args, str(se)))
+            return
+
+        except Exception as e :
+            print('An error occurred processing {0}: {1}'.format(args, str(e)))
+            return
+
+    # -----------------------------------------------------------------
+    def do_create(self, args) :
+        """
+        create -- create a contract
+        """
+
+        pargs = shlex.split(self.bindings.expand(args))
+
+        try :
+            create(self.state, self.bindings, pargs)
+
+        except SystemExit as se :
+            if se.code > 0 : print('An error occurred processing {0}: {1}'.format(args, str(se)))
+            return
+
+        except Exception as e :
+            print('An error occurred processing {0}: {1}'.format(args, str(e)))
+            return
+
+    # -----------------------------------------------------------------
+    def do_send(self, args) :
+        """
+        send -- send a message to the contract
+        """
+
+        pargs = shlex.split(self.bindings.expand(args))
+
+        try :
+            send(self.state, self.bindings, pargs)
+
+        except SystemExit as se :
+            if se.code > 0 : print('An error occurred processing {0}: {1}'.format(args, str(se)))
+            return
+
+        except Exception as e :
+            print('An error occurred processing {0}: {1}'.format(args, str(e)))
+            return
+
+    # -----------------------------------------------------------------
+    def do_get_public_key(self, args) :
+        """
+        get_public_key -- get the public key from the current contract
+        """
+
+        pargs = shlex.split(self.bindings.expand(args))
+
+        try :
+            GetPublicKey.GetPublicKey(self, pargs)
+
+        except SystemExit as se :
+            if se.code > 0 : print('An error occurred processing {0}: {1}'.format(args, str(se)))
+            return
+
+        except Exception as e :
+            print('An error occurred processing {0}: {1}'.format(args, str(e)))
+            return
+
+
+    # XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    # XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+    # -----------------------------------------------------------------
+    def do_exit(self, args) :
+        """
+        exit -- shutdown the simulator and exit the command loop
+        """
+        return True
+
+    # -----------------------------------------------------------------
+    def do_EOF(self, args) :
+        """
+        exit -- shutdown the simulator and exit the command loop
+        """
+        return True

--- a/client/pdo/client/controller/plugins/integer-key.py
+++ b/client/pdo/client/controller/plugins/integer-key.py
@@ -19,7 +19,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 from pdo.client.SchemeExpression import SchemeExpression
-from controller.commands.SendMessage import send_to_contract
+from pdo.client.controller.commands.send import send_to_contract
 
 ## -----------------------------------------------------------------
 ## -----------------------------------------------------------------

--- a/client/pdo/client/controller/plugins/integer-key.py
+++ b/client/pdo/client/controller/plugins/integer-key.py
@@ -1,0 +1,157 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import shlex
+import logging
+
+logger = logging.getLogger(__name__)
+
+from pdo.client.SchemeExpression import SchemeExpression
+from controller.commands.SendMessage import send_to_contract
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def __command_integer_key__(state, bindings, pargs) :
+    """controller command to interact with an integer-key contract
+    """
+
+    parser = argparse.ArgumentParser(prog='integer_key')
+    parser.add_argument('-e', '--enclave', help='URL of the enclave service to use', type=str)
+    parser.add_argument('-f', '--save-file', help='File where contract data is stored', type=str)
+    parser.add_argument('-q', '--quiet', help='Suppress printing the result', action='store_true')
+    parser.add_argument('-w', '--wait', help='Wait for the transaction to commit', action='store_true')
+
+    subparsers = parser.add_subparsers(dest='command')
+
+    create_parser = subparsers.add_parser('create')
+    create_parser.add_argument('-k', '--key', help='key to create', type=str, required=True)
+    create_parser.add_argument('-v', '--value', help='initial value to give to the key', type=int, default=0)
+
+    inc_parser = subparsers.add_parser('inc')
+    inc_parser.add_argument('-k', '--key', help='key to increment', type=str, required=True)
+    inc_parser.add_argument('-v', '--value', help='initial value to give to the key', type=int, required=True)
+
+    dec_parser = subparsers.add_parser('dec')
+    dec_parser.add_argument('-k', '--key', help='key to decrement', type=str, required=True)
+    dec_parser.add_argument('-v', '--value', help='initial value to give to the key', type=int, required=True)
+
+    get_parser = subparsers.add_parser('get')
+    get_parser.add_argument('-k', '--key', help='key to retrieve', type=str, required=True)
+
+    transfer_parser = subparsers.add_parser('transfer')
+    transfer_parser.add_argument('-k', '--key', help='key to transfer', type=str, required=True)
+    transfer_parser.add_argument('-o', '--owner', help='identity to transfer ownership', type=str, required=True)
+
+    escrow_parser = subparsers.add_parser('escrow')
+    escrow_parser.add_argument('-k', '--key', help='key to escrow', type=str, required=True)
+    escrow_parser.add_argument('-a', '--agent', help='identity of the escrow agent', type=str, required=True)
+
+    attestation_parser = subparsers.add_parser('attestation')
+    attestation_parser.add_argument('-k', '--key', help='key to escrow', type=str, required=True)
+    attestation_parser.add_argument('-s', '--symbol', help='binding symbol for result', type=str, nargs=3)
+
+    disburse_parser = subparsers.add_parser('disburse')
+    disburse_parser.add_argument('-d', '--dependencies', help='list of dependencies', type=str, nargs='*', default=[])
+    disburse_parser.add_argument('-k', '--key', help='key to disburse', type=str, required=True)
+    disburse_parser.add_argument('-s', '--signature', help='signature from the escrow agent', type=str, required=True)
+
+    exchange_parser = subparsers.add_parser('exchange')
+    exchange_parser.add_argument('-d', '--dependencies', help='list of dependencies', type=str, nargs='*', default=[])
+    exchange_parser.add_argument('--key1', help='source key', type=str, required=True)
+    exchange_parser.add_argument('--key2', help='destination key', type=str, required=True)
+    exchange_parser.add_argument('-s', '--signature', help='signature from the escrow agent', type=str, required=True)
+
+    options = parser.parse_args(pargs)
+
+    extraparams={'quiet' : options.quiet, 'wait' : options.wait}
+
+    if options.command == 'create' :
+        message = "'(create \"{0}\" {1})".format(options.key, options.value)
+        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        return
+
+    if options.command == 'inc' :
+        message = "'(inc \"{0}\" {1})".format(options.key, options.value)
+        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        return
+
+    if options.command == 'dec' :
+        message = "'(dec \"{0}\" {1})".format(options.key, options.value)
+        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        return
+
+    if options.command == 'get' :
+        extraparams['commit'] = False
+        message = "'(get-value \"{0}\")".format(options.key)
+        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        return
+
+    if options.command == 'transfer' :
+        message = "'(transfer-ownership \"{0}\" \"{1}\")".format(options.key, options.owner)
+        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        return
+
+    if options.command == 'escrow' :
+        message = "'(escrow \"{0}\" \"{1}\")".format(options.key, options.agent)
+        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        return
+
+    if options.command == 'attestation' :
+        message = "'(escrow-attestation \"{0}\")".format(options.key)
+        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        if result and options.symbol :
+            expression = SchemeExpression.ParseExpression(result)
+            bindings.bind(options.symbol[0], str(expression.nth(0)))
+            bindings.bind(options.symbol[1], str(expression.nth(1)))
+            bindings.bind(options.symbol[2], str(expression.nth(2)))
+        return
+
+    if options.command == 'disburse' :
+        dependencies = " ".join(options.dependencies)
+        message = "'(disburse \"{0}\" ({1}) \"{2}\")".format(options.key, dependencies, options.signature)
+        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        return
+
+    if options.command == 'exchange' :
+        dependencies = " ".join(options.dependencies)
+        message = "'(disburse \"{0}\" \"{1}\" ({2}) \"{3}\")".format(
+            options.key1, options.key2, dependencies, options.signature)
+        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        return
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def do_integer_key(self, args) :
+    """
+    integer_key -- invoke integer key commands
+    """
+
+    pargs = shlex.split(self.bindings.expand(args))
+
+    try :
+        __command_integer_key__(self.state, self.bindings, pargs)
+
+    except SystemExit as se :
+        if se.code > 0 : print('An error occurred processing {0}: {1}'.format(args, str(se)))
+        return
+
+    except Exception as e :
+        print('An error occurred processing {0}: {1}'.format(args, str(e)))
+        return
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def load_commands(cmdclass) :
+    setattr(cmdclass, 'do_integer_key', do_integer_key)

--- a/client/pdo/client/scripts/ShellCLI.py
+++ b/client/pdo/client/scripts/ShellCLI.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import sys
+
+import logging
+logger = logging.getLogger(__name__)
+
+from pdo.client.controller.contract_controller import ContractController
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def LocalMain(config) :
+    shell = ContractController(config)
+
+    # load the bindings specified in the configuration
+    for (key, val) in config.get("VariableMap", {}).items() :
+        shell.bindings.bind(key, val)
+
+    # if there is a script file, process it; the interactive
+    # shell will start unless there is an explicit exit in the script
+    script_file = config.get("ScriptFile")
+    if script_file :
+        if not ContractController.ProcessScript(shell, script_file) :
+            sys.exit(0)
+
+    shell.cmdloop()
+    print("")
+
+    sys.exit(0)
+
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+## -----------------------------------------------------------------
+ContractHost = os.environ.get("HOSTNAME", "localhost")
+ContractHome = os.environ.get("CONTRACTHOME") or os.path.realpath("/opt/pdo")
+ContractEtc = os.environ.get("CONTRACTETC") or os.path.join(ContractHome, "etc")
+ContractKeys = os.environ.get("CONTRACTKEYS") or os.path.join(ContractHome, "keys")
+ContractLogs = os.environ.get("CONTRACTLOGS") or os.path.join(ContractHome, "logs")
+ContractData = os.environ.get("CONTRACTDATA") or os.path.join(ContractHome, "data")
+ScriptBase = os.path.splitext(os.path.basename(sys.argv[0]))[0]
+
+config_map = {
+    'base' : ScriptBase,
+    'data' : ContractData,
+    'etc'  : ContractEtc,
+    'home' : ContractHome,
+    'host' : ContractHost,
+    'keys' : ContractKeys,
+    'logs' : ContractLogs
+}
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+def Main() :
+    import pdo.common.config as pconfig
+    import pdo.common.logger as plogger
+
+    # parse out the configuration file first
+    conffiles = [ 'pcontract.toml' ]
+    confpaths = [ ".", "./etc", ContractEtc ]
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--config', help='configuration file', nargs = '+')
+    parser.add_argument('--config-dir', help='directories to search for the configuration file', nargs = '+')
+
+    parser.add_argument('-i', '--identity', help='Identity to use for the process', type=str)
+    parser.add_argument('-c', '--contract', help='Name of the contract', type = str)
+
+    parser.add_argument('--logfile', help='Name of the log file, __screen__ for standard output', type=str)
+    parser.add_argument('--loglevel', help='Logging level', type=str)
+
+    parser.add_argument('--ledger', help='URL for the Sawtooth ledger', type=str)
+
+    parser.add_argument('--data-dir', help='Directory for storing generated files', type=str)
+    parser.add_argument('--source-dir', help='Directories to search for contract source', nargs='+', type=str)
+    parser.add_argument('--key-dir', help='Directories to search for key files', nargs='+')
+
+    parser.add_argument('--eservice-url', help='List of enclave service URLs to use', nargs='+')
+    parser.add_argument('--pservice-url', help='List of provisioning service URLs to use', nargs='+')
+
+    parser.add_argument('-m', '--mapvar', help='Define variables for script use', nargs=2, action='append')
+    parser.add_argument('-s', '--script', help='File from which to read script', type=str)
+
+    options = parser.parse_args()
+
+    # first process the options necessary to load the default configuration
+    if options.config :
+        conffiles = options.config
+
+    if options.config_dir :
+        confpaths = options.config_dir
+
+    global config_map
+    config_map['identity'] = '__unknown__'
+    if options.identity :
+        config_map['identity'] = options.identity
+    config_map['contract'] = '__unknown__'
+    if options.data_dir :
+        config_map['data'] = options.data_dir
+
+    try :
+        config = pconfig.parse_configuration_files(conffiles, confpaths, config_map)
+    except pconfig.ConfigurationException as e :
+        logger.error(str(e))
+        sys.exit(-1)
+
+    # set up the logging configuration
+    if config.get('Logging') is None :
+        config['Logging'] = {
+            'LogFile' : '__screen__',
+            'LogLevel' : 'INFO'
+        }
+    if options.logfile :
+        config['Logging']['LogFile'] = options.logfile
+    if options.loglevel :
+        config['Logging']['LogLevel'] = options.loglevel.upper()
+
+    plogger.setup_loggers(config.get('Logging', {}))
+
+    # set up the ledger configuration
+    if config.get('Sawtooth') is None :
+        config['Sawtooth'] = {
+            'LedgerURL' : 'http://localhost:8008',
+        }
+    if options.ledger :
+        config['Sawtooth']['LedgerURL'] = options.ledger
+
+    # set up the key search paths
+    if config.get('Key') is None :
+        config['Key'] = {
+            'SearchPath' : ['.', './keys', ContractKeys],
+            'FileName' : options.identity + ".pem"
+        }
+    if options.key_dir :
+        config['Key']['SearchPath'] = options.key_dir
+
+    # set up the service configuration
+    if config.get('Service') is None :
+        config['Service'] = {
+            'EnclaveServiceURLs' : [],
+            'ProvisioningServiceURLs' : []
+        }
+    if options.eservice_url :
+        config['Service']['EnclaveServiceURLs'] = options.eservice_url
+    if options.pservice_url :
+        config['Service']['ProvisioningServiceURLs'] = options.pservice_url
+
+    # set up the data paths
+    if config.get('Contract') is None :
+        config['Contract'] = {
+            'DataDirectory' : ContractData,
+            'SourceSearchPath' : [ ".", "./contract", os.path.join(ContractHome,'contracts') ]
+        }
+
+    if options.data_dir :
+        config['Contract']['DataDirectory'] = options.data_dir
+    if options.source_dir :
+        config['Contract']['SourceSearchPath'] = options.source_dir
+
+    if options.script :
+        config["ScriptFile"] = options.script
+
+    if options.mapvar :
+        varmap = config.get("VariableMap", {})
+        for (k, v) in options.mapvar : varmap[k] = v
+        config["VariableMap"] = varmap
+
+    # GO!
+    LocalMain(config)
+
+## -----------------------------------------------------------------
+## Entry points
+## -----------------------------------------------------------------
+Main()

--- a/client/setup.py
+++ b/client/setup.py
@@ -68,6 +68,7 @@ setup(name='pdo_client',
               'pdo-create = pdo.client.scripts.CreateCLI:Create',
               'pdo-add-enclave = pdo.client.scripts.CreateCLI:AddEnclave',
               'pdo-update = pdo.client.scripts.UpdateCLI:Main',
+              'pdo-shell = pdo.client.scripts.ShellCLI:Main',
           ]
       }
 )

--- a/pservice/bin/ps-start.sh
+++ b/pservice/bin/ps-start.sh
@@ -57,7 +57,7 @@ fi
 
 for index in `seq 1 $F_COUNT` ; do
     IDENTITY="${F_BASENAME}$index"
-    echo start enclave service $IDENTITY
+    echo start provisioning service $IDENTITY
 
     rm -f $F_LOGDIR/$IDENTITY.log
 


### PR DESCRIPTION
NOTE: this depends on the build script improvement PR

This commit adds the pdo-shell interpreter for interacting with
private data objects. The shell provides some basic commands for
configuring provisioning and enclave services, managing identities,
creating & sending messages to contract objects.

In addition, the shell can be extended to provide per-contract class
extensions through a plugin system. And example plugin for the
integer-key contract is provided.

Finally, the shell can be scripted for execution through the command
line or through the shell prompt itself.

The details of the shell are still in flux. Documentation will follow
when the interface stabilizes.