### PR TITLE
Implement the storage service

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -95,6 +95,8 @@ keys : $(PYTHON_DIR)
 	. $(abspath $(DSTDIR)/bin/activate) ; \
 		for i in 1 2 3 4 5 ; do $(KEYGEN) --keyfile $(DSTDIR)/opt/pdo/keys/eservice$${i} --format skf; done
 	. $(abspath $(DSTDIR)/bin/activate) ; \
+		for i in 1 2 3 4 5 ; do $(KEYGEN) --keyfile $(DSTDIR)/opt/pdo/keys/sservice$${i} --format pem; done
+	. $(abspath $(DSTDIR)/bin/activate) ; \
 		for i in 1 2 3 4 5 ; do $(KEYGEN) --keyfile $(DSTDIR)/opt/pdo/keys/pservice$${i} --format pem; done
 	. $(abspath $(DSTDIR)/bin/activate) ; \
 		for i in 1 2 3 4 5 6 7 8 9 10 ; do $(KEYGEN) --keyfile $(DSTDIR)/opt/pdo/keys/user$${i} --format pem; done
@@ -105,6 +107,10 @@ conf : $(PYTHON_DIR)
 		$(CNFGEN) --template eservice.toml --template-directory $(SCRIPTDIR)/opt/pdo/etc/template \
 		--output-directory $(DSTDIR)/opt/pdo/etc \
 		multiple --file-base eservice --http-base 7100 --count 5
+	@ . $(abspath $(DSTDIR)/bin/activate) ; \
+		$(CNFGEN) --template sservice.toml --template-directory $(SCRIPTDIR)/opt/pdo/etc/template \
+		--output-directory $(DSTDIR)/opt/pdo/etc \
+		multiple --file-base sservice --http-base 7200 --count 5
 	@ . $(abspath $(DSTDIR)/bin/activate) ; \
 		$(CNFGEN) --template pservice.toml --template-directory $(SCRIPTDIR)/opt/pdo/etc/template \
 		--output-directory $(DSTDIR)/opt/pdo/etc \

--- a/build/__tools__/expand-config
+++ b/build/__tools__/expand-config
@@ -140,6 +140,9 @@ if options.set :
 
 if options.command == 'multiple' :
     for n in range(1, int(options.count)+1) :
+        # this provides a means to pair storage & enclave services
+        config_map['_count_'] = str(n)
+
         node = options.file_base + str(n)
         httpport = options.http_base + n
         expand_multiple(options, node, httpport = httpport)

--- a/build/opt/pdo/etc/template/sservice.toml
+++ b/build/opt/pdo/etc/template/sservice.toml
@@ -1,0 +1,39 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# --------------------------------------------------
+# Service -- general information about the service
+# --------------------------------------------------
+[StorageService]
+# Identity is a string used to identify the service in log files
+Identity = "${identity}"
+HttpPort = ${httpport}
+Host = "localhost"
+BlockStore = "${data}/eservice${_count_}.mdb"
+
+# --------------------------------------------------
+# Logging -- configuration of service logging
+# --------------------------------------------------
+[Logging]
+LogLevel = "INFO"
+LogFile  = "${logs}/${identity}.log"
+
+# --------------------------------------------------
+# Keys -- configuration for retrieving service keys
+# --------------------------------------------------
+[Key]
+# Keys are used to sign the registration transaction
+# should it be required
+SearchPath = [ ".", "./keys", "${keys}" ]
+FileName = "${identity}_private.pem"

--- a/eservice/Makefile
+++ b/eservice/Makefile
@@ -46,6 +46,7 @@ PYTHON_FILES = \
 	pdo/eservice/enclave/__init__.py \
 	pdo/eservice/pdo_helper.py \
 	pdo/eservice/scripts/EServiceCLI.py \
+	pdo/eservice/scripts/SServiceCLI.py \
 	pdo/eservice/scripts/__init__.py \
 	pdo/eservice/pdo_enclave.py \
 	pdo/eservice/__init__.py \

