### PR TITLE
Move enclave module configuration to a single file

### DIFF
--- a/__tools__/build/Makefile
+++ b/__tools__/build/Makefile
@@ -20,7 +20,7 @@ DSTDIR?=$(abspath $(SRCDIR)/_dev)
 ROOTDIR=$(abspath $(SRCDIR)/../..)
 
 KEYGEN=$(abspath $(SRCDIR)/../make-keys)
-CNFGEN=$(abspath $(SRCDIR)/../make-config)
+CNFGEN=$(abspath $(SRCDIR)/../expand-config)
 PKGGEN=$(abspath $(SRCDIR)/../rebuild.sh)
 
 PY_VERSION=${shell python3 --version | sed 's/Python \(3\.[0-9]\).*/\1/'}
@@ -63,13 +63,19 @@ keys :
 		for i in 1 2 3 4 5 6 7 8 9 10 ; do $(KEYGEN) --keyfile $(DSTDIR)/opt/pdo/keys/user$${i} --format pem; done
 
 conf :
-	. $(abspath $(DSTDIR)/bin/activate) ; \
-		$(CNFGEN) --template eservice.toml --template-directory $(SRCDIR)/opt/pdo/etc/template \
-		--node-base eservice --http-base 7100 --output $(DSTDIR)/opt/pdo/etc --count 5
-	. $(abspath $(DSTDIR)/bin/activate) ; \
-		$(CNFGEN) --template pservice.toml --template-directory $(SRCDIR)/opt/pdo/etc/template \
-		--node-base pservice --http-base 7000 --output $(DSTDIR)/opt/pdo/etc --count 5
-	cp $(SRCDIR)/opt/pdo/etc/template/pcontract.toml $(DSTDIR)/opt/pdo/etc
+	@ echo Create configuration files from templates
+	@ . $(abspath $(DSTDIR)/bin/activate) ; \
+		$(CNFGEN) --template eservice.toml --template-directory $(SRCDIR)/opt/pdo/etc/template  --output-directory $(DSTDIR)/opt/pdo/etc \
+		multiple --file-base eservice --http-base 7100 --count 5
+	@ . $(abspath $(DSTDIR)/bin/activate) ; \
+		$(CNFGEN) --template pservice.toml --template-directory $(SRCDIR)/opt/pdo/etc/template  --output-directory $(DSTDIR)/opt/pdo/etc \
+		multiple --file-base pservice --http-base 7000 --count 5
+	@ . $(abspath $(DSTDIR)/bin/activate) ; \
+		$(CNFGEN) --template enclave.toml --template-directory $(SRCDIR)/opt/pdo/etc/template  --output-directory $(DSTDIR)/opt/pdo/etc \
+		single --file enclave.toml
+	@ . $(abspath $(DSTDIR)/bin/activate) ; \
+		$(CNFGEN) --template pcontract.toml --template-directory $(SRCDIR)/opt/pdo/etc/template  --output-directory $(DSTDIR)/opt/pdo/etc \
+		single --file pcontract.toml
 
 template :
 	mkdir -p $(DSTDIR)/opt/pdo/data

--- a/__tools__/build/opt/pdo/etc/template/enclave.toml
+++ b/__tools__/build/opt/pdo/etc/template/enclave.toml
@@ -25,13 +25,13 @@ num_of_enclaves = '7'
 block_store_file_name = "${data}/blockstore.mdb"
 
 # spid is a 32-digit hex string tied to the enclave implementation
-spid = 'DEADBEEF00000000DEADBEEF00000000'
+spid = '${spid}'
 
 # ias_url is the URL of the Intel Attestation Service (IAS) server.  The
 # example server is for debug enclaves only
 ias_url = 'https://test-as.sgx.trustedservices.intel.com:443'
-https_proxy = ''
+https_proxy = '${proxy}'
 
 # spid_cert_file is the full path to the PEM-encoded certificate file that was
 # submitted to Intel in order to obtain a SPID
-spid_cert_file = '/etc/sawtooth/ias_rk_pub.pem'
+spid_cert_file = '${spid_cert_file}'

