### PR TITLE
Refactor state moving all block retrieval into one place.

### DIFF
--- a/python/pdo/contract/contract.py
+++ b/python/pdo/contract/contract.py
@@ -111,7 +111,7 @@ class Contract(object) :
     # -------------------------------------------------------
     # state -- base64 encoded, encrypted state
     def set_state(self, state) :
-        self.contract_state.encrypted_state = state
+        self.contract_state.update_state(state)
 
     # -------------------------------------------------------
     def create_initialize_request(self, request_originator_keys, enclave_service) :

--- a/python/pdo/contract/response.py
+++ b/python/pdo/contract/response.py
@@ -101,6 +101,7 @@ class ContractResponse(object) :
         self.status = response['Status']
         self.result = response['Result']
         self.state_changed = response['StateChanged']
+        self.new_state_object = request.contract_state
 
         if self.status and self.state_changed :
             self.signature = response['Signature']
@@ -132,30 +133,9 @@ class ContractResponse(object) :
             if not self.__verify_enclave_signature(request.enclave_keys) :
                 raise Exception('failed to verify enclave signature')
 
-            # Retrieve the encrypted state from the enclave's block store
-            # Note that this channel is untrusted - must verify the retrieved data has the correct hash!
-            # This is intentionally done after the signature verification
-            encrypted_state_u_b64 = self.enclave_service.block_store_get(state_hash_b64)
-            #check whether this hash is redundant (blockstore does it)
-            encrypted_state_u_hash_b64 = ContractState.compute_hash(encrypted_state_u_b64, encoding='b64')
-            if (state_hash_b64 != encrypted_state_u_hash_b64):
-                raise Exception('Encrypted state from block store has incorrect hash!')
-            self.encrypted_state = encrypted_state_u_b64;
-
-            #retrieve rest of state
-            logger.debug('retrieving state blocks for %s', crypto.byte_array_to_hex(crypto.base64_to_byte_array(state_hash_b64)))
-            string_main_state_block = crypto.byte_array_to_string(crypto.base64_to_byte_array(encrypted_state_u_b64))
-            string_main_state_block = string_main_state_block.rstrip('\0')
-            logger.debug("json blob in main state block: %s", string_main_state_block)
-            json_main_state_block = json.loads(string_main_state_block)
-            for hex_str_block_id in json_main_state_block['BlockIds']:
-                logger.debug("block id: %s", hex_str_block_id)
-                b64_block_id = crypto.byte_array_to_base64(crypto.hex_to_byte_array(hex_str_block_id))
-                b64_block = self.enclave_service.block_store_get(b64_block_id)
-                if b64_block is None:
-                        raise Exception('Unable to retrieve block from EService')
-                contractstate_block = ContractState(request.contract_id, b64_block)
-                contractstate_block.save_to_cache()
+            self.encrypted_state = self.enclave_service.block_store_get(state_hash_b64)
+            self.new_state_object = ContractState(self.contract_id, self.encrypted_state)
+            self.new_state_object.pull_state_from_eservice(self.enclave_service)
 
     # -------------------------------------------------------
     def __verify_enclave_signature(self, enclave_keys) :

--- a/python/pdo/contract/state.py
+++ b/python/pdo/contract/state.py
@@ -162,6 +162,11 @@ class ContractState(object) :
         # it is not in the cache so grab it from the eservice
         raw_data = eservice.block_store_get(state_hash)
         if raw_data :
+            # since we don't really trust the eservice, make sure that the
+            # block it sent us is really the one that we were supposed to get
+            if ContractState.compute_hash(raw_data, encoding='b64') != state_hash :
+                raise Exception('invalid block returned from eservice')
+
             ContractState.__cache_data_block__(contract_id, raw_data, data_dir)
 
         logger.debug('sent block %s to eservice', state_hash)


### PR DESCRIPTION
No functional changes. State cache for blocks is still going
in the local directory only, ignoring the configuration.

Signed-off-by: Mic Bowman <mic.bowman@intel.com>