### PR TITLE
Implemented enclave block store

### DIFF
--- a/eservice/Makefile
+++ b/eservice/Makefile
@@ -28,9 +28,11 @@ SWIG_SOURCES = \
 	enclave/contract.cpp \
 	enclave/signup.cpp \
 	enclave/enclave.cpp \
+	enclave/block_store.cpp \
 	enclave_info.cpp \
 	signup_info.cpp \
-	contract.cpp
+	contract.cpp \
+	block_store.cpp
 SWIG_FILES = $(addprefix pdo/eservice/enclave/,$(SWIG_SOURCES))
 SWIG_TARGET = pdo/eservice/enclave/pdo_enclave_internal.py
 

--- a/eservice/lib/libpdo_enclave/block_store.edl
+++ b/eservice/lib/libpdo_enclave/block_store.edl
@@ -14,11 +14,18 @@
  */
 
 enclave {
-    from "sgx_tstdc.edl" import *;
-    from "sgx_tsgxssl.edl" import *;
-    from "base.edl" import *;
-    from "signup.edl" import *;
-    from "contract.edl" import *;
-    from "block_store.edl" import *;
-};
+    trusted {
+    };
 
+    untrusted {
+        int ocall_BlockStoreGet([in, size=keySize] const uint8_t* key,
+                                size_t keySize,
+                                [out] uint8_t** value,
+                                [out] size_t* valueSize);
+
+        int ocall_BlockStorePut([in, size=keySize] const uint8_t* key,
+                                size_t keySize,
+                                [in, size=valueSize] const uint8_t* value,
+                                size_t valueSize);
+    };
+};

--- a/eservice/lib/libpdo_enclave/block_store.edl
+++ b/eservice/lib/libpdo_enclave/block_store.edl
@@ -18,14 +18,18 @@ enclave {
     };
 
     untrusted {
-        int ocall_BlockStoreGet([in, size=keySize] const uint8_t* key,
-                                size_t keySize,
-                                [out] uint8_t** value,
-                                [out] size_t* valueSize);
+        int ocall_BlockStoreHead([in, size=inKeySize] const uint8_t* inKey,
+                                 size_t inKeySize,
+                                 [out] size_t* outValueSize);
 
-        int ocall_BlockStorePut([in, size=keySize] const uint8_t* key,
-                                size_t keySize,
-                                [in, size=valueSize] const uint8_t* value,
-                                size_t valueSize);
+        int ocall_BlockStoreGet([in, size=inKeySize] const uint8_t* inKey,
+                                size_t inKeySize,
+                                [out, size=inValueSize] uint8_t* outValue,
+                                size_t inValueSize);
+
+        int ocall_BlockStorePut([in, size=inKeySize] const uint8_t* inKey,
+                                size_t inKeySize,
+                                [in, size=inValueSize] const uint8_t* inValue,
+                                size_t inValueSize);
     };
 };

