### PR TITLE
Root block authentication + related tests + related fixes

### DIFF
--- a/build/__tools__/run-tests.sh
+++ b/build/__tools__/run-tests.sh
@@ -122,6 +122,14 @@ say start request test
 try pdo-test-request --no-ledger --iterations 100 \
     --logfile __screen__ --loglevel warn
 
+say start request test with tampered block order, this should fail
+pdo-test-request --no-ledger \
+    --tamper-block-order \
+    --logfile __screen__ --loglevel warn
+if [ $? == 0 ]; then
+    die request test with tampered block order succeeded though it should have failed
+fi
+
 say start integer-key contract test
 try pdo-test-contract --no-ledger --contract integer-key \
     --logfile __screen__ --loglevel warn
@@ -146,16 +154,6 @@ try pdo-test-request --ledger ${PDO_LEDGER_URL} \
     --pservice http://localhost:7001/ http://localhost:7002 http://localhost:7003 \
     --eservice http://localhost:7101/ \
     --logfile __screen__ --loglevel warn
-
-say start request test with tampered block order
-pdo-test-request --ledger ${PDO_LEDGER_URL} \
-    --pservice http://localhost:7001/ http://localhost:7002 http://localhost:7003 \
-    --eservice http://localhost:7101/ \
-    --tamper-block-order \
-    --logfile __screen__ --loglevel warn
-if [ $? == 0 ]; then
-    die request test with tampered block order succeeded though it should have failed
-fi
 
 say start integer-key contract test
 try pdo-test-contract --ledger ${PDO_LEDGER_URL} --contract integer-key \

--- a/build/__tools__/run-tests.sh
+++ b/build/__tools__/run-tests.sh
@@ -147,6 +147,16 @@ try pdo-test-request --ledger ${PDO_LEDGER_URL} \
     --eservice http://localhost:7101/ \
     --logfile __screen__ --loglevel warn
 
+say start request test with tampered block order
+pdo-test-request --ledger ${PDO_LEDGER_URL} \
+    --pservice http://localhost:7001/ http://localhost:7002 http://localhost:7003 \
+    --eservice http://localhost:7101/ \
+    --tamper-block-order \
+    --logfile __screen__ --loglevel warn
+if [ $? == 0 ]; then
+    die request test with tampered block order succeeded though it should have failed
+fi
+
 say start integer-key contract test
 try pdo-test-contract --ledger ${PDO_LEDGER_URL} --contract integer-key \
     --pservice http://localhost:7001/ http://localhost:7002 http://localhost:7003 \

--- a/common/crypto/crypto_utils.cpp
+++ b/common/crypto/crypto_utils.cpp
@@ -56,10 +56,31 @@ static void SHA256HMAC(
     const unsigned char* buf, int buf_size, const unsigned char* key, unsigned int key_len,
     unsigned char *hmac, unsigned int hmac_len)
 {
+    Error::ThrowIfNull(buf, "null buffer");
+    Error::ThrowIfNull(key, "null key");
+    Error::ThrowIfNull(hmac, "null hmac buffer");
+
     HMAC_CTX* hmac_ctx = HMAC_CTX_new();
-    HMAC_Init_ex(hmac_ctx, key, key_len, EVP_sha256(), NULL);
-    HMAC_Update(hmac_ctx, buf, buf_size);
-    HMAC_Final(hmac_ctx, hmac, &hmac_len);
+    Error::ThrowIfNull(hmac_ctx, "invalid hmac context");
+
+    try
+    {
+        int ret;
+        ret = HMAC_Init_ex(hmac_ctx, key, key_len, EVP_sha256(), NULL);
+        Error::ThrowIf<Error::RuntimeError>(ret == 0, "hmac init failed");
+
+        ret = HMAC_Update(hmac_ctx, buf, buf_size);
+        Error::ThrowIf<Error::RuntimeError>(ret == 0, "hmac update failed");
+
+        ret = HMAC_Final(hmac_ctx, hmac, &hmac_len);
+        Error::ThrowIf<Error::RuntimeError>(ret == 0, "hmac final failed");
+    }
+    catch(...)
+    {
+        HMAC_CTX_free(hmac_ctx);
+        throw;
+    }
+
     HMAC_CTX_free(hmac_ctx);
 }  // pcrypto::SHA256HMAC
 

