### PR TITLE
Clean up some of the enclave debugging to make it less verbose

### DIFF
--- a/eservice/lib/libpdo_enclave/base_enclave.cpp
+++ b/eservice/lib/libpdo_enclave/base_enclave.cpp
@@ -52,6 +52,11 @@ copy them into EPC memory.
 pdo_err_t ecall_Initialize()
 {
     pdo_err_t result = PDO_SUCCESS;
+
+    // we need to make sure we print a warning if the logging is turned on
+    // since it can break confidentiality of contract execution
+    SAFE_LOG(PDO_LOG_CRITICAL, "enclave initialized with debugging turned on");
+
     return result;
 }  // ecall_Initialize
 
@@ -91,4 +96,3 @@ pdo_err_t ecall_CreateErsatzEnclaveReport(sgx_target_info_t* targetInfo, sgx_rep
 
     return result;
 }  // ecall_CreateErsatzEnclaveReport
-

--- a/eservice/lib/libpdo_enclave/contract_response.cpp
+++ b/eservice/lib/libpdo_enclave/contract_response.cpp
@@ -73,27 +73,30 @@ ByteArray ContractResponse::SerializeForSigning(void) const
     std::copy(creator_id_.begin(), creator_id_.end(), std::back_inserter(serialized));
 
 #ifdef DEBUG
-    std::string contract_hash = ByteArrayToBase64EncodedString(contract_code_hash_);
-    SAFE_LOG(PDO_LOG_DEBUG, "contract_code_hash: %s", contract_hash.c_str());
+    std::string debug_contract_hash = ByteArrayToBase64EncodedString(contract_code_hash_);
+    SAFE_LOG(PDO_LOG_DEBUG, "contract_code_hash: %s", debug_contract_hash.c_str());
 #endif
+
     std::copy(
         contract_code_hash_.begin(),
         contract_code_hash_.end(),
         std::back_inserter(serialized));
 
 #ifdef DEBUG
-    std::string message_hash = ByteArrayToBase64EncodedString(contract_message_hash_);
-    SAFE_LOG(PDO_LOG_DEBUG, "contract_message_hash: %s", message_hash.c_str());
+    std::string debug_message_hash = ByteArrayToBase64EncodedString(contract_message_hash_);
+    SAFE_LOG(PDO_LOG_DEBUG, "contract_message_hash: %s", debug_message_hash.c_str());
 #endif
+
     std::copy(
         contract_message_hash_.begin(),
         contract_message_hash_.end(),
         std::back_inserter(serialized));
 
 #ifdef DEBUG
-    std::string state_hash = ByteArrayToBase64EncodedString(output_contract_state_hash_);
-    SAFE_LOG(PDO_LOG_DEBUG, "new state hash: %s", state_hash.c_str());
+    std::string debug_state_hash = ByteArrayToBase64EncodedString(output_contract_state_hash_);
+    SAFE_LOG(PDO_LOG_DEBUG, "new state hash: %s", debug_state_hash.c_str());
 #endif
+
     std::copy(
         output_contract_state_hash_.begin(),
         output_contract_state_hash_.end(),
@@ -113,10 +116,11 @@ ByteArray ContractResponse::SerializeForSigning(void) const
     }
 
 #ifdef DEBUG
-    std::string mhash = ByteArrayToBase64EncodedString(pdo::crypto::ComputeMessageHash(serialized));
+    std::string debug_mhash = ByteArrayToBase64EncodedString(pdo::crypto::ComputeMessageHash(serialized));
     SAFE_LOG(PDO_LOG_DEBUG, "serialized contract response message has length %d and hash %s",
-        serialized.size(), mhash.c_str());
+        serialized.size(), debug_mhash.c_str());
 #endif
+
     return serialized;
 }
 

--- a/eservice/lib/libpdo_enclave/contract_secrets.cpp
+++ b/eservice/lib/libpdo_enclave/contract_secrets.cpp
@@ -51,7 +51,7 @@ static void VerifySecretSignature(const std::string& inEnclaveId,
     std::copy(inCreatorId.begin(), inCreatorId.end(), std::back_inserter(message_array));
 
     std::string msg = encoded_secret + inEnclaveId + inContractId + inCreatorId;
-    SAFE_LOG(PDO_LOG_WARNING, "MESSAGE: <%s>\n", msg.c_str());
+    SAFE_LOG(PDO_LOG_DEBUG, "MESSAGE: <%s>\n", msg.c_str());
 
     int result = ps_public_key.VerifySignature(message_array, signature);
     pdo::error::ThrowIf<pdo::error::ValueError>(
@@ -115,7 +115,7 @@ pdo_err_t CreateEnclaveStateEncryptionKey(const EnclaveData& enclave_data,
 
         const std::string encoded_secret = decrypted_ps_secret.substr(0, ENCODED_SECRET_SIZE);
 
-        SAFE_LOG(PDO_LOG_ERROR, "Secret: %s\nSignature: %s\n",
+        SAFE_LOG(PDO_LOG_DEBUG, "Secret: %s\nSignature: %s\n",
             decrypted_ps_secret.substr(0, ENCODED_SECRET_SIZE).c_str(),
             decrypted_ps_secret.substr(ENCODED_SECRET_SIZE).c_str());
 


### PR DESCRIPTION
Dropped the logging level to debug for all of the statements in the
secrets module. Add the "debug" prefix to any variables that are created
exclusively for logging.

Added a critical message in enclave initialization to note that the
enclave was compiled with debugging on. Debug logging creates an obvious
channel that exposes confidential information.

Signed-off-by: Mic Bowman <mic.bowman@intel.com>