--- a/eservice/docs/sservice.md
+++ b/eservice/docs/sservice.md
@@ -1,0 +1,94 @@
+<!--- -*- mode: markdown; fill-column: 100 -*- --->
+<!---
+Licensed under Creative Commons Attribution 4.0 International License
+https://creativecommons.org/licenses/by/4.0/
+--->
+
+# Storage Service #
+
+The storage service is an HTTP server that manages the client interface to the block storage associated with a [contract enclave service](eservice.md).
+
+See the [build documentation](BUILD.md) for information about installation of the contract enclave and storage services. This document assumes that the storage service will be run from a virtual environment rooted at the path pointed to by the environment variable ``PDO_HOME``.
+
+## Configuration ##
+
+The storage service is configured through a Toml configuration file generally place in ``$PDO_HOME_/etc/sservice.toml``.
+
+## Command Line Parameters ##
+
+* config -- one or more configuration files, default is ``sservice.toml``
+* config-dir -- one or more directories to search for the configuration file, default is ``[".", "./etc", "$PDO_HOME/etc"]``.
+* identity -- *REQUIRED*, a string used to identify log and key files
+* logfile -- name of the file for logging, use ``__screen__`` for logging to standard output
+* loglevel -- level of logging to use, can be one of ``DEBUG``, ``INFO``, ``WARN``, ``ERROR``
+* http -- the port where the HTTP server will listen
+* key-dir -- one or more directories to search for the private key used by the storage service to sign storage contracts
+* data-dir -- path where data files are stored
+* block-store -- name of the file where blocks are stored, defaults to ``${data}/${identity}.mdb``
+
+## Operations ##
+
+The storage service supports several operations for interacting with the block store.
+
+| URL           | Method | Request Body     | Response Body            | Description                                    |
+|:--------------|:-------|:-----------------|:-------------------------|------------------------------------------------|
+| /block/<id>   | GET    | None             | application/octet-string | Return the requested block                     |
+| /block/<id>   | PUT    | None             | None                     | Store the requested block                      |
+| /block/<id>   | HEAD   | None             | None                     | Return size of block or NOT_FOUND              |
+| /block/list   | GET    | None             | application/json         | List of all known blocks                       |
+| /block/status | POST   | application/json | application/json         | Size and expiration of requested blocks        |
+| /block/store  | POST   | multipart/form   | application/json         | Store multiple blocks, return proof of storage |
+| /info         | GET    | None             | application/json         | Request information about the service          |
+| /shutdown     | GET    | None             | None                     | Request to shutdown the service                |
+
+Across operations, a block id (the sha256 hash of the block) will be represented as a url-encoded, base64 string. Block data is always binary and identified as ``application/octet-string``.
+
+### Status ###
+
+The ``status`` operation returns the size and expiration time of any requested block that is currently maintained by the storage service. If a requested block is currently not managed by the storage service, length and expiration will be set to 0. Note that the expiration is the number of seconds in the future when the block will expire; it is not a wall clock time.
+
+#### Input ####
+
+```JSON
+[
+    "base64 encoded block hash", ...
+]
+```
+
+#### Output ####
+
+```JSON
+[
+    {
+        "block_id" : "base64 encoded block hash",
+        "size" : "integer",
+        "expiration" : "integer"
+    },
+    ...
+    {}
+]
+```
+### Store Blocks ###
+
+The ``store`` operation requests that the storage service manage a set of blocks for at least a requested interval of time. If the storage service agrees to manage the blocks for the requested time, it will sign the hash of the hashes of the stored blocks (computed in the same order as the blocks were requested). The request will be encoded as ``multipart/form``. The first section of the form will contain a ``JSON`` request that includes requested interval and a list of block identifiers. Each specified block will be in its own section in the form.
+
+#### Input ####
+
+
+```JSON
+{
+    "interval" : "integer",
+    "block_ids" : [
+        "base64 encoded block hash", ...
+    ]
+}
+```
+
+#### Output ####
+
+```JSON
+{
+    "public-key" : "PEM encoded ECDSA verifying key",
+    "signature" : "base64 encoded signature"
+}
+```

--- a/eservice/etc/sample_sservice.toml
+++ b/eservice/etc/sample_sservice.toml
@@ -1,0 +1,39 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# --------------------------------------------------
+# Service -- general information about the service
+# --------------------------------------------------
+[StorageService]
+# Identity is a string used to identify the service in log files
+Identity = "${identity}"
+HttpPort = 7200
+Host = "localhost"
+BlockStore = "${data}/${identity}.mdb"
+
+# --------------------------------------------------
+# Logging -- configuration of service logging
+# --------------------------------------------------
+[Logging]
+LogLevel = "INFO"
+LogFile  = "${logs}/${identity}.log"
+
+# --------------------------------------------------
+# Keys -- configuration for retrieving service keys
+# --------------------------------------------------
+[Key]
+# Keys are used to sign the registration transaction
+# should it be required
+SearchPath = [ ".", "./keys", "${keys}" ]
+FileName = "${identity}_private.skf"