--- a/common/crypto/crypto_utils.h
+++ b/common/crypto/crypto_utils.h
@@ -25,6 +25,9 @@ namespace crypto
     // SHA256 hashing
     ByteArray ComputeMessageHash(const ByteArray& message);
 
+    // SHA256 HMAC
+    ByteArray ComputeMessageHMAC(const ByteArray& key, const ByteArray& message);
+
     // Generate cryptographically strong reandom bitstring
     // throws RuntimeError
     ByteArray RandomBitString(size_t length);

--- a/common/state/StateUtils.h
+++ b/common/state/StateUtils.h
@@ -37,8 +37,8 @@ namespace state
         void AppendChild(pdo::state::StateNode& childNode);
         void AppendChildId(StateBlockId& childId);
         void SetHasParent();
-        void BlockifyChildren();
-        void UnBlockifyChildren();
+        void BlockifyChildren(const ByteArray& state_encryption_key);
+        void UnBlockifyChildren(const ByteArray& state_encryption_key);
         pdo::state::StateBlockIdArray GetChildrenBlocks();
         void ClearChildren();
     };

--- a/common/state/block_warehouse.cpp
+++ b/common/state/block_warehouse.cpp
@@ -24,12 +24,12 @@ void pdo::state::block_warehouse::serialize_block_ids(pdo::state::StateNode& nod
     {
         node.AppendChildId(blockIds_[i]);
     }
-    node.BlockifyChildren();
+    node.BlockifyChildren(state_encryption_key_);
 }
 
 void pdo::state::block_warehouse::deserialize_block_ids(pdo::state::StateNode& node)
 {
-    node.UnBlockifyChildren();
+    node.UnBlockifyChildren(state_encryption_key_);
     blockIds_ = node.GetChildrenBlocks();
 }
 

--- a/common/tests/testCrypto.cpp
+++ b/common/tests/testCrypto.cpp
@@ -222,6 +222,23 @@ int pcrypto::testCrypto()
     printf("testCrypto: ComputeMessageHash test passed!\n\n");
     // End Test ComputMessageHash
 
+    // Test ComputeMessageHMAC
+    ByteArray hmackey {4, 6, 8, 5, 1, 2, 3, 4, 3, 4, 7, 8, 9, 7, 8, 0};
+    msg.clear();
+    msg.insert(msg.end(), msgStr.data(), msgStr.data() + msgStr.size());
+    std::string msg_SHA256HMAC_B64("mO+yrlHk5HH1vyDlKuSjhTgWR0Y9Iqv1JlZW+pKDwWk=");
+    ByteArray hmac = ComputeMessageHMAC(hmackey, msg);
+    std::string hmacStr_B64 = base64_encode(hmac);
+    if (hmacStr_B64.compare(msg_SHA256HMAC_B64) != 0)
+    {
+        printf(
+            "testCrypto: ComputeMessageHMAC test failed, SHA256 digest "
+            "mismatch.\n");
+        return -1;
+    }
+    printf("testCrypto: ComputeMessageHMAC test passed!\n\n");
+    // End Test ComputMessageHMAC
+
     // Tesf of SignMessage and VerifySignature
     ByteArray sig;
     try

--- a/common/tests/testCrypto.cpp
+++ b/common/tests/testCrypto.cpp
@@ -223,19 +223,96 @@ int pcrypto::testCrypto()
     // End Test ComputMessageHash
 
     // Test ComputeMessageHMAC
