### PR TITLE
Update documentation for the new contract structure.

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -36,7 +36,7 @@ A "contract" is, at its core, just some Gipsy Scheme code. This code runs
 inside the contract enclave where it is protected from eavesdropping
 (confidentiality) and tampering (integrity). The contracts themselves enforce
 what they can and can not do - they are just code that runs on data. More
-information about contracts is available [here](client/docs/contract.md).
+information about contracts is available [here](contracts/docs/contract.md).
 
 This project comes bundled with a few example contracts which you can
 experiment with. Here is a brief overview of each one:

--- a/USAGE.md
+++ b/USAGE.md
@@ -41,11 +41,11 @@ information about contracts is available [here](client/docs/contract.md).
 This project comes bundled with a few example contracts which you can
 experiment with. Here is a brief overview of each one:
 
-- [mock-contract](client/contracts/contracts/mock-contract.scm)
+- [mock-contract](contracts/mock-contract/mock-contract.scm)
 A very simple contract which allows the contract owner to increment and
 retrieve a stored value. Other parties can not interact with the contract.
 
-- [integer-key](client/contracts/contracts/integer-key.scm)
+- [integer-key](contracts/integer-key/integer-key.scm)
 Like mock contract, provides an interface for interacting with a stored integer
 value. Only the contract owner may retrieve and decrement the value. Anyone may
 increment the counter, and the owner can transfer some or all of the value to a
@@ -54,10 +54,17 @@ can choose to transfer ownership of the contract to someone else. Integer key
 also supports escrow - the ability to transfer control of the value to another
 entity temporarily (such as when participating in an auction).
 
-- [auction](client/contracts/contracts/auction.scm)
+- [auction](contracts/auction/auction.scm)
 More sophisticated contract that implements a "silent" auction. Participants in
 the auction can "bid" integer-key values by placing them in escrow.
 Participants may only see the highest bid and their current bid - not even the
 owner of the auction can retrieve all of the bids. The owner may choose when to
 close bidding and select a winner, after which point the "for sale" value is
 exchanged with the highest bid.
+
+- [exchange](contracts/exchange/docs/exchange.md)
+Where the integer-key and auction contracts are primarily for demonstration and testing, the suite
+of contracts that make up the asset exchange can be used to implement a multi-asset ledger with
+several types of exchanges possible. The exchange contract suite includes plugins for the pdo client
+shell to simplify interaction with the contracts and [example scripts](contracts/exchange/scripts/README.md)
+that can be used to set up asset ledgers.

--- a/contracts/exchange/scripts/README.md
+++ b/contracts/exchange/scripts/README.md
@@ -1,0 +1,74 @@
+<!---
+Licensed under Creative Commons Attribution 4.0 International License
+https://creativecommons.org/licenses/by/4.0/
+--->
+# Exchange Scripts
+
+This directory contains a number of pdo-shell scripts. The scripts
+assume that a complete installation of the PDO client is complete.
+
+The scripts use pdo-shell variables that can be set from the pdo-shell
+invocation using the `-m` switch: `-m <variable> <value>`.
+
+## init.psh
+
+Simple initialization script that loads the plugins for the exchange
+suite of contracts.
+
+## create.psh
+
+This script creates the contract objects required for a colored marble
+exchange. The assumuption is that there are three keys available:
+
+  - `${color}_type` -- keys used for the asset type object
+  - `${color}_vetting` -- keys used for the vetting organization
+  - `${color}_issuer` -- keys used for the issuer
+
+Two pdo-shell variables are used:
+
+  -  color -- the color to use for the marble
+  -  path -- the path where the contract objects are stored
+
+This can be invoked as follows:
+
+`$ pdo-shell -s create.psh -m color <color> -m path <contract path>`
+
+## issue.psh
+
+This script issues assets to participants for a colored marble exchange.
+
+The assumption is that the following keys are available:
+
+    - `${color}_type` -- keys used for the asset type object
+    - `${color}_vetting` -- keys used for the vetting organization
+    - `${color}_issuer` -- keys used for the issuer
+    - issuee -- keys for the participant being issued the assets
+
+The following pdo-shell variables are assumed:
+
+    - color -- the color to use for the marble (default = 'green')
+    - path -- the path where the contract objects are stored (default = '.')
+    - issuee -- name of the issuee, there must be a public key in the path (required)
+    - count -- number of assets to issue (default = 100)
+
+This can be invoked as follows:
+
+`$ pdo-shell -s issue.psh -m color <color> -m path <contract path> -m issuee <identity> -m count <count>`
+
+## exchange.psh
+
+This script demonstrates the fair exchange of assets between two parties
+where the only mediator is the contract object.
+
+The following pdo-shell variables are assumed:
+
+    - path -- the path where the contract objects are stored (default = '.')
+    - offer_user -- the identity of the user initiating the exchange (default = user1)
+    - offer_color -- the color to use for the offered marbles (default = 'green')
+    - exchange_user -- the identity of the user responding to the exchange (default = user6)
+    - exchange_color -- the color to use for the requested marbles (default = 'red')
+    - request_count -- the number of marbles requested for the offered marbles (default = 60)
+
+This can be invoked as follows:
+
+`$ pdo-shell -s exchange.psh -m offer_user <identity> -m exchange_user <identity>`


### PR DESCRIPTION
Fix links in the usage document that still referenced the old contract
layout. Also add links to the documentation for the exchange family of
contracts.

Signed-off-by: Mic Bowman <mic.bowman@intel.com>