--- a/eservice/pdo/eservice/scripts/SServiceCLI.py
+++ b/eservice/pdo/eservice/scripts/SServiceCLI.py
@@ -1,0 +1,652 @@
+#!/usr/bin/env python
+
+# Copyright 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Storage service.
+"""
+
+import os
+import sys
+import argparse
+
+import base64
+import hashlib
+import json
+import lmdb
+
+import pdo.common.config as pconfig
+import pdo.common.keys as keys
+import pdo.common.logger as plogger
+
+import logging
+logger = logging.getLogger(__name__)
+
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+from twisted.web import http
+from twisted.web.server import Site
+from twisted.web.resource import Resource, NoResource
+from twisted.internet import reactor, defer
+from twisted.internet.threads import deferToThread
+from twisted.web.server import NOT_DONE_YET
+from twisted.web.error import Error
+from twisted.python.threadpool import ThreadPool
+
+## -----------------------------------------------------------------
+def ErrorResponse(request, error_code, msg) :
+    """
+    Generate a common error response for broken requests
+    """
+
+    if error_code > 400 :
+        logger.warn(msg)
+    elif error_code > 300 :
+        logger.debug(msg)
+
+    result = "" if request.method == 'HEAD' else (msg + '\n')
+
+    request.setResponseCode(error_code)
+    request.setHeader('content-type', 'text/plain')
+    request.write(result.encode('utf8'))
+
+    return request
+
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+class CommonResource(Resource) :
+
+    ## -----------------------------------------------------------------
+    def __init__(self, service_keys, block_store_env) :
+        Resource.__init__(self)
+        self.service_keys = service_keys
+        self.block_store_env = block_store_env
+
+    ## -----------------------------------------------------------------
+    def _handle_error_(self, failure) :
+        f = failure.trap(Exception)
+        logger.warn("an error occurred (%s): %s", type(self).__name__, failure.value.args)
+
+    ## -----------------------------------------------------------------
+    def _handle_done_(self, request) :
+        request.finish()
+
+    ## -----------------------------------------------------------------
+    def _defer_request_(self, handler, request) :
+        d = deferToThread(handler, request)
+        d.addErrback(self._handle_error_)
+        d.addCallback(self._handle_done_)
+
+        return NOT_DONE_YET
+
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+class BlockList(CommonResource) :
+    isLeaf = True
+
+    ## -----------------------------------------------------------------
+    def __init__(self, service_keys, block_store_env) :
+        CommonResource.__init__(self, service_keys, block_store_env)
+
+    ## -----------------------------------------------------------------
+    def _handle_request_(self, request) :
+        try :
+            block_ids = []
+            with self.block_store_env.begin() as txn :
+                cursor = txn.cursor()
+                for key, value in cursor :
+                    block_ids.append(base64.urlsafe_b64encode(key).decode())
+
+            result = json.dumps(block_ids).encode()
+
+        except Exception as e :
+            logger.error("unknown exception (BlockList); %s", str(e))
+            return ErrorResponse(request, http.BAD_REQUEST, "unknown exception while processing list blocks request")
+
+        request.setHeader('content-type', 'application/json')
+        request.write(result)
+
+        return request
+
+    ## -----------------------------------------------------------------
+    def render_GET(self, request) :
+        return self._defer_request_(self._handle_request_, request)
+
+
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+class BlockData(CommonResource) :
+
+    ## -----------------------------------------------------------------
+    def __init__(self, service_keys, block_store_env, block_hash) :
+        CommonResource.__init__(self, service_keys, block_store_env)
+        self.block_hash = block_hash
+
+    ## -----------------------------------------------------------------
+    def _handle_get_request_(self, request) :
+        try :
+            try :
+                block_hash = base64.urlsafe_b64decode(self.block_hash)
+            except :
+                return ErrorResponse(request, http.BAD_REQUEST, "invalid block hash; {0}".format(self.block_hash))
+
+            with self.block_store_env.begin() as txn :
+                block_data = txn.get(block_hash)
+                if not block_data :
+                    return ErrorResponse(request, http.NOT_FOUND, "no such block; {0}".format(self.block_hash))
+
+            request.setResponseCode(http.OK)
+            request.setHeader('content-type', 'application/octet-stream')
+            request.write(block_data)
+            return request
+
+        except Exception as e :
+            logger.error("unknown exception (BlockGet); %s", str(e))
+            return ErrorResponse(request, http.BAD_REQUEST,
+                                 "unknown exception while processing get block request; {0}".format(self.block_hash))
+
+    ## -----------------------------------------------------------------
+    def _handle_put_request_(self, request) :
+        try :
+            try :
+                requested_block_hash = base64.urlsafe_b64decode(self.block_hash)
+            except :
+                return ErrorResponse(request, http.BAD_REQUEST, "invalid block hash; {0}".format(self.block_hash))
+
+            block_data = request.content.getvalue()
+            block_hash = hashlib.sha256(block_data).digest()
+            if requested_block_hash != block_hash :
+                return ErrorResponse(request, http.BAD_REQUEST, "mismatch block hash; {0}".format(self.block_hash))
+
+            with self.block_store_env.begin(write=True) as txn :
+                if not txn.get(block_hash) :
+                    if not txn.put(block_hash, block_data) :
+                        return ErrorResponse(request, http.BAD_REQUEST, "failed to save block data")
+
+            request.setResponseCode(http.OK)
+            request.write(b"SUCCESS\n")
+            return request
+
+        except Exception as e :
+            logger.error("unknown exception (BlockPut); %s", str(e))
+            return ErrorResponse(request, http.BAD_REQUEST,
+                                 "unknown exception while processing put block request; {0}".format(self.block_hash))
+
+    ## -----------------------------------------------------------------
+    def _handle_head_request_(self, request) :
+        try :
+            try :
+                block_hash = base64.urlsafe_b64decode(self.block_hash)
+            except :
+                return ErrorResponse(request, http.BAD_REQUEST, "invalid block hash; {0}".format(self.block_hash))
+
+            block_size = -1
+            with self.block_store_env.begin() as txn :
+                block_data = txn.get(block_hash)
+                if block_data :
+                    block_size = len(block_data)
+
+            if block_size < 0 :
+                request.setResponseCode(http.NOT_FOUND)
+                request.setHeader('content-length', str(0))
+                request.write(b"")
+            else :
+                request.setResponseCode(http.OK)
+                request.setHeader('content-length', str(block_size))
+                request.write(b"")
+
+            return request
+
+        except Exception as e :
+            logger.error("unknown exception (BlockHead); %s", str(e))
+            return ErrorResponse(request, http.BAD_REQUEST,
+                                 "unknown exception while processing block head request; {0}".format(self.block_hash))
+
+    ## -----------------------------------------------------------------
+    def render_GET(self, request) :
+        return self._defer_request_(self._handle_get_request_, request)
+
+    ## -----------------------------------------------------------------
+    def render_PUT(self, request) :
+        return self._defer_request_(self._handle_put_request_, request)
+
+    ## -----------------------------------------------------------------
+    def render_HEAD(self, request) :
+        return self._defer_request_(self._handle_head_request_, request)
+
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+class BlockStatus(CommonResource) :
+    isLeaf = True
+
+    ## -----------------------------------------------------------------
+    def __init__(self, service_keys, block_store_env) :
+        CommonResource.__init__(self, service_keys, block_store_env)
+
+    ## -----------------------------------------------------------------
+    def _handle_request_(self, request) :
+        try :
+            # process the message encoding
+            encoding = request.getHeader('Content-Type')
+            data = request.content.getvalue()
+
+            if encoding != 'application/json' :
+                msg = 'unknown message encoding, {0}'.format(encoding)
+                return ErrorResponse(request, http.BAD_REQUEST, msg)
+
+            # Attempt to decode the data if it is not already a string
+            try:
+                data = data.decode('utf-8')
+            except AttributeError:
+                pass
+
+            block_ids = json.loads(data)
+
+        except Exception as e :
+            logger.error("unknown exception unpacking request (BlockStatus); %s", str(e))
+            return ErrorResponse(request, http.BAD_REQUEST, "unknown exception while unpacking block status request")
+
+        try :
+            block_status_list = []
+            with self.block_store_env.begin() as txn :
+                for block_id in block_ids :
+                    try :
+                        block_hash = base64.urlsafe_b64decode(block_id)
+                    except :
+                        return ErrorResponse(request, http.BAD_REQUEST, "invalid block hash; {0}".format(block_id))
+
+                    block_status = { 'block_id' : block_id, 'size' : 0, 'expiration' : 0 }
+                    block_data = txn.get(block_hash)
+                    if block_data :
+                        block_status['size'] = len(block_data)
+
+                    block_status_list.append(block_status)
+
+        except Exception as e :
+            logger.error("unknown exception computing status (BlockStatus); %s", str(e))
+            return ErrorResponse(request, http.BAD_REQUEST, "unknown exception while computing block status")
+
+        try :
+            result = json.dumps(block_status_list).encode()
+        except Exception as e :
+            logger.error("unknown exception packing response (BlockStatus); %s", str(e))
+            return ErrorResponse(request, http.BAD_REQUEST, "unknown exception while packing response")
+
+        request.setHeader('content-type', 'application/json')
+        request.write(result)
+        return request
+
+    ## -----------------------------------------------------------------
+    def render_POST(self, request) :
+        return self._defer_request_(self._handle_request_, request)
+
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+class BlockStore(CommonResource) :
+
+    ## -----------------------------------------------------------------
+    def __init__(self, service_keys, block_store_env) :
+        CommonResource.__init__(self, service_keys, block_store_env)
+
+    ## -----------------------------------------------------------------
+    def _handle_request_(self, request) :
+        try :
+            data = request.args[b'operation'][0]
+
+            try:
+                data = data.decode('utf-8')
+            except AttributeError:
+                pass
+            minfo = json.loads(data)
+            block_ids = minfo['block_ids']
+            interval = minfo['interval']
+
+            signing_hash_accumulator = interval.to_bytes(32, byteorder='big', signed=False)
+
+        except Exception as e :
+            logger.error("unknown exception unpacking request (BlockStore); %s", str(e))
+            return ErrorResponse(request, http.BAD_REQUEST, "unknown exception while unpacking block store request")
+
+        try :
+            # this might keep the database locked for too long for a write transaction
+            # might want to flip the order, one transaction per update
+            with self.block_store_env.begin(write=True) as txn :
+                for block_id in block_ids :
+                    block_id = block_id.encode()
+                    try :
+                        requested_block_hash = base64.urlsafe_b64decode(block_id)
+                    except :
+                        return ErrorResponse(request, http.BAD_REQUEST, "invalid block hash; {0}".format(block_id))
+
+                    try :
+                        block_data = request.args[block_id][0]
+                    except :
+                        return ErrorResponse(request, http.BAD_REQUEST, "missing block data; {0}".format(block_id))
+
+                    block_hash = hashlib.sha256(block_data).digest()
+                    if requested_block_hash != block_hash :
+                        return ErrorResponse(request, http.BAD_REQUEST, "block hash mismatch; {0}".format(block_id))
+
+                    if not txn.put(block_hash, block_data) :
+                        return ErrorResponse(request, http.BAD_REQUEST, "failed to save block data")
+
+                    signing_hash_accumulator += block_hash
+
+        except Exception as e :
+            logger.error("unknown exception (BlockStore); %s", str(e))
+            return ErrorResponse(request, http.BAD_REQUEST, "unknown exception while storing blocks")
+
+        try :
+            signing_hash = hashlib.sha256(signing_hash_accumulator).digest()
+            signature = self.service_keys.sign(signing_hash, encoding='b64')
+            result = json.dumps({'signature' : signature}).encode('utf8')
+
+        except Exception as e :
+            logger.error("unknown exception packing response (BlockStatus); %s", str(e))
+            return ErrorResponse(request, http.BAD_REQUEST, "unknown exception while packing response")
+
+        request.setHeader('content-type', 'application/json')
+        request.write(result)
+        return request
+
+    ## -----------------------------------------------------------------
+    def render_POST(self, request) :
+        return self._defer_request_(self._handle_request_, request)
+
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+class BlockRoot(Resource) :
+
+    ## -----------------------------------------------------------------
+    def __init__(self, service_keys, block_store_env) :
+        Resource.__init__(self)
+        self.service_keys = service_keys
+        self.block_store_env = block_store_env
+
+    ## -----------------------------------------------------------------
+    def getChild(self, name, request) :
+        if name == b'list' :
+            return BlockList(self.service_keys, self.block_store_env)
+        elif name == b'status' :
+            return BlockStatus(self.service_keys, self.block_store_env)
+        elif name == b'store' :
+            return BlockStore(self.service_keys, self.block_store_env)
+        elif name :
+            return BlockData(self.service_keys, self.block_store_env, name)
+        else :
+            return NoResource()
+
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+class Info(CommonResource) :
+    isLeaf = True
+
+    ## -----------------------------------------------------------------
+    def __init__(self, service_keys, block_store_env) :
+        CommonResource.__init__(self, service_keys, block_store_env)
+
+    ## -----------------------------------------------------------------
+    def _handle_request_(self, request) :
+
+        try :
+            response = dict()
+            response['verifying_key'] = self.service_keys.verifying_key
+            result = json.dumps(response).encode()
+
+        except Exception as e :
+            logger.error("unknown exception (Info); %s", str(e))
+            return ErrorResponse(request, http.BAD_REQUEST, "unknown exception while processing info request")
+
+        request.setHeader('content-type', 'application/json')
+        request.write(result)
+
+        return request
+
+    ## -----------------------------------------------------------------
+    def render_GET(self, request) :
+        return self._defer_request_(self._handle_request_, request)
+
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+class Shutdown(Resource) :
+    isLeaf = True
+
+    ## -----------------------------------------------------------------
+    def __init__(self) :
+        Resource.__init__(self)
+
+    ## -----------------------------------------------------------------
+    def render_GET(self, request) :
+        logger.warn('shutdown request received')
+        reactor.callLater(1, reactor.stop)
+
+        ErrorResponse(request, http.NO_CONTENT, "shutdown")
+        request.finish()
+
+
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+class ContractStorageServer(Resource) :
+    ## -----------------------------------------------------------------
+    def __init__(self, service_keys, block_store_env) :
+        Resource.__init__(self)
+        self.service_keys = service_keys
+        self.block_store_env = block_store_env
+
+    ## -----------------------------------------------------------------
+    def getChild(self, name, request) :
+        if name == b'block' :
+            return BlockRoot(self.service_keys, self.block_store_env)
+        elif name == b'info' :
+            return Info(self.service_keys, self.block_store_env)
+        elif name == b'shutdown' :
+            return Shutdown()
+        else :
+            return NoResource()
+
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+def RunStorageService(http_host, http_port, service_keys, block_store_env) :
+    logger.info('service started on port %s', http_port)
+
+    root = ContractStorageServer(service_keys, block_store_env)
+    site = Site(root)
+
+    threadpool = reactor.getThreadPool()
+    threadpool.start()
+    threadpool.adjustPoolsize(8, 100) # Min & Max number of request to service at a time
+    logger.info('# of workers: %d', threadpool.workers)
+
+    reactor.listenTCP(http_port, site, interface=http_host)
+
+    @defer.inlineCallbacks
+    def shutdown_twisted():
+        logger.info("Stopping Twisted")
+        yield reactor.callFromThread(reactor.stop)
+
+    reactor.addSystemEventTrigger('before', 'shutdown', shutdown_twisted)
+
+    try :
+        reactor.run()
+    except ReactorNotRunning:
+        logger.warn('shutdown')
+    except :
+        logger.warn('shutdown')
+
+    # sync and close the database
+    block_store_env.sync()
+    block_store_env.close()
+
+    sys.exit(0)
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+def LocalMain(config) :
+    try :
+        key_config = config.get('Key', {})
+
+        try :
+            key_file = key_config['FileName']
+            key_path = key_config['SearchPath']
+            service_keys = keys.ServiceKeys.read_from_file(key_file, search_path = key_path)
+        except KeyError as ke :
+            logger.error('missing configuration for Key.%s', str(ke))
+            sys.exit(-1)
+        except Exception as e :
+            logger.error('unable to load transaction keys; %s', str(e))
+            sys.exit(-1)
+
+        service_config = config.get('StorageService', {})
+
+        try :
+            http_port = service_config['HttpPort']
+            http_host = service_config['Host']
+
+            map_size = 1024 * 1024 * 1024
+            create = config.get('create', False)
+            block_store = service_config['BlockStore']
+            block_store_env = lmdb.open(block_store, create=create, max_dbs=2, subdir=False, sync=False, map_size=map_size)
+            #mdb = env.open_db('meta_data'.encode())
+            #bdb = env.open_db('block_data'.encode())
+        except KeyError as ke :
+            logger.error('missing configuration for StorageService.%s', str(ke))
+            sys.exit(-1)
+        except Exception as e :
+            logger.error('unable to open the block store; %s', str(e))
+            sys.exit(-1)
+
+    except Error as e:
+        logger.exception('failed to initialize the storage service; %s', e)
+        sys.exit(-1)
+
+    RunStorageService(http_host, http_port, service_keys, block_store_env)
+
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+## -----------------------------------------------------------------
+ContractHost = os.environ.get("HOSTNAME", "localhost")
+ContractHome = os.environ.get("PDO_HOME") or os.path.realpath("/opt/pdo")
+ContractEtc = os.path.join(ContractHome, "etc")
+ContractKeys = os.path.join(ContractHome, "keys")
+ContractLogs = os.path.join(ContractHome, "logs")
+ContractData = os.path.join(ContractHome, "data")
+LedgerURL = os.environ.get("PDO_LEDGER_URL", "http://127.0.0.1:8008/")
+ScriptBase = os.path.splitext(os.path.basename(sys.argv[0]))[0]
+
+config_map = {
+    'base' : ScriptBase,
+    'data' : ContractData,
+    'etc'  : ContractEtc,
+    'home' : ContractHome,
+    'host' : ContractHost,
+    'keys' : ContractKeys,
+    'logs' : ContractLogs,
+    'ledger' : LedgerURL
+}
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+def Main() :
+    # parse out the configuration file first
+    conffiles = [ 'sservice.toml' ]
+    confpaths = [ ".", "./etc", ContractEtc ]
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--config', help='configuration file', nargs = '+')
+    parser.add_argument('--config-dir', help='directory to search for configuration files', nargs = '+')
+
+    parser.add_argument('--identity', help='Identity to use for the process', required = True, type = str)
+
+    parser.add_argument('--key-dir', help='Directories to search for key files', nargs='+')
+    parser.add_argument('--data-dir', help='Path for storing generated files', type=str)
+
+    parser.add_argument('--block-store', help='Name of the file where blocks are stored', type=str)
+    parser.add_argument('--create', help='Create the blockstore if it does not exist', action='store_true')
+    parser.add_argument('--logfile', help='Name of the log file, __screen__ for standard output', type=str)
+    parser.add_argument('--loglevel', help='Logging level', type=str)
+
+    parser.add_argument('--http', help='Port on which to run the http server', type=int)
+
+    options = parser.parse_args()
+
+    # first process the options necessary to load the default configuration
+    if options.config :
+        conffiles = options.config
+
+    if options.config_dir :
+        confpaths = options.config_dir
+
+    global config_map
+    config_map['identity'] = options.identity
+    if options.data_dir :
+        config_map['data'] = options.data_dir
+
+    try :
+        config = pconfig.parse_configuration_files(conffiles, confpaths, config_map)
+    except pconfig.ConfigurationException as e :
+        logger.error(str(e))
+        sys.exit(-1)
+
+    # set up the logging configuration
+    if config.get('Logging') is None :
+        config['Logging'] = {
+            'LogFile' : '__screen__',
+            'LogLevel' : 'INFO'
+        }
+    if options.logfile :
+        config['Logging']['LogFile'] = options.logfile
+    if options.loglevel :
+        config['Logging']['LogLevel'] = options.loglevel.upper()
+
+    plogger.setup_loggers(config.get('Logging', {}))
+    sys.stdout = plogger.stream_to_logger(logging.getLogger('STDOUT'), logging.DEBUG)
+    sys.stderr = plogger.stream_to_logger(logging.getLogger('STDERR'), logging.WARN)
+
+    if options.create :
+        config['create'] = True
+
+    # set up the key search paths
+    if config.get('Key') is None :
+        config['Key'] = {
+            'SearchPath' : ['.', './keys', ContractKeys],
+            'FileName' : options.identity + ".pem"
+        }
+    if options.key_dir :
+        config['Key']['SearchPath'] = options.key_dir
+
+    # set up the enclave service configuration
+    if config.get('StorageService') is None :
+        config['StorageService'] = {
+            'HttpPort' : 7101,
+            'Host' : 'localhost',
+            'Identity' : options.identity,
+            'BlockStore' : os.path.join(ContractData, options.identity + '.mdb')
+        }
+    if options.http :
+        config['StorageService']['HttpPort'] = options.http
+
+    if options.block_store :
+        config['StorageService']['BlockStore'] = options.block_store
+
+    # GO!
+    LocalMain(config)
+
+## -----------------------------------------------------------------
+## Entry points
+## -----------------------------------------------------------------
+Main()

--- a/eservice/setup.py
+++ b/eservice/setup.py
@@ -165,6 +165,7 @@ setup(name='pdo_eservice',
       data_files = data_files,
       entry_points = {
           'console_scripts': [
+              'sservice = pdo.eservice.scripts.SServiceCLI:Main',
               'eservice = pdo.eservice.scripts.EServiceCLI:Main',
               'eservice-enclave-info = pdo.eservice.scripts.EServiceEnclaveInfoCLI:Main'
           ]

--- a/python/pdo/service_client/__init__.py
+++ b/python/pdo/service_client/__init__.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 all = [
-    'enclave'
-    'provisioning'
-    'generic'
+    'enclave',
+    'generic',
+    'provisioning',
+    'storage'
 ]

--- a/python/pdo/service_client/storage.py
+++ b/python/pdo/service_client/storage.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+
+# Copyright 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+
+import base64
+import hashlib
+import json
+import requests
+
+import logging
+logger = logging.getLogger(__name__)
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+class StorageException(Exception) :
+    """
+    A class to capture storage exceptions
+    """
+    pass
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+class StorageServiceClient(object) :
+    def __init__(self, url) :
+        self.url_base = url
+        self.service_info = self.get_service_info()
+
+    @property
+    def verifying_key(self) :
+        self.service_info['verifying_key']
+
+    def get_service_info(self) :
+        url = "{0}/info".format(self.url_base)
+        response = requests.get(url)
+        logger.info('get_service_info response code = %s', response.status_code)
+        response.raise_for_status()
+        return response.json()
+
+    def get_block_list(self) :
+        url = "{0}/block/list".format(self.url_base)
+        response = requests.get(url)
+        logger.info('get_block_list response code = %s', response.status_code)
+        response.raise_for_status()
+        return response.json()
+
+    def get_block(self, block_id) :
+        url = "{0}/block/{1}".format(self.url_base, block_id)
+        response = requests.get(url)
+        logger.info('get_block response code = %s', response.status_code)
+        response.raise_for_status()
+        return response.content
+
+    def put_block(self, block_data) :
+        block_hash = hashlib.sha256(block_data).digest()
+        block_id = base64.urlsafe_b64encode(block_hash).decode()
+        url = "{0}/block/{1}".format(self.url_base, block_id)
+        response = requests.put(url, data=block_data)
+        logger.info('put_block response code = %s', response.status_code)
+        response.raise_for_status()
+        return block_id
+
+    def put_blocks(self, block_data_list) :
+        request_data = dict()
+        block_ids = []
+        for i in range(len(block_data_list)) :
+            block_hash = hashlib.sha256(block_data_list[i]).digest()
+            block_id = base64.urlsafe_b64encode(block_hash).decode()
+            block_ids.append(block_id)
+            request_data[block_id] = (block_id, block_data_list[i], 'application/octet-stream')
+        request_data['operation'] = json.dumps({'block_ids' : block_ids, 'interval' : 0})
+        url = "{0}/block/store".format(self.url_base)
+        response = requests.post(url, files=request_data)
+        logger.info('put_blocks response code = %s', response.status_code)
+        response.raise_for_status()
+        return block_ids
+
+    def check_status(self, block_ids) :
+        url = "{0}/block/status".format(self.url_base)
+        response = requests.post(url, json=block_ids)
+        logger.info('put_blocks response code = %s', response.status_code)
+        response.raise_for_status()
+        return response.json()

--- a/python/pdo/test/storage.py
+++ b/python/pdo/test/storage.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+
+# Copyright 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+
+import argparse
+import logging
+import pdo.common.logger as plogger
+
+logger = logging.getLogger(__name__)
+
+from pdo.service_client.storage import StorageServiceClient
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+import argparse
+parser = argparse.ArgumentParser()
+parser.add_argument('--url', help='storage service url', required=True, type=str)
+parser.add_argument('--loglevel', help='Set the logging level', default='INFO')
+parser.add_argument('--logfile', help='Name of the log file', default='__screen__')
+options = parser.parse_args()
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+plogger.setup_loggers({'LogLevel' : options.loglevel.upper(), 'LogFile' : options.logfile})
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+client = StorageServiceClient(options.url)
+
+# -----------------------------------------------------------------
+# Begin the tests
+# -----------------------------------------------------------------
+
+# -----------------------------------------------------------------
+logger.info('attempt to put a single block to the service')
+# -----------------------------------------------------------------
+try :
+    block_data = os.urandom(1000)
+    block_id = client.put_block(block_data)
+    assert block_id
+except Exception as e :
+    logger.error('put test failed; %s', str(e))
+    sys.exit(-1)
+
+# -----------------------------------------------------------------
+logger.info('verify that the put succeeded')
+# -----------------------------------------------------------------
+try :
+    verify_block_data = client.get_block(block_id)
+    assert block_data == verify_block_data
+except Exception as e :
+    logger.error('verify put test failed; %s', str(e))
+    sys.exit(-1)
+
+# -----------------------------------------------------------------
+logger.info('test bulk upload of blocks')
+# -----------------------------------------------------------------
+try :
+    block_data = []
+    block_data.append(os.urandom(10))
+    block_data.append(os.urandom(10))
+    block_data.append(os.urandom(10))
+    block_ids = client.put_blocks(block_data)
+    assert block_ids and len(block_ids) == 3
+except Exception as e :
+    logger.error('bulk upload test failed; %s', str(e))
+    sys.exit(-1)
+
+# -----------------------------------------------------------------
+logger.info('verify that the upload succeeded')
+# -----------------------------------------------------------------
+try :
+    for i in range(len(block_ids)) :
+        verify_block_data = client.get_block(block_ids[i])
+        assert block_data[i] == verify_block_data
+except Exception as e :
+    logger.error('failed to verify bulk upload; %s', str(e))
+    sys.exit(-1)
+
+# -----------------------------------------------------------------
+logger.info('test bulk status')
+# -----------------------------------------------------------------
+try :
+    status = client.check_status(block_ids)
+    assert status and len(status) == 3
+except Exception as e :
+    logger.error('bulk status failed; %s', str(e))
+    sys.exit(-1)
+
+# -----------------------------------------------------------------
+logger.info('make sure we get an error for a bad block id')
+# -----------------------------------------------------------------
+try :
+    block_data = client.get_block('abcd')
+except Exception as e:
+    pass
+else :
+    logger.error('failed to catch bad request')
+    sys.exit(-1)


### PR DESCRIPTION
This implements a storage service designed to run side-by-side with the
enclave service. The storage service shares an LMDB database with the
enclave service.

Several differences between the storage service and the storage interface
implemented in the enclave service. First, the storage service move binary
data for blocks in order to avoid the multiple levels of format translation
that occurs with the existing interfaces. Second, the storage service
provides bulk upload and status checks consolidating a number of operations
into a single call. Download is still one block at a time. Finally, the
storage service provides a signature for a bulk upload that can be used for
proof of replication.

This update does not integrate calls to the storage service into the clients
though it does provide a script to test the storage service API.

Signed-off-by: Mic Bowman <mic.bowman@intel.com>