### PR TITLE
change return from block store init to avoid memory leak warning

### DIFF
--- a/eservice/pdo/eservice/enclave/block_store.cpp
+++ b/eservice/pdo/eservice/enclave/block_store.cpp
@@ -27,12 +27,10 @@
 #include "enclave/block_store.h"
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-pdo_err_t block_store_init()
+void block_store_init()
 {
     pdo_err_t presult = pdo::enclave_api::block_store::BlockStoreInit();
     ThrowPDOError(presult);
-
-    return presult;
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/eservice/pdo/eservice/enclave/block_store.h
+++ b/eservice/pdo/eservice/enclave/block_store.h
@@ -22,7 +22,7 @@
  *  Success (return PDO_SUCCESS) - Block store ready to use
  *  Failure (return nonzero) - Block store is unusable
  */
-pdo_err_t block_store_init();
+void block_store_init();
 
 /**
  * Gets the size of a block in the block store


### PR DESCRIPTION
Signed-off-by: Mic Bowman <mic.bowman@intel.com>