### PR TITLE
fix security issue with seal

### DIFF
--- a/common/crypto/crypto.h
+++ b/common/crypto/crypto.h
@@ -14,6 +14,7 @@
  */
 
 #pragma once
+#include "sgx_defaults.h"
 #include <openssl/sha.h>
 #include "crypto_shared.h"
 #include "crypto_utils.h"

--- a/common/crypto/sgx_defaults.h
+++ b/common/crypto/sgx_defaults.h
@@ -1,0 +1,45 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <sgx_attributes.h>
+
+// Note: below definitions are taken from common/inc/internal/tseal_migration_attr.h
+// of the SGX SDK (v2.4.1).
+
+/* Set the bits which have no security implications to 0 for sealed data migration */
+/* Bits which have no security implications in attributes.flags:
+ *    Reserved bit[55:6]  - 0xFFFFFFFFFFFFC0ULL
+ *    SGX_FLAGS_MODE64BIT
+ *    SGX_FLAGS_PROVISION_KEY
+ *    SGX_FLAGS_EINITTOKEN_KEY */
+#define FLAGS_NON_SECURITY_BITS     (0xFFFFFFFFFFFFC0ULL | SGX_FLAGS_MODE64BIT | SGX_FLAGS_PROVISION_KEY| SGX_FLAGS_EINITTOKEN_KEY)
+#define TSEAL_DEFAULT_FLAGSMASK     (~FLAGS_NON_SECURITY_BITS)
+
+#define MISC_NON_SECURITY_BITS      0x0FFFFFFF  /* bit[27:0]: have no security implications */
+#define TSEAL_DEFAULT_MISCMASK      (~MISC_NON_SECURITY_BITS)
+
+
+// key-policy, attribute-mask, xfrm & misc mask as used in PDO seal and attestation
+// (keep attestation and seal-policy consistent for easier reasoning ..)
+
+#define PDO_SGX_ATTRIBUTTE_MASK	    (sgx_attributes_t){TSEAL_DEFAULT_FLAGSMASK | SGX_FLAGS_MODE64BIT, 0x0}
+// As we are in a multi-pary security case, we do not make the assumption, though,
+// that there is no way to write a binary which is at same time valid 32-bit code
+// and valid 64-bit code (of different behaviour). Additionally, we do not require
+// mixed mode binaries. Hence and different to sdk, we set the SGX_FLAGS_MODE64BIT flag.
+#define PDO_SGX_MISCMASK            TSEAL_DEFAULT_MISCMASK
+#define PDO_SGX_KEYPOLICY           SGX_KEYPOLICY_MRENCLAVE

--- a/docker/Dockerfile.pdo-dev
+++ b/docker/Dockerfile.pdo-dev
@@ -19,7 +19,7 @@
 #  Configuration (build) paramaters
 #  - proxy configuration: 	https_proxy http_proxy ftp_proxy, no_proxy  (default: undefined)
 #  - ubuntu base image to use: 	UBUNTU_VERSION (default: bionic)
-#  - sgx sdk version: 		SGX_SDK (default: v2.4.1)
+#  - sgx sdk version: 		SGX_SDK (default: sgx_2.4)
 #  - openssl version: 		OPENSSL (default: 1.1.0j)
 #  - sgxssl version: 		SGXSSL  (default: v2.4.1)
 #  - additional apt packages:	ADD_APT_PKGS (default: )
@@ -42,6 +42,8 @@
 #     or the PSW/aesmd might cause enclave launch problems
 #   - if behind a proxy, you might want to add also below options
 #     --env https_proxy=$https_proxy --env http_proxy=$http_proxy --env ftp_proxy=$ftp_proxy --env no_proxy=$no_proxy
+#   - if you want to debug with gdb and alike, you also might want to add options
+#     '--security-opt seccomp=unconfined --security-opt apparmor=unconfined --cap-add=SYS_PTRACE '
 #   - for develooping based on source in host you might map source into container with an option
 #     like -v $(pwd):/project/pdo/src/private-data-objects/
 