-    ByteArray hmackey {4, 6, 8, 5, 1, 2, 3, 4, 3, 4, 7, 8, 9, 7, 8, 0};
-    msg.clear();
-    msg.insert(msg.end(), msgStr.data(), msgStr.data() + msgStr.size());
-    std::string msg_SHA256HMAC_B64("mO+yrlHk5HH1vyDlKuSjhTgWR0Y9Iqv1JlZW+pKDwWk=");
-    ByteArray hmac = ComputeMessageHMAC(hmackey, msg);
-    std::string hmacStr_B64 = base64_encode(hmac);
-    if (hmacStr_B64.compare(msg_SHA256HMAC_B64) != 0)
-    {
-        printf(
-            "testCrypto: ComputeMessageHMAC test failed, SHA256 digest "
-            "mismatch.\n");
-        return -1;
+
+    {//test expected hmac
+        ByteArray hmackey {4, 6, 8, 5, 1, 2, 3, 4, 3, 4, 7, 8, 9, 7, 8, 0};
+        std::string msgStr("Proof of Elapsed Time");
+        ByteArray msg;
+        msg.insert(msg.end(), msgStr.data(), msgStr.data() + msgStr.size());
+        std::string msg_SHA256HMAC_B64("mO+yrlHk5HH1vyDlKuSjhTgWR0Y9Iqv1JlZW+pKDwWk=");
+        ByteArray hmac = ComputeMessageHMAC(hmackey, msg);
+        std::string hmacStr_B64 = base64_encode(hmac);
+        if (hmacStr_B64.compare(msg_SHA256HMAC_B64) != 0)
+        {
+            printf(
+                "testCrypto: ComputeMessageHMAC test failed, SHA256 digest "
+                "mismatch.\n");
+            return -1;
+        }
     }
+
+    {//test unexpected hmac (due to wrong key)
+        ByteArray hmackey {0, 6, 8, 5, 1, 2, 3, 4, 3, 4, 7, 8, 9, 7, 8, 0};
+        std::string msgStr("Proof of Elapsed Time");
+        ByteArray msg;
+        msg.insert(msg.end(), msgStr.data(), msgStr.data() + msgStr.size());
+        std::string msg_SHA256HMAC_B64("mO+yrlHk5HH1vyDlKuSjhTgWR0Y9Iqv1JlZW+pKDwWk=");
+        ByteArray hmac = ComputeMessageHMAC(hmackey, msg);
+        std::string hmacStr_B64 = base64_encode(hmac);
+        if (hmacStr_B64.compare(msg_SHA256HMAC_B64) == 0)
+        {
+            printf("testCrypto: ComputeMessageHMAC, wrong key test shoud have failed.\n");
+            return -1;
+        }
+    }
+
+    {//test unexpected hmac (due to wrong message)
+        ByteArray hmackey {4, 6, 8, 5, 1, 2, 3, 4, 3, 4, 7, 8, 9, 7, 8, 0};
+        std::string msgStr("proof of Elapsed Time");
+        ByteArray msg;
+        msg.insert(msg.end(), msgStr.data(), msgStr.data() + msgStr.size());
+        std::string msg_SHA256HMAC_B64("mO+yrlHk5HH1vyDlKuSjhTgWR0Y9Iqv1JlZW+pKDwWk=");
+        ByteArray hmac = ComputeMessageHMAC(hmackey, msg);
+        std::string hmacStr_B64 = base64_encode(hmac);
+        if (hmacStr_B64.compare(msg_SHA256HMAC_B64) == 0)
+        {
+            printf("testCrypto: ComputeMessageHMAC, wrong message test should have failed.\n");
+            return -1;
+        }
+    }
+
+    {//test big key big data hmac
+        ByteArray hmackey(1<<18, 0);
+        ByteArray msg(1<<18, 1);
+        try
+        {
+            ByteArray hmac = ComputeMessageHMAC(hmackey, msg);
+        }
+        catch(...)
+        {
+            printf("testCrypto: ComputeMessageHMAC, test big key/data failed.\n");
+            return -1;
+        }
+    }
+
+    {//test zero key hmac
+        ByteArray hmackey;
+        ByteArray msg(1,0);
+        try
+        {
+            ByteArray hmac = ComputeMessageHMAC(hmackey, msg);
+            throw pdo::error::RuntimeError("testCrypto: ComputeMessageHMAC, test zero key should have failed.\n");
+        }
+        catch(...)
+        {
+            //test success, do nothing
+        }
+    }
+
+    {//test zero data hmac
+        ByteArray hmackey(1,0);
+        ByteArray msg;
+        try
+        {
+            ByteArray hmac = ComputeMessageHMAC(hmackey, msg);
+            throw pdo::error::RuntimeError("testCrypto: ComputeMessageHMAC, test zero data should have failed.\n");
+        }
+        catch(...)
+        {
+            //test success, do nothing
+        }
+    }
+
     printf("testCrypto: ComputeMessageHMAC test passed!\n\n");
     // End Test ComputMessageHMAC
 

--- a/python/pdo/contract/state.py
+++ b/python/pdo/contract/state.py
@@ -137,8 +137,7 @@ class ContractState(object) :
         if raw_data is None :
             raise Exception('unable to locate required block; {}'.format(state_hash))
 
-        if not eservice.block_store_put(state_hash, raw_data) :
-            raise Exception('failed to push block to eservice; {}'.format(state_hash))
+        eservice.block_store_put(state_hash, raw_data)
 
         logger.debug('sent block %s to eservice', state_hash)
         return True
@@ -172,7 +171,7 @@ class ContractState(object) :
 
             ContractState.__cache_data_block__(contract_id, raw_data, data_dir)
 
-        logger.debug('sent block %s to eservice', state_hash)
+        logger.debug('retrieved block %s from eservice', state_hash)
         return True
 
     # --------------------------------------------------

--- a/python/pdo/service_client/enclave.py
+++ b/python/pdo/service_client/enclave.py
@@ -157,7 +157,7 @@ class EnclaveServiceClient(GenericServiceClient) :
     # -----------------------------------------------------------------
     def block_store_put(self, state_hash_b64, state_b64) :
         """
-        Retrieves a block from the enclave service's block store
+        Uploads a block to the enclave service's block store
         Returns:
             True - Success
             False - Failure

--- a/python/pdo/test/__init__.py
+++ b/python/pdo/test/__init__.py
@@ -16,4 +16,5 @@ __all__ = [
     'helpers',
     'contract',
     'request',
+    'state'
 ]

--- a/python/pdo/test/request.py
+++ b/python/pdo/test/request.py
@@ -436,7 +436,6 @@ def Main() :
     parser.add_argument('--secret-count', help='Number of secrets to generate', type=int, default=3)
     parser.add_argument('--iterations', help='Number of operations to perform', type=int, default=10)
 
-    tamper_block_order = False
     parser.add_argument('--tamper-block-order', help='Flag for tampering with the order of the state blocks', action='store_true')
 
     options = parser.parse_args()
@@ -535,6 +534,8 @@ def Main() :
     config['iterations'] = options.iterations
 
     tamper_block_order = options.tamper_block_order
+    if tamper_block_order :
+        config['iterations'] = 1
 
     LocalMain(config)
 

--- a/python/pdo/test/state.py
+++ b/python/pdo/test/state.py
@@ -1,0 +1,50 @@
+# Copyright 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import json
+import pdo.common.crypto as crypto
+
+import logging
+logger = logging.getLogger(__name__)
+
+def TamperWithStateBlockOrder(state_object) :
+    """
+    swaps the first two blocks of the state, leaving any authentication info unchanged
+    """
+    if len(state_object.component_block_ids) < 2 :
+        raise Exception('cannot tamper with state block order')
+
+    temp_id = state_object.component_block_ids[0]
+    state_object.component_block_ids[0] = state_object.component_block_ids[1]
+    state_object.component_block_ids[1] = temp_id
+
+    # get the original block and modify it
+    b64_decoded_byte_array = crypto.base64_to_byte_array(state_object.encrypted_state)
+    b64_decoded_string = crypto.byte_array_to_string(b64_decoded_byte_array).rstrip('\0')
+    json_main_state_block = json.loads(b64_decoded_string)
+    json_main_state_block['BlockIds'] = state_object.component_block_ids
+
+    #re-store the tampered main state block
+    new_main_state_block = json.dumps(json_main_state_block)
+    new_main_state_block_byte_array = crypto.string_to_byte_array(new_main_state_block)
+    state_object.update_state(crypto.byte_array_to_base64(new_main_state_block_byte_array))
+    state_object.save_to_cache()
+
+def RestoreStateBlockOrder(state_object, state_hash) :
+    """
+    re-initializes the state object using the input state hash
+    """
+    so = state_object.read_from_cache(state_object.contract_id, state_hash)
+    state_object.update_state(so.encrypted_state)

--- a/python/pdo/test/state.py
+++ b/python/pdo/test/state.py
@@ -41,10 +41,3 @@ def TamperWithStateBlockOrder(state_object) :
     new_main_state_block_byte_array = crypto.string_to_byte_array(new_main_state_block)
     state_object.update_state(crypto.byte_array_to_base64(new_main_state_block_byte_array))
     state_object.save_to_cache()
-
-def RestoreStateBlockOrder(state_object, state_hash) :
-    """
-    re-initializes the state object using the input state hash
-    """
-    so = state_object.read_from_cache(state_object.contract_id, state_hash)
-    state_object.update_state(so.encrypted_state)


### PR DESCRIPTION
this PR adds
-an HMAC wrapper to the crypto library
-tests for the HMAC function
-an authenticator field in the root block
-tests for checking whether the authenticator (and so the root block) is correct
-several fixes to make the tests work
-add another test in run-tests