### PR TITLE
clean up the scripts that process enclave information

### DIFF
--- a/eservice/pdo/eservice/pdo_helper.py
+++ b/eservice/pdo/eservice/pdo_helper.py
@@ -66,7 +66,7 @@ def shutdown() :
 def get_enclave_service_info(spid) :
     """get_enclave_service_info -- Retrieve enclave MRENCLAVE & BASENAME
     """
-    pdo_enclave.get_enclave_service_info(spid)
+    return pdo_enclave.get_enclave_service_info(spid)
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------


### PR DESCRIPTION
The scripts for processing enclave information were failing because the enclave was not shutdown cleanly. This should address that problem and cleans up the shell scripts.