--- a/eservice/lib/libpdo_enclave/contract_response.cpp
+++ b/eservice/lib/libpdo_enclave/contract_response.cpp
@@ -181,14 +181,10 @@ ByteArray ContractResponse::SerializeAndEncrypt(
 
         sgx_ret = ocall_BlockStorePut(&ret, &contract_state_.state_hash_[0], contract_state_.state_hash_.size(),
                                       &contract_state_.encrypted_state_[0], contract_state_.encrypted_state_.size());
-        if (sgx_ret != 0) {
-            SAFE_LOG(PDO_LOG_ERROR, "SGX error %d invoking ocall_BlockStorePut()", sgx_ret);
-            throw;
-        }
-        if (ret != 0) {
-            SAFE_LOG(PDO_LOG_ERROR, "Error %d saving state via ocall_BlockStorePut()", ret);
-            throw;
-        }
+        pdo::error::ThrowIf<pdo::error::RuntimeError>(
+            sgx_ret != 0, "sgx failed during put to the block store");
+        pdo::error::ThrowIf<pdo::error::RuntimeError>(
+            ret != 0, "failed to put to the block store");
 
         jret = json_object_dotset_string(contract_response_object, "StateHash", base64_encode(contract_state_.state_hash_).c_str());
         pdo::error::ThrowIf<pdo::error::RuntimeError>(

--- a/eservice/pdo/eservice/enclave/block_store.cpp
+++ b/eservice/pdo/eservice/enclave/block_store.cpp
@@ -1,0 +1,73 @@
+/* Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <string>
+
+#include "error.h"
+#include "pdo_error.h"
+#include "types.h"
+#include "packages/base64/base64.h"
+
+#include "block_store.h"
+#include "swig_utils.h"
+
+#include "enclave/block_store.h"
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+pdo_err_t block_store_init()
+{
+    pdo_err_t presult = pdo::enclave_api::block_store::BlockStoreInit();
+    ThrowPDOError(presult);
+
+    return presult;
+}
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+int block_store_head(
+    const std::string& key
+    )
+{
+    ByteArray raw_key = base64_decode(key);
+
+    return pdo::enclave_api::block_store::BlockStoreHead(raw_key);
+}
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+std::string block_store_get(
+    const std::string& key
+    )
+{
+    ByteArray raw_key = base64_decode(key);
+    ByteArray raw_value;
+
+    pdo_err_t presult = pdo::enclave_api::block_store::BlockStoreGet(raw_key, raw_value);
+    ThrowPDOError(presult);
+
+    return base64_encode(raw_value);
+}
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+void block_store_put(
+    const std::string& key,
+    const std::string& value
+    )
+{
+    ByteArray raw_key = base64_decode(key);
+    ByteArray raw_value = base64_decode(value);
+
+    pdo_err_t presult = pdo::enclave_api::block_store::BlockStorePut(raw_key, raw_value);
+    ThrowPDOError(presult);
+}

--- a/eservice/pdo/eservice/enclave/block_store.cpp
+++ b/eservice/pdo/eservice/enclave/block_store.cpp
@@ -37,20 +37,20 @@ pdo_err_t block_store_init()
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 int block_store_head(
-    const std::string& key
+    const std::string& key_b64
     )
 {
-    ByteArray raw_key = base64_decode(key);
+    ByteArray raw_key = base64_decode(key_b64);
 
     return pdo::enclave_api::block_store::BlockStoreHead(raw_key);
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 std::string block_store_get(
-    const std::string& key
+    const std::string& key_b64
     )
 {
-    ByteArray raw_key = base64_decode(key);
+    ByteArray raw_key = base64_decode(key_b64);
     ByteArray raw_value;
 
     pdo_err_t presult = pdo::enclave_api::block_store::BlockStoreGet(raw_key, raw_value);
@@ -61,12 +61,12 @@ std::string block_store_get(
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 void block_store_put(
-    const std::string& key,
-    const std::string& value
+    const std::string& key_b64,
+    const std::string& value_b64
     )
 {
-    ByteArray raw_key = base64_decode(key);
-    ByteArray raw_value = base64_decode(value);
+    ByteArray raw_key = base64_decode(key_b64);
+    ByteArray raw_value = base64_decode(value_b64);
 
     pdo_err_t presult = pdo::enclave_api::block_store::BlockStorePut(raw_key, raw_value);
     ThrowPDOError(presult);

--- a/eservice/pdo/eservice/enclave/block_store.h
+++ b/eservice/pdo/eservice/enclave/block_store.h
@@ -13,12 +13,24 @@
  * limitations under the License.
  */
 
-enclave {
-    from "sgx_tstdc.edl" import *;
-    from "sgx_tsgxssl.edl" import *;
-    from "base.edl" import *;
-    from "signup.edl" import *;
-    from "contract.edl" import *;
-    from "block_store.edl" import *;
-};
+#include <string>
+#include <map>
 
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+pdo_err_t block_store_init();
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+int block_store_head(
+    const std::string& key
+    );
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+std::string block_store_get(
+    const std::string& key
+    );
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+void block_store_put(
+    const std::string& key,
+    const std::string& value
+    );

--- a/eservice/pdo/eservice/enclave/block_store.h
+++ b/eservice/pdo/eservice/enclave/block_store.h
@@ -16,21 +16,51 @@
 #include <string>
 #include <map>
 
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+/**
+ * Initialize the block store - must be called before performing gets/puts
+ *
+ *  Success (return PDO_SUCCESS) - Block store ready to use
+ *  Failure (return nonzero) - Block store is unusable
+ */
 pdo_err_t block_store_init();
 
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+/**
+ * Gets the size of a block in the block store
+ *
+ * @param key_b64       base64 encoded key string
+ *
+ * @return
+ *  Success: length of value corresponding to key
+ *  Failure: -1
+ */
 int block_store_head(
-    const std::string& key
+    const std::string& key_b64
     );
 
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+/**
+ * Gets the value corresponding to a key from the block store
+ *
+ * @param key_b64       base64 encoded key string
+ *
+ * @return
+ *  Success: base64 encoded value corresponding to key
+ *  Failure: throws exception
+ */
 std::string block_store_get(
-    const std::string& key
+    const std::string& key_b64
     );
 
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+/**
+ * Puts a key->value pair into the block store
+ *
+ * @param key_b64       base64 encoded key string
+ * @param value_b64     base64 encoded value string
+ *
+ * @return
+ *  Success: void/no return
+ *  Failure: throws exception
+ */
 void block_store_put(
-    const std::string& key,
-    const std::string& value
+    const std::string& key_b64,
+    const std::string& value_b64
     );

--- a/eservice/pdo/eservice/enclave/enclave/block_store.cpp
+++ b/eservice/pdo/eservice/enclave/enclave/block_store.cpp
@@ -1,0 +1,187 @@
+/* Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+#include <pthread.h>
+#include <bits/stdc++.h>
+
+#include "pdo_error.h"
+#include "error.h"
+#include "log.h"
+#include "types.h"
+#include "hex_string.h"
+
+#include "enclave/base.h"
+#include "enclave/block_store.h"
+
+static std::unordered_map<std::string, std::string> map;
+static pthread_spinlock_t lock;
+
+pdo_err_t pdo::enclave_api::block_store::BlockStoreInit() {
+    int ret;
+
+    ret = pthread_spin_init(&lock, PTHREAD_PROCESS_SHARED);
+    if (ret != 0) {
+        Log(PDO_LOG_DEBUG, "Failed to init block store spinlock: %d", ret);
+        return PDO_ERR_SYSTEM;
+    }
+
+    return PDO_SUCCESS;
+}
+
+int pdo::enclave_api::block_store::BlockStoreGet(
+    const uint8_t* key,
+    const size_t keySize,
+    uint8_t **value,
+    size_t* valueSize
+    )
+{
+    int result = 0;
+    std::string keyStr = BinaryToHexString(key, keySize);
+    Log(PDO_LOG_DEBUG, "Block Store Get: '%s'", keyStr.c_str());
+
+    // **********
+    // LOCK
+    pthread_spin_lock(&lock);
+
+    if (map.find(keyStr) == map.end()) {
+        Log(PDO_LOG_DEBUG, "Failed to find key in block store map: '%s'",
+            keyStr.c_str());
+        *valueSize = 0;
+        *value = NULL;
+        result = PDO_ERR_VALUE;
+        goto done;
+    } else {
+        std::string valueStr = map[keyStr];
+        Log(PDO_LOG_DEBUG, "Block Store found key: '%s' -> '%s'",
+            keyStr.c_str(), valueStr.c_str());
+
+        /*
+         * TODO - This leaks memory! There is nothing to clean up this
+         * allocated data later
+         */
+        *valueSize = valueStr.size() / 2;
+        *value = (uint8_t *)malloc(*valueSize);
+        if (!*value) {
+            Log(PDO_LOG_ERROR,
+                "Failed to allocate %zu bytes for get return value.",
+                *valueSize);
+            *valueSize = 0;
+            result = PDO_ERR_MEMORY;
+            goto done;
+        }
+
+        // Deserialize the data from the cache into the buffer
+        HexStringToBinary(*value, *valueSize, valueStr);
+
+        result = PDO_SUCCESS;
+    }
+
+done:
+    pthread_spin_unlock(&lock);
+    // UNLOCK
+    // **********
+
+    return result;
+}
+
+int pdo::enclave_api::block_store::BlockStorePut(
+    const uint8_t* key,
+    const size_t keySize,
+    const uint8_t* value,
+    const size_t valueSize
+    )
+{
+    std::string keyStr = BinaryToHexString(key, keySize);
+    std::string valueStr = BinaryToHexString(value, valueSize);
+
+    Log(PDO_LOG_DEBUG, "Block Store Put: %zu bytes '%s' -> %zu bytes '%s'",
+        keySize, keyStr.c_str(), valueSize, valueStr.c_str());
+    // **********
+    // LOCK
+    pthread_spin_lock(&lock);
+
+    map[keyStr] = valueStr;
+
+    pthread_spin_unlock(&lock);
+    // UNLOCK
+    // **********
+
+    return PDO_SUCCESS;
+}
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+int pdo::enclave_api::block_store::BlockStoreHead(
+    const ByteArray& inKey
+    )
+{
+    uint8_t *value;
+    size_t value_size;
+
+    // Fetch the state from the block storage
+    int ret = BlockStoreGet(inKey.data(), inKey.size(),
+                            &value, &value_size);
+    if (ret != 0) {
+        // No data found - return -1 for size
+        return -1;
+    }
+
+    // Found data - return its size
+    return (int)value_size;
+}
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+pdo_err_t pdo::enclave_api::block_store::BlockStoreGet(
+    const ByteArray& inKey,
+    ByteArray& outValue
+    )
+{
+    pdo_err_t result = PDO_SUCCESS;
+
+    uint8_t *value;
+    size_t value_size;
+
+    // Fetch the state from the block storage
+    int ret = BlockStoreGet(inKey.data(), inKey.size(),
+                            &value, &value_size);
+    pdo::error::ThrowIf<pdo::error::ValueError>(
+       ret != 0, "Unable to get from Block Store");
+
+    // Copy the buffer back to the caller's ByteArray
+    outValue.resize(value_size);
+    outValue.assign(value, value + value_size);
+
+    return result;
+}
+
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+pdo_err_t pdo::enclave_api::block_store::BlockStorePut(
+    const ByteArray& inKey,
+    const ByteArray& inValue
+    )
+{
+    pdo_err_t result = PDO_SUCCESS;
+
+    int ret = BlockStorePut(inKey.data(), inKey.size(),
+                            inValue.data(), inValue.size());
+
+    pdo::error::ThrowIf<pdo::error::ValueError>(
+       ret != 0, "Unable to put into the Block Store");
+
+    return result;
+}