--- a/__tools__/build/opt/pdo/etc/template/eservice.toml
+++ b/__tools__/build/opt/pdo/etc/template/eservice.toml
@@ -57,27 +57,3 @@ DataPath = "${data}"
 # BaseName is the root of the name used to store data
 # about the enclave. A 'enc' extension will be added
 BaseName = "${identity}"
-
-# --------------------------------------------------
-# EnclaveModule -- configuration of the SGX contract enclave
-# --------------------------------------------------
-[EnclaveModule]
-
-# Number of available enclave workers to service requests
-num_of_enclaves = '7'
-
-# block_store_file_name is the path where persistent state data is stored
-# This is safe to share between eservice's
-block_store_file_name = "${data}/blockstore.mdb"
-
-# spid is a 32-digit hex string tied to the enclave implementation
-spid = 'DEADBEEF00000000DEADBEEF00000000'
-
-# ias_url is the URL of the Intel Attestation Service (IAS) server.  The
-# example server is for debug enclaves only
-ias_url = 'https://test-as.sgx.trustedservices.intel.com:443'
-https_proxy = '${proxy}'
-
-# spid_cert_file is the full path to the PEM-encoded certificate file that was
-# submitted to Intel in order to obtain a SPID
-spid_cert_file = '/etc/sawtooth/ias_rk_pub.pem'

--- a/__tools__/build/opt/pdo/etc/template/pservice.toml
+++ b/__tools__/build/opt/pdo/etc/template/pservice.toml
@@ -63,19 +63,3 @@ DataPath = "${data}"
 # BaseName is the root of the name used to store data
 # about the enclave. A 'enc' extension will be added
 BaseName = "${identity}"
-
-# --------------------------------------------------
-# EnclaveModule -- configuration of the SGX contract enclave
-# --------------------------------------------------
-[EnclaveModule]
-# spid is a 32-digit hex string tied to the enclave implementation
-spid = 'DEADBEEF00000000DEADBEEF00000000'
-
-# ias_url is the URL of the Intel Attestation Service (IAS) server.  The
-# example server is for debug enclaves only
-ias_url = 'https://test-as.sgx.trustedservices.intel.com:443'
-https_proxy = '${proxy}'
-
-# spid_cert_file is the full path to the PEM-encoded certificate file that was
-# submitted to Intel in order to obtain a SPID
-spid_cert_file = '/etc/sawtooth/ias_rk_pub.pem'

--- a/__tools__/expand-config
+++ b/__tools__/expand-config
@@ -30,8 +30,11 @@ ContractEtc = os.environ.get("CONTRACTETC") or os.path.join(ContractHome, "etc")
 ContractKeys = os.environ.get("CONTRACTKEYS") or os.path.join(ContractHome, "keys")
 ContractLogs = os.environ.get("CONTRACTLOGS") or os.path.join(ContractHome, "logs")
 ContractData = os.environ.get("CONTRACTDATA") or os.path.join(ContractHome, "data")
-LedgerURL = os.environ.get("LEDGER_URL", "http://127.0.0.1:8008/")
 HttpsProxy = os.environ.get("https_proxy", "")