--- a/eservice/lib/libpdo_enclave/contract.edl
+++ b/eservice/lib/libpdo_enclave/contract.edl
@@ -27,6 +27,12 @@ enclave {
         //
         public pdo_err_t ecall_ShutdownContractWorker();
 
+	//
+        public pdo_err_t ecall_CalculateSealedContractKeySize(
+	    size_t contractIdSize,
+            [out] size_t* pSealedContractKeySize
+            );
+
         //
         public pdo_err_t ecall_VerifySecrets(
             [in, size=inSealedSignupDataSize] const uint8_t* inSealedSignupData,

--- a/eservice/lib/libpdo_enclave/contract_secrets.h
+++ b/eservice/lib/libpdo_enclave/contract_secrets.h
@@ -41,7 +41,7 @@ pdo_err_t CreateEnclaveStateEncryptionKey(const EnclaveData& enclave_data,
 ByteArray EncryptStateEncryptionKey(
     const std::string& inContractId, const ByteArray& inContractStateEncryptionKey);
 
-Base64EncodedString EncodeAndEncryptStateEncryptionKey(
+Base64EncodedString EncryptAndEncodeStateEncryptionKey(
     const std::string& inContractId, const ByteArray& inContractStateEncryptionKey);
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/eservice/pdo/eservice/enclave/enclave/contract.h
+++ b/eservice/pdo/eservice/enclave/enclave/contract.h
@@ -28,8 +28,11 @@ namespace pdo
         namespace contract
         {
 
-             // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-            size_t ContractKeySize(void);
+            // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+	    size_t EncryptedContractKeySize(
+	        size_t contractIdSize,
+	        int enclaveIndex
+	        );
 
             // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
             pdo_err_t VerifySecrets(

--- a/pservice/lib/libpdo_enclave/secret_enclave.cpp
+++ b/pservice/lib/libpdo_enclave/secret_enclave.cpp
@@ -231,12 +231,11 @@ pdo_err_t ecall_CreateEnclaveData(const sgx_target_info_t* inTargetInfo,
         (*outSealedEnclaveDataSize) = enclaveData.get_sealed_data_size();;
 
         // Seal up the enclave data into the caller's buffer.
-        // NOTE - the attributes mask 0xfffffffffffffff3 seems rather
-        // arbitrary, but according to SGX SDK documentation, this is
-        // what sgx_seal_data uses, so it is good enough for us.
-        sgx_attributes_t attribute_mask = {0xfffffffffffffff3, 0};
-        sgx_status_t ret = sgx_seal_data_ex(SGX_KEYPOLICY_MRENCLAVE, attribute_mask,
-            0,        // misc_mask
+        // See comments on seal for ecall_CreateEnclaveData in
+        // eservice/lib/libpdo_enclave/signup_enclave.cpp
+	// for some important notes ...
+        sgx_status_t ret = sgx_seal_data_ex(
+	    PDO_SGX_KEYPOLICY, PDO_SGX_ATTRIBUTTE_MASK, PDO_SGX_MISCMASK,
             0,        // additional mac text length
             nullptr,  // additional mac text
             enclaveData.get_private_data_size(),
@@ -337,12 +336,11 @@ pdo_err_t ecall_CreateSealedSecret(size_t secret_len,
         pdo::error::ThrowSgxError(status, "Failed to generate random key");
 
         // Seal up the enclave data into the caller's buffer.
-        // NOTE - the attributes mask 0xfffffffffffffff3 seems rather
-        // arbitrary, but according to SGX SDK documentation, this is
-        // what sgx_seal_data uses, so it is good enough for us.
-        sgx_attributes_t attribute_mask = {0xfffffffffffffff3, 0};
-        status = sgx_seal_data_ex(SGX_KEYPOLICY_MRENCLAVE, attribute_mask,
-            0,        // misc_mask
+        // See comments on seal for ecall_CreateEnclaveData in
+        // eservice/lib/libpdo_enclave/signup_enclave.cpp
+	// for some important notes ...
+        status = sgx_seal_data_ex(
+	    PDO_SGX_KEYPOLICY, PDO_SGX_ATTRIBUTTE_MASK, PDO_SGX_MISCMASK,
             0,        // additional mac text length
             nullptr,  // additional mac text
             secret_len,


### PR DESCRIPTION
This fix a major and a minor security issue with seal of contract state and unifies the settings for seal and attestation.

Note this will stop existing contracts from being read as sealkey changes!