--- a/eservice/pdo/eservice/enclave/enclave/block_store.h
+++ b/eservice/pdo/eservice/enclave/enclave/block_store.h
@@ -24,37 +24,115 @@ namespace pdo
     {
         namespace block_store
         {
-            // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+            /**
+             * Initialize the block store - must be called before performing gets/puts
+             * Primary expected use: python / untrusted side
+             *
+             * @return
+             *  Success (return PDO_SUCCESS) - Block store ready to use
+             *  Failure (return nonzero) - Block store is unusable
+             */
             pdo_err_t BlockStoreInit();
 
-            // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+            /**
+             * Gets the size of a block in the block store
+             * Primary expected use: ocall
+             *
+             * @param inKey         pointer to raw key byte array
+             * @param inKeySize     length of inKey
+             * @param outValueSize  size (in # bytes) of value will be written here
+             *
+             * @return
+             *  Success (return 0) - outValueSize set to the number of bytes of raw value
+             *  Failure (return nonzero) - outValueSize undefined
+             */
+            int BlockStoreHead(
+                const uint8_t* inKey,
+                const size_t inKeySize,
+                size_t* outValueSize
+                );
+
+            /**
+             * Gets a block from the block store
+             * Primary expected use: ocall
+             *
+             * @param inKey         pointer to raw key byte array
+             * @param inKeySize     length of inKey
+             * @param outValue      buffer where value should be copied
+             * @param inValueSize   length of caller's outValue buffer
+             *
+             * @return
+             *  Success (return 0) - outValue contains the requested block
+             *  Failure (return nonzero) - outValue unchanged
+             */
             int BlockStoreGet(
-                const uint8_t* key,
-                const size_t keySize,
-                uint8_t **value,
-                size_t* valueSize
+                const uint8_t* inKey,
+                const size_t inKeySize,
+                uint8_t *outValue,
+                const size_t inValueSize
                 );
 
-            // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+            /**
+             * Puts a block into the block store
+             * Primary expected use: ocall
+             *
+             * @param inKey         pointer to raw key byte array
+             * @param inKeySize     length of inKey
+             * @param inValue       pointer to raw value byte array
+             * @param inValueSize   length of inValue
+             *
+             * @return
+             *  Success (return 0) - key->value stored
+             *  Failure (return nonzero) - block store unchanged
+             */
             int BlockStorePut(
-                const uint8_t* key,
-                const size_t keySize,
-                const uint8_t* value,
-                const size_t valueSize
+                const uint8_t* inKey,
+                const size_t inKeySize,
+                const uint8_t* inValue,
+                const size_t inValueSize
                 );
 
-            // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+            /**
+             * Gets the size of a block in the block store
+             * Primary expected use: python / untrusted side
+             *
+             * @param inKey     raw bytes
+             *
+             * @return
+             *  Block present - return size of block
+             *  Block not present - return -1
+             */
             int BlockStoreHead(
                 const ByteArray& inKey
                 );
 
-            // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+            /**
+             * Gets a block from the block store
+             * Primary expected use: python / untrusted side
+             *
+             * @param inKey     raw bytes
+             * @param outValue  raw bytes
+             *
+             * @return
+             *  Success (return 0) - outValue resized and contains block data
+             *  Failure (return nonzero) - outValue unchanged
+             */
             pdo_err_t BlockStoreGet(
                 const ByteArray& inKey,
                 ByteArray& outValue
                 );
 
-            // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+            /**
+             * Puts a block into the block store
+             * Primary expected use: python / untrusted side
+             *
+             * @param inKey     raw bytes
+             * @param inValue   raw bytes
+             *
+             * @return
+             *  Success (return PDO_SUCCESS) - key->value stored
+             *  Failure (return nonzero) - block store unchanged
+             */
             pdo_err_t BlockStorePut(
                 const ByteArray& inKey,
                 const ByteArray& inValue

--- a/eservice/pdo/eservice/enclave/enclave/block_store.h
+++ b/eservice/pdo/eservice/enclave/enclave/block_store.h
@@ -1,0 +1,65 @@
+/* Copyright 2018 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "pdo_error.h"
+#include "types.h"
+
+namespace pdo
+{
+    namespace enclave_api
+    {
+        namespace block_store
+        {
+            // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+            pdo_err_t BlockStoreInit();
+
+            // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+            int BlockStoreGet(
+                const uint8_t* key,
+                const size_t keySize,
+                uint8_t **value,
+                size_t* valueSize
+                );
+
+            // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+            int BlockStorePut(
+                const uint8_t* key,
+                const size_t keySize,
+                const uint8_t* value,
+                const size_t valueSize
+                );
+
+            // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+            int BlockStoreHead(
+                const ByteArray& inKey
+                );
+
+            // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+            pdo_err_t BlockStoreGet(
+                const ByteArray& inKey,
+                ByteArray& outValue
+                );
+
+            // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+            pdo_err_t BlockStorePut(
+                const ByteArray& inKey,
+                const ByteArray& inValue
+                );
+
+        } /* contract */
+    }     /* enclave_api */
+}         /* pdo */

--- a/eservice/pdo/eservice/enclave/enclave/ocall.cpp
+++ b/eservice/pdo/eservice/enclave/enclave/ocall.cpp
@@ -19,6 +19,7 @@
 #include <chrono>
 
 #include "log.h"
+#include "block_store.h"
 
 std::string g_enclaveError;
 
@@ -58,4 +59,23 @@ extern "C" {
         }
     } // ocall_SetErrorMessage
 
+    int ocall_BlockStoreGet(
+        const uint8_t* key,
+        const size_t keySize,
+        uint8_t **value,
+        size_t* valueSize
+        )
+    {
+        return pdo::enclave_api::block_store::BlockStoreGet(key, keySize, value, valueSize);
+    } // ocall_BlockStoreGet
+
+    int ocall_BlockStorePut(
+        const uint8_t* key,
+        const size_t keySize,
+        const uint8_t* value,
+        const size_t valueSize
+        )
+    {
+        return pdo::enclave_api::block_store::BlockStorePut(key, keySize, value, valueSize);
+    } // ocall_BlockStorePut
 } // extern "C"