+
+LedgerURL = os.environ.get("LEDGER_URL", "http://127.0.0.1:8008/")
+SPID = os.environ.get("PDO_SPID",'DEADBEEF00000000DEADBEEF00000000')
+SPID_CERT_FILE = os.environ.get("PDO_SPID_CERT_FILE",'/etc/sawtooth/ias_rk_pub.pem')
 
 config_map = {
     'data' : ContractData,
@@ -41,7 +44,9 @@ config_map = {
     'keys' : ContractKeys,
     'logs' : ContractLogs,
     'ledger' : LedgerURL,
-    'proxy' : HttpsProxy
+    'proxy' : HttpsProxy,
+    'spid' : SPID,
+    'spid_cert_file' : SPID_CERT_FILE
 }
 
 # -----------------------------------------------------------------
@@ -65,14 +70,33 @@ def parse_configuration_file(filename, variable_map) :
     for line in lines :
         text += re.sub(cpattern, '', line) + ' '
 
+    # try :
+    #     if variable_map :
+    #         text = Template(text).safe_substitute(variable_map)
+    # except ValueError as ve :
+    #     print('VALUEERROR: %s', ve)
+
+    # except Exception as e :
+    #     print('EXCEPTION: %s', e)
+
     if variable_map :
-        text = Template(text).substitute(variable_map)
+        text = Template(text).safe_substitute(variable_map)
 
     return toml.loads(text)
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
-def ConfigNode(options, node, httpport = 0) :
+def expand_single(options) :
+    filename = os.path.join(options.template_directory, options.template)
+    config = parse_configuration_file(filename, config_map)
+
+    filename = os.path.join(options.output_directory, options.file)
+    with open(filename, 'w') as outfile:
+        toml.dump(config, outfile)
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+def expand_multiple(options, node, httpport = 0) :
     node_map = config_map.copy()
     node_map['identity'] = node
     node_map['httpport'] = httpport
@@ -80,7 +104,7 @@ def ConfigNode(options, node, httpport = 0) :
     filename = os.path.join(options.template_directory, options.template)
     config = parse_configuration_file(filename, node_map)
 
-    filename = os.path.join(options.output, node + '.toml')
+    filename = os.path.join(options.output_directory, node + '.toml')
     with open(filename, 'w') as outfile:
         toml.dump(config, outfile)
 
@@ -92,14 +116,28 @@ parser = argparse.ArgumentParser(description='Script to generate sawtooth config
 
 parser.add_argument('--template', help='Name of the base configuration file to use', default='template.js')
 parser.add_argument('--template-directory', help='Directory in which the template configuration will be found', default='etc/templates')
-parser.add_argument('--node-base', help='Base for node names', default='node')
-parser.add_argument('--http-base', help='Base for http ports used for nodes', default=8800, type=int)
-parser.add_argument('--output', help='Name of the directory where generated configuration files are written', default='etc')
-parser.add_argument('--count', help='Number of validators to configure', default=9)
+parser.add_argument('--output-directory', help='Name of the directory where generated configuration files are written', default='etc')
+parser.add_argument('--set', help='Specify arbitrary configuration options', nargs=2, action='append')
+
+subparsers = parser.add_subparsers(dest='command')
+expand_parser = subparsers.add_parser('single', help='expand a template into a single file')
+expand_parser.add_argument('--file', help='Base for node names', required=True)
+
+multi_parser = subparsers.add_parser('multiple', help='expand a template into multiple files')
+multi_parser.add_argument('--file-base', help='Base for file names', required=True)
+multi_parser.add_argument('--http-base', help='Base for http ports used for nodes', default=8800, type=int)
+multi_parser.add_argument('--count', help='Number of validators to configure', default=9, type=int)
 
 options = parser.parse_args()
 
-for n in range(1, int(options.count)+1) :
-    node = options.node_base + str(n)
-    httpport = options.http_base + n
-    ConfigNode(options, node, httpport = httpport)
+if options.set :
+    for (k, v) in options.set : config_map[k] = v
+
+if options.command == 'multiple' :
+    for n in range(1, int(options.count)+1) :
+        node = options.file_base + str(n)
+        httpport = options.http_base + n
+        expand_multiple(options, node, httpport = httpport)
+
+elif options.command == 'single' :
+    expand_single(options)

--- a/eservice/bin/es-start.sh
+++ b/eservice/bin/es-start.sh
@@ -75,7 +75,7 @@ for index in `seq 1 $F_COUNT` ; do
 
     sleep 5
 
-    eservice --identity ${IDENTITY} --config ${IDENTITY}.toml --config-dir ${F_CONFDIR} ${F_LEDGERURL} \
+    eservice --identity ${IDENTITY} --config ${IDENTITY}.toml enclave.toml --config-dir ${F_CONFDIR} ${F_LEDGERURL} \
              --loglevel ${F_LOGLEVEL} --logfile ${F_LOGDIR}/${IDENTITY}.log 2> $EFILE > $OFILE &
 
 done

--- a/eservice/pdo/eservice/scripts/EServiceCLI.py
+++ b/eservice/pdo/eservice/scripts/EServiceCLI.py
@@ -466,13 +466,13 @@ config_map = {
 # -----------------------------------------------------------------
 def Main() :
     # parse out the configuration file first
-    conffiles = [ 'eservice.toml' ]
+    conffiles = [ 'eservice.toml', 'enclave.toml' ]
     confpaths = [ ".", "./etc", ContractEtc ]
 
     parser = argparse.ArgumentParser()
 
     parser.add_argument('--config', help='configuration file', nargs = '+')
-    parser.add_argument('--config-dir', help='configuration file', nargs = '+')
+    parser.add_argument('--config-dir', help='directory to search for configuration files', nargs = '+')
 
     parser.add_argument('--identity', help='Identity to use for the process', required = True, type = str)
 

--- a/eservice/tests/test-contract.py
+++ b/eservice/tests/test-contract.py
@@ -398,7 +398,7 @@ def Main() :
     import pdo.common.logger as plogger
 
     # parse out the configuration file first
-    conffiles = [ 'pcontract.toml', 'eservice_tests.toml' ]
+    conffiles = [ 'pcontract.toml', 'enclave.toml' ]
     confpaths = [ ".", "./etc", ContractEtc ]
 
     parser = argparse.ArgumentParser()

--- a/eservice/tests/test-request.py
+++ b/eservice/tests/test-request.py
@@ -395,7 +395,7 @@ def Main() :
     import pdo.common.logger as plogger
 
     # parse out the configuration file first
-    conffiles = [ 'pcontract.toml', 'eservice_tests.toml' ]
+    conffiles = [ 'pcontract.toml', 'enclave.toml' ]
     confpaths = [ ".", "./etc", ContractEtc ]
 
     parser = argparse.ArgumentParser()

--- a/eservice/tests/test-secrets.py
+++ b/eservice/tests/test-secrets.py
@@ -57,8 +57,8 @@ config_map = {
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
-conffiles = [ 'eservice_tests.toml' ]
-confpaths = [ ".", "./etc" ]
+conffiles = [ 'pcontract.toml', 'enclave.toml' ]
+confpaths = [ ".", "./etc", ContractEtc ]
 
 import argparse
 parser = argparse.ArgumentParser()

--- a/pservice/bin/ps-start.sh
+++ b/pservice/bin/ps-start.sh
@@ -75,7 +75,7 @@ for index in `seq 1 $F_COUNT` ; do
         rm -f $EFILE $OFILE
     fi
 
-    pservice --identity ${IDENTITY} --config ${IDENTITY}.toml --config-dir ${F_CONFDIR} ${F_LEDGERURL} \
+    pservice --identity ${IDENTITY} --config ${IDENTITY}.toml enclave.toml --config-dir ${F_CONFDIR} ${F_LEDGERURL} \
              --loglevel ${F_LOGLEVEL} --logfile ${F_LOGDIR}/${IDENTITY}.log 2> $EFILE > $OFILE &
 
 done

--- a/pservice/pdo/pservice/scripts/PServiceCLI.py
+++ b/pservice/pdo/pservice/scripts/PServiceCLI.py
@@ -437,7 +437,7 @@ def Main() :
     parser = argparse.ArgumentParser()
 
     parser.add_argument('--config', help='configuration file', nargs = '+')
-    parser.add_argument('--config-dir', help='configuration file', nargs = '+')
+    parser.add_argument('--config-dir', help='directory to search for configuration files', nargs = '+')
 
     parser.add_argument('--identity', help='Identity to use for the process', required = True, type = str)
 
@@ -467,6 +467,10 @@ def Main() :
         config = pconfig.parse_configuration_files(conffiles, confpaths, config_map)
     except pconfig.ConfigurationException as e :
         logger.error(str(e))
+        sys.exit(-1)
+
+    if config is None :
+        logger.error('failed to parse configuration file')
         sys.exit(-1)
 
     # set up the logging configuration

--- a/python/pdo/common/config.py
+++ b/python/pdo/common/config.py
@@ -101,6 +101,6 @@ def parse_configuration_file(filename, variable_map) :
         text += re.sub(cpattern, '', line) + ' '
 
     if variable_map :
-        text = Template(text).substitute(variable_map)
+        text = Template(text).safe_substitute(variable_map)
 
     return toml.loads(text)


### PR DESCRIPTION
Multiple applications depended on the enclave module
configuration. All applications now share a single
enclave module configuration file.

To use effectively, this requires that two new environment
variables are set: PDO_SPID and PDO_SPID_CERT_FILE. If these
are not set, then the enclave configuration uses the old
default values.

Signed-off-by: Mic Bowman <mic.bowman@intel.com>