--- a/eservice/pdo/eservice/enclave/enclave/ocall.cpp
+++ b/eservice/pdo/eservice/enclave/enclave/ocall.cpp
@@ -59,23 +59,32 @@ extern "C" {
         }
     } // ocall_SetErrorMessage
 
-    int ocall_BlockStoreGet(
-        const uint8_t* key,
-        const size_t keySize,
-        uint8_t **value,
-        size_t* valueSize
+    int ocall_BlockStoreHead(
+        const uint8_t* inKey,
+        const size_t inKeySize,
+        size_t* outValueSize
         )
     {
-        return pdo::enclave_api::block_store::BlockStoreGet(key, keySize, value, valueSize);
+        return pdo::enclave_api::block_store::BlockStoreHead(inKey, inKeySize, outValueSize);
+    } // ocall_BlockStoreHead
+
+    int ocall_BlockStoreGet(
+        const uint8_t* inKey,
+        const size_t inKeySize,
+        uint8_t *outValue,
+        const size_t inValueSize
+        )
+    {
+        return pdo::enclave_api::block_store::BlockStoreGet(inKey, inKeySize, outValue, inValueSize);
     } // ocall_BlockStoreGet
 
     int ocall_BlockStorePut(
-        const uint8_t* key,
-        const size_t keySize,
-        const uint8_t* value,
-        const size_t valueSize
+        const uint8_t* inKey,
+        const size_t inKeySize,
+        const uint8_t* inValue,
+        const size_t inValueSize
         )
     {
-        return pdo::enclave_api::block_store::BlockStorePut(key, keySize, value, valueSize);
+        return pdo::enclave_api::block_store::BlockStorePut(inKey, inKeySize, inValue, inValueSize);
     } // ocall_BlockStorePut
 } // extern "C"

--- a/eservice/pdo/eservice/enclave/pdo_enclave.h
+++ b/eservice/pdo/eservice/enclave/pdo_enclave.h
@@ -21,6 +21,7 @@
 #include "signup_info.h"
 #include "enclave_info.h"
 #include "contract.h"
+#include "block_store.h"
 
 void InitializePDOEnclaveModule();
 

--- a/eservice/pdo/eservice/enclave/pdo_enclave_internal.i
+++ b/eservice/pdo/eservice/enclave/pdo_enclave_internal.i
@@ -87,6 +87,7 @@ namespace std {
 %include "signup_info.h"
 %include "enclave_info.h"
 %include "contract.h"
+%include "block_store.h"
 %include "pdo_enclave.h"
 
 %init %{

--- a/eservice/pdo/eservice/pdo_enclave.py
+++ b/eservice/pdo/eservice/pdo_enclave.py
@@ -36,6 +36,9 @@ __all__ = [
     'get_enclave_public_info',
     'get_enclave_measurement',
     'get_enclave_basename',
+    'block_store_head',
+    'block_store_get',
+    'block_store_put',
     'verify_secrets',
     'send_to_contract',
     'shutdown'
@@ -167,6 +170,8 @@ def initialize_with_configuration(config) :
             logger.warning("Retrying in 60 sec")
             time.sleep(60)
 
+    enclave.block_store_init()
+
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
 def shutdown():
@@ -191,6 +196,18 @@ def get_enclave_measurement():
 def get_enclave_basename():
     global _pdo
     return _pdo.basename if _pdo is not None else None
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+def block_store_head(key): return enclave.block_store_head(key)
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+def block_store_get(key): return enclave.block_store_get(key)
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+def block_store_put(key, value): return enclave.block_store_put(key, value)
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------

--- a/eservice/pdo/eservice/pdo_helper.py
+++ b/eservice/pdo/eservice/pdo_helper.py
@@ -191,6 +191,28 @@ class Enclave(object) :
         """
         return pdo_enclave.get_enclave_public_info(self.sealed_data)
 
+    # -----------------------------------------------------------------
+    def block_store_head(self, key_b64) :
+        """
+        get the number of bytes stored in the block store for the given key
+        or -1 if no corresponding block matches
+        """
+        return pdo_enclave.block_store_head(key_b64)
+
+    # -----------------------------------------------------------------
+    def block_store_get(self, key_b64) :
+        """
+        request the block corresponding to the specified key
+        """
+        return pdo_enclave.block_store_get(key_b64)
+
+    # -----------------------------------------------------------------
+    def block_store_put(self, key_b64, value_b64) :
+        """
+        store the given value into the eservice's block store
+        """
+        return pdo_enclave.block_store_put(key_b64, value_b64)
+
     # -------------------------------------------------------
     def save_to_file(self, basename, data_dir = "./data") :
         enclave_info = dict()

--- a/eservice/setup.py
+++ b/eservice/setup.py
@@ -111,9 +111,11 @@ module_files = [
     os.path.join(module_src_path, 'enclave/contract.cpp'),
     os.path.join(module_src_path, 'enclave/signup.cpp'),
     os.path.join(module_src_path, 'enclave/enclave.cpp'),
+    os.path.join(module_src_path, 'enclave/block_store.cpp'),
     os.path.join(module_src_path, 'enclave_info.cpp'),
     os.path.join(module_src_path, 'signup_info.cpp'),
-    os.path.join(module_src_path, 'contract.cpp')
+    os.path.join(module_src_path, 'contract.cpp'),
+    os.path.join(module_src_path, 'block_store.cpp'),
 ]
 
 enclave_module = Extension(

--- a/python/pdo/contract/state.py
+++ b/python/pdo/contract/state.py
@@ -124,11 +124,38 @@ class ContractState(object) :
         self.encrypted_state = encrypted_state
 
     # --------------------------------------------------
+    def getStateHash(self, encoding='raw') :
+        """
+        gets the hash of the encrypted state if it is non-empty
+        returns None if no encrypted state exists
+        """
+        if self.encrypted_state:
+            return ContractState.compute_hash(self.encrypted_state, encoding)
+        return None
+
+    # --------------------------------------------------
+    def serializeForInvokation(self) :
+        """
+        serializes the elements needed by the contract enclave to invoke the contract
+        does not include the encrypted state itself
+        """
+        result = dict()
+        result['ContractID'] = self.contract_id
+        if self.encrypted_state :
+            result['StateHash'] = ContractState.compute_hash(self.encrypted_state, encoding='b64')
+
+        return result
+
+    # --------------------------------------------------
     def serialize(self) :
+        """
+        serializes the entire state (including the state itself) for storage
+        """
         result = dict()
         result['ContractID'] = self.contract_id
         if self.encrypted_state :
             result['EncryptedState'] = self.encrypted_state
+            result['StateHash'] = ContractState.compute_hash(self.encrypted_state, encoding='b64')
 
         return result
 

--- a/python/pdo/service_client/enclave.py
+++ b/python/pdo/service_client/enclave.py
@@ -99,3 +99,74 @@ class EnclaveServiceClient(GenericServiceClient) :
         except :
             logger.exception('get_enclave_info')
             return None
+
+    # -----------------------------------------------------------------
+    def block_store_head(self, state_hash_b64) :
+        """
+        Checks if a block is present in the block store.
+        Returns:
+            int(length) if present
+            -1 if not present
+            None on error
+        """
+        request = { 'operation' : 'BlockStoreHeadRequest' }
+        request['key'] = state_hash_b64
+
+        try :
+            response = self._postmsg(request)
+            return int(response['length'])
+
+        except MessageException as me :
+            logger.warn('unable to contact enclave service (block_store_head); %s', me)
+            return None
+
+        except :
+            logger.exception('block_store_head')
+            return None
+
+    # -----------------------------------------------------------------
+    def block_store_get(self, state_hash_b64) :
+        """
+        Retrieves a block from the enclave service's block store
+        Returns:
+            base64 encoded block data
+            None on error
+        """
+        request = { 'operation' : 'BlockStoreGetRequest' }
+        request['key'] = state_hash_b64
+
+        try :
+            response = self._postmsg(request)
+            return response['result']
+
+        except MessageException as me :
+            logger.warn('unable to contact enclave service (block_store_get); %s', me)
+            return None
+
+        except :
+            logger.exception('block_store_get')
+            return None
+
+    # -----------------------------------------------------------------
+    def block_store_put(self, state_hash_b64, state_b64) :
+        """
+        Retrieves a block from the enclave service's block store
+        Returns:
+            True - Success
+            False - Failure
+        """
+        request = { 'operation' : 'BlockStorePutRequest' }
+        request['key'] = state_hash_b64
+        request['value'] = state_b64
+
+        try :
+            response = self._postmsg(request)
+            return True
+
+        except MessageException as me :
+            logger.warn('unable to contact enclave service (block_store_put); %s', me)
+            return False
+
+        except :
+            logger.exception('block_store_put')
+            return False


### PR DESCRIPTION
The block store is a state cache for the eservice which eliminates the
need to send state back and forth on every transaction. State is pulled
from the block store when running contracts, and the resulting state is
placed there when the contract execution completes.

Current implementation details:
- The block store is not persistent across restarts
- The client must retrieve state from the block store to store on the
ledger after any operation that updates the state
- The client must put the state block(s) into the block store when
starting work with an enclave service that does not currently have them.

Signed-off-by: Byron Marohn <byron.marohn@intel.com>