### PR TITLE
Eservice database changes

### DIFF
--- a/build/__tools__/run-tests-with-database.sh
+++ b/build/__tools__/run-tests-with-database.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+cred=`tput setaf 1`
+cgrn=`tput setaf 2`
+cblu=`tput setaf 4`
+cmag=`tput setaf 5`
+cwht=`tput setaf 7`
+cbld=`tput bold`
+bred=`tput setab 1`
+bgrn=`tput setab 2`
+bblu=`tput setab 4`
+bwht=`tput setab 7`
+crst=`tput sgr0`
+
+function recho () {
+    echo "${cbld}${cred}" $@ "${crst}" >&2
+}
+
+function becho () {
+    echo "${cbld}${cblu}" $@ "${crst}" >&2
+}
+
+function say () {
+    echo "$(basename $0): $*" >&2;
+}
+
+function yell () {
+    becho "$(basename $0): $*" >&2;
+}
+
+function die() {
+    recho "$(basename $0): $*" >&2
+    exit 111
+}
+
+try() {
+    "$@" || die "test failed: $*"
+}
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+PY3_VERSION=$(python --version | sed 's/Python 3\.\([0-9]\).*/\1/')
+if [[ $PY3_VERSION -lt 5 ]]; then
+    die activate python3 first
+fi
+
+SCRIPTDIR="$(dirname $(readlink --canonicalize ${BASH_SOURCE}))"
+SRCDIR="$(realpath ${SCRIPTDIR}/../..)"
+
+
+
+: "${PDO_HOME:-$(die Missing environment variable PDO_HOME)}"
+: "${PDO_LEDGER_URL:-$(die Missing environment variable PDO_LEDGER_URL)}"
+
+# check for existing enclave and provisioning services
+pgrep eservice
+if [ $? == 0 ] ; then
+    die existing enclave services detected, please shutdown
+fi
+
+pgrep pservice
+if [ $? == 0 ] ; then
+    die existing provisioning services detected, please shutdown
+fi
+
+SAVE_FILE=$(mktemp /tmp/pdo-test.XXXXXXXXX)
+ESERVICE_DB=${PDO_HOME}/data/eservice-db.json
+
+declare -i NUM_SERVICES=5 # must be at least 3 for pconntract update test to work
+function cleanup {
+    read -p "Enter any key to shutdown services."
+    yell "shutdown services"
+    ${PDO_HOME}/bin/ps-stop.sh --count ${NUM_SERVICES} > /dev/null
+    ${PDO_HOME}/bin/es-stop.sh --count ${NUM_SERVICES} > /dev/null
+    ${PDO_HOME}/bin/ss-stop.sh --count ${NUM_SERVICES} > /dev/null
+    rm -f ${SAVE_FILE}
+    rm -r ${ESERVICE_DB}
+}
+
+trap cleanup EXIT
+
+
+# -----------------------------------------------------------------
+yell start enclave and provisioning services
+# -----------------------------------------------------------------
+try ${PDO_HOME}/bin/ss-start.sh --count ${NUM_SERVICES} > /dev/null
+try ${PDO_HOME}/bin/ps-start.sh --count ${NUM_SERVICES} --ledger ${PDO_LEDGER_URL} --clean > /dev/null
+try ${PDO_HOME}/bin/es-start.sh --count ${NUM_SERVICES} --ledger ${PDO_LEDGER_URL} --clean > /dev/null
+
+cd ${SRCDIR}/build 
+
+#-----------------------------------------
+yell test the eservice database 
+#------------------------------------------
+say run module level tests for database manager
+cd ${SRCDIR}/python/pdo/test
+try python servicedb.py --logfile $PDO_HOME/logs/client.log --loglevel info \
+    --eservice-db $PDO_HOME/data/db-test.json --url http://localhost:7101 http://localhost:7102 http://localhost:7103
+try rm $PDO_HOME/data/db-test.json
+
+cd ${SRCDIR}/build
+
+say create the eservice database using database CLI 
+try pdo-create-eservicedb --logfile $PDO_HOME/logs/client.log --loglevel info \
+    --eservice-db ${ESERVICE_DB} --eservice-url http://localhost:7101 --eservice-name e1
+# add more entires
+for v in $(seq 2 ${NUM_SERVICES}) ; do
+    try pdo-add-to-eservicedb --logfile $PDO_HOME/logs/client.log --loglevel info \
+        --eservice-db ${ESERVICE_DB} --eservice-url http://localhost:710${v} --eservice-name e${v}
+done
+
+say run various pdo scripts - test-request, test-contract, create, update, shell - using database
+
+
+try pdo-test-request --no-ledger   \
+    --eservice-name e1 --logfile $PDO_HOME/logs/client.log --loglevel info --eservice-db ${ESERVICE_DB}
+
+try pdo-test-contract --no-ledger --contract integer-key \
+    --eservice-name e2 --logfile $PDO_HOME/logs/client.log --loglevel info --eservice-db ${ESERVICE_DB}
+
+# make sure we have the necessary files in place
+CONFIG_FILE=${PDO_HOME}/etc/pcontract.toml
+if [ ! -f ${CONFIG_FILE} ]; then
+    die missing client configuration file, ${CONFIG_FILE}
+fi
+
+CONTRACT_FILE=${PDO_HOME}/contracts/_mock-contract.scm
+if [ ! -f ${CONTRACT_FILE} ]; then
+    die missing contract source file, ${CONTRACT_FILE}
+fi
+
+try pdo-create --config ${CONFIG_FILE} --ledger ${PDO_LEDGER_URL} \
+     --logfile $PDO_HOME/logs/client.log --loglevel info \
+    --identity user1 --save-file ${SAVE_FILE} \
+    --contract mock-contract --source _mock-contract.scm --eservice-name e1 e2 e3 --eservice-db ${ESERVICE_DB}
+
+# this will invoke the increment operation 5 times on each enclave round robin
+# fashion; the objective of this test is to ensure that the client touches
+# multiple, independent enclave services and pushes missing state correctly
+declare -i pcontract_es=3 #.see ../opt/pdo/etc/template/pcontract.toml
+declare -i n=$((NUM_SERVICES*pcontract_es)) e v value
+for v in $(seq 1 ${n}) ; do
+    e=$((v % pcontract_es + 1))
+    value=$(pdo-update --config ${CONFIG_FILE} --ledger ${PDO_LEDGER_URL} \
+                       --eservice-name e${e} \
+                       --logfile $PDO_HOME/logs/client.log --loglevel info \
+                       --identity user1 --save-file ${SAVE_FILE} --eservice-db ${ESERVICE_DB} \
+                       "'(inc-value)")
+    if [ $value != $v ]; then
+        die "contract has the wrong value ($value instead of $v) for enclave $e"
+    fi
+done
+
+KEYGEN=${SRCDIR}/build/__tools__/make-keys
+if [ ! -f ${PDO_HOME}/keys/red_type_private.pem ]; then
+    for color in red green blue ; do
+        ${KEYGEN} --keyfile ${PDO_HOME}/keys/${color}_type --format pem
+        ${KEYGEN} --keyfile ${PDO_HOME}/keys/${color}_vetting --format pem
+        ${KEYGEN} --keyfile ${PDO_HOME}/keys/${color}_issuer --format pem
+    done
+fi
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+try pdo-shell --logfile $PDO_HOME/logs/client.log --loglevel info --ledger $PDO_LEDGER_URL \
+    --eservice-name e1 e2 e3 e4 e5 --eservice-db ${ESERVICE_DB} -s ${SRCDIR}/contracts/exchange/scripts/create.psh -m color red 
+
+for p in $(seq 1 5); do
+    pdo-shell --logfile $PDO_HOME/logs/client.log --loglevel info --ledger $PDO_LEDGER_URL \
+    --eservice-name e${p} --eservice-db ${ESERVICE_DB} -s ${SRCDIR}/contracts/exchange/scripts/issue.psh -m color red -m issuee user$p -m count $(($p * 10))
+done
+
+yell completed all tests
+exit 0

--- a/build/__tools__/run-tests.sh
+++ b/build/__tools__/run-tests.sh
@@ -78,6 +78,7 @@ if [ $? == 0 ] ; then
 fi
 
 SAVE_FILE=$(mktemp /tmp/pdo-test.XXXXXXXXX)
+
 declare -i NUM_SERVICES=5 # must be at least 3 for pconntract update test to work
 function cleanup {
     yell "shutdown services"
@@ -157,25 +158,25 @@ try pdo-test-storage --url http://localhost:7201 --loglevel warn --logfile __scr
 say start request test
 try pdo-test-request --ledger ${PDO_LEDGER_URL} \
     --pservice http://localhost:7001/ http://localhost:7002 http://localhost:7003 \
-    --eservice http://localhost:7101/ \
+    --eservice-url http://localhost:7101/ \
     --logfile __screen__ --loglevel warn
 
 say start integer-key contract test
 try pdo-test-contract --ledger ${PDO_LEDGER_URL} --contract integer-key \
     --pservice http://localhost:7001/ http://localhost:7002 http://localhost:7003 \
-    --eservice http://localhost:7101/ \
+    --eservice-url http://localhost:7101/ \
     --logfile __screen__ --loglevel warn
 
 say start key value store test
 try pdo-test-contract --ledger ${PDO_LEDGER_URL} --contract key-value-test \
     --pservice http://localhost:7001/ http://localhost:7002 http://localhost:7003 \
-    --eservice http://localhost:7101/ \
+    --eservice-url http://localhost:7101/ \
     --logfile __screen__ --loglevel warn
 
 say start memory test
 try pdo-test-contract --ledger ${PDO_LEDGER_URL} --contract memory-test \
     --pservice http://localhost:7001/ http://localhost:7002 http://localhost:7003 \
-    --eservice http://localhost:7101/ \
+    --eservice-url http://localhost:7101/ \
     --logfile __screen__ --loglevel warn
 
 ## -----------------------------------------------------------------

--- a/client/pdo/client/controller/commands/contract.py
+++ b/client/pdo/client/controller/commands/contract.py
@@ -92,10 +92,8 @@ def load_contract(state, contract_file) :
 ## -----------------------------------------------------------------
 ## -----------------------------------------------------------------
 def get_contract(state, save_file=None) :
-    """create an enclave client for the preferred enclave service; assumes
-    exception handling by the calling procedure
-    """
-
+    """ Get contract object using the save_file. If there is no save_file, try loading contract using config."""
+   
     if save_file is not None :
         return load_contract(state, save_file)
 

--- a/client/pdo/client/controller/commands/create.py
+++ b/client/pdo/client/controller/commands/create.py
@@ -15,6 +15,7 @@
 import argparse
 import logging
 import random
+import sys
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +29,9 @@ from pdo.contract import register_contract
 from pdo.contract import add_enclave_to_contract
 from pdo.service_client.enclave import EnclaveServiceClient
 from pdo.service_client.provisioning import ProvisioningServiceClient
+from pdo.service_client.servicedatabase import ServiceDB_Manager
+
+
 
 __all__ = ['command_create']
 
@@ -134,17 +138,28 @@ def command_create(state, bindings, pargs) :
     logger.info('Loaded contract code for %s', contract_class)
 
     # ---------- set up the enclave clients ----------
-    try :
+    enclaveclients = []
+    enclave_names = state.get(['Service', 'EnclaveServiceNames'], [])
+    if len(enclave_names) > 0: #use the database to get the list of enclaves for the contract
+        logger.info('Using eservice database to look up service URL for the contract enclave')
+        try:
+            db = ServiceDB_Manager(service_type='eservice', file_name=state.get(['Service', 'EnclaveServiceDatabaseFile']))
+            for name in enclave_names:
+                enclaveclients.append(db.get_serviceclient_by_name(name))
+        except Exception as e:
+            logger.error('Unable to get the eservice clients using the eservice database: ' + str(e)) 
+            sys.exit(-1)   
+    else:
         eservice_urls = state.get(['Service', 'EnclaveServiceURLs'], [])
         if len(eservice_urls) == 0 :
             raise Exception('no enclave services specified')
+        try:
+            for url in eservice_urls :
+                enclaveclients.append(EnclaveServiceClient(url))
+        except Exception as e :
+            raise Exception('unable to contact enclave services; {0}'.format(str(e)))
 
-        enclaveclients = []
-        for url in eservice_urls :
-            enclaveclients.append(EnclaveServiceClient(url))
-    except Exception as e :
-        raise Exception('unable to contact enclave services; {0}'.format(str(e)))
-
+    
     # ---------- set up the provisioning service clients ----------
     # This is a dictionary of provisioning service public key : client pairs
     try :

--- a/client/pdo/client/controller/commands/eservice.py
+++ b/client/pdo/client/controller/commands/eservice.py
@@ -15,6 +15,7 @@
 import argparse
 import logging
 
+
 logger = logging.getLogger(__name__)
 
 from pdo.service_client.enclave import EnclaveServiceClient

--- a/client/pdo/client/controller/commands/eservice.py
+++ b/client/pdo/client/controller/commands/eservice.py
@@ -16,7 +16,7 @@ import argparse
 import logging
 import sys
 import os
-import json
+
 
 
 logger = logging.getLogger(__name__)
@@ -31,7 +31,7 @@ __all__ = ['command_eservice']
 def command_eservice(state, bindings, pargs) :
     """controller command to manage the list of enclave services
     """
-    subcommands = ['add', 'remove', 'set', 'use', 'info', 'list', 'udpatedb']
+    subcommands = ['add', 'remove', 'set', 'use', 'info', 'list']
 
     parser = argparse.ArgumentParser(prog='eservice')
     subparsers = parser.add_subparsers(dest='command')
@@ -98,7 +98,7 @@ def command_eservice(state, bindings, pargs) :
 
 ## -----------------------------------------------------------------
 ## -----------------------------------------------------------------
-def get_enclave_service(state=None, enclave_url=None) :
+def get_enclave_service(state, enclave_url=None) :
     """create an enclave client for the preferred enclave service; assumes
     exception handling by the calling procedure
     """

--- a/client/pdo/client/controller/commands/send.py
+++ b/client/pdo/client/controller/commands/send.py
@@ -15,6 +15,7 @@
 import argparse
 import random
 import logging
+import sys
 logger = logging.getLogger(__name__)
 
 from pdo.common.keys import ServiceKeys
@@ -22,6 +23,7 @@ from pdo.service_client.enclave import EnclaveServiceClient
 
 from pdo.client.controller.commands.contract import get_contract
 from pdo.client.controller.commands.eservice import get_enclave_service
+from pdo.service_client.servicedatabase import ServiceDB_Manager
 
 __all__ = ['command_send']
 
@@ -44,10 +46,20 @@ def send_to_contract(state, save_file, enclave, message, quiet=False, wait=False
         raise Exception('unable to load the contract')
 
     # ---------- set up the enclave service ----------
-    try :
-        enclave_client = get_enclave_service(state, enclave)
-    except Exception as e :
-        raise Exception('unable to connect to enclave service; {0}'.format(str(e)))
+    enclave_names = state.get(['Service', 'EnclaveServiceNames'], [])
+    if len(enclave_names) > 0: #use the database to get the list of enclaves for the contract
+        logger.info('Using eservice database to look up service URL for the contract enclave')
+        try:
+            eservice_to_use = random.choice(state.get(['Service', 'EnclaveServiceNames']))
+            db = ServiceDB_Manager(service_type='eservice', file_name=state.get(['Service', 'EnclaveServiceDatabaseFile']))
+            enclave_client = db.get_serviceclient_by_name(eservice_to_use)
+        except Exception as e:
+            logger.error('Unable to get the eservice clients using the eservice database: ' + str(e)) 
+    else:
+        try :
+            enclave_client = get_enclave_service(state, enclave)
+        except Exception as e :
+            raise Exception('unable to connect to enclave service; {0}'.format(str(e)))
 
     try :
         # this is just a sanity check to make sure the selected enclave
@@ -102,7 +114,7 @@ def command_send(state, bindings, pargs) :
     parser.add_argument('-s', '--symbol', help='Save the result in a symbol for later use', type=str)
     parser.add_argument('--wait', help='Wait for the transaction to commit', action = 'store_true')
     parser.add_argument('message', help='Message to be sent to the contract', type=str)
-
+    
     options = parser.parse_args(pargs)
     message = options.message
     waitflag = options.wait

--- a/client/pdo/client/controller/commands/send.py
+++ b/client/pdo/client/controller/commands/send.py
@@ -109,7 +109,7 @@ def command_send(state, bindings, pargs) :
     """
 
     parser = argparse.ArgumentParser(prog='read')
-    parser.add_argument('-e', '--enclave', help='URL of the enclave service to use or say "random-db" to pick one randomly from the eservice databse', type=str)
+    parser.add_argument('-e', '--enclave', help='URL of the enclave service to use', type=str)
     parser.add_argument('-f', '--save-file', help='File where contract data is stored', type=str)
     parser.add_argument('-s', '--symbol', help='Save the result in a symbol for later use', type=str)
     parser.add_argument('--wait', help='Wait for the transaction to commit', action = 'store_true')

--- a/client/pdo/client/scripts/ShellCLI.py
+++ b/client/pdo/client/scripts/ShellCLI.py
@@ -95,8 +95,11 @@ def Main() :
     parser.add_argument('--source-dir', help='Directories to search for contract source', nargs='+', type=str)
     parser.add_argument('--key-dir', help='Directories to search for key files', nargs='+')
 
+    parser.add_argument('--eservice-name', help='List of enclave services to use. Give names as in database', nargs='+')
     parser.add_argument('--eservice-url', help='List of enclave service URLs to use', nargs='+')
     parser.add_argument('--pservice-url', help='List of provisioning service URLs to use', nargs='+')
+
+    parser.add_argument('--eservice-db', help='json file for eservice database', type=str)
 
     parser.add_argument('-m', '--mapvar', help='Define variables for script use', nargs=2, action='append')
     parser.add_argument('-s', '--script', help='File from which to read script', type=str)
@@ -154,12 +157,18 @@ def Main() :
     if options.key_dir :
         config['Key']['SearchPath'] = options.key_dir
 
-    # set up the service configuration
+   # set up the service configuration
     if config.get('Service') is None :
         config['Service'] = {
+            'EnclaveServiceNames' : [],
             'EnclaveServiceURLs' : [],
-            'ProvisioningServiceURLs' : []
+            'ProvisioningServiceURLs' : [],
+            'EnclaveServiceDatabaseFile' : None
         }
+    if options.eservice_name:
+        config['Service']['EnclaveServiceNames'] = options.eservice_name
+    if options.eservice_db:
+        config['Service']['EnclaveServiceDatabaseFile'] = options.eservice_db
     if options.eservice_url :
         config['Service']['EnclaveServiceURLs'] = options.eservice_url
     if options.pservice_url :
@@ -176,7 +185,7 @@ def Main() :
         config['Contract']['DataDirectory'] = options.data_dir
     if options.source_dir :
         config['Contract']['SourceSearchPath'] = options.source_dir
-
+    
     putils.set_default_data_directory(config['Contract']['DataDirectory'])
 
     if options.script :

--- a/client/pdo/client/scripts/__init__.py
+++ b/client/pdo/client/scripts/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__all__ = [ 'controller', 'AuctionTestCLI', 'CreateCLI', 'UpdateCLI' ]
+__all__ = [ 'controller', 'AuctionTestCLI', 'CreateCLI', 'UpdateCLI', 'eservicedatabaseCLI' ]

--- a/client/pdo/client/scripts/eservicedatabaseCLI.py
+++ b/client/pdo/client/scripts/eservicedatabaseCLI.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python
+
+# Copyright 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+ 
+import os
+import sys
+
+import argparse
+import logging
+logger = logging.getLogger(__name__)
+
+import pdo.common.config as pconfig
+import pdo.common.logger as plogger
+
+from pdo.service_client.servicedatabase import ServiceDB_Manager
+
+import argparse
+
+
+def LocalMain(commands, config) :
+
+    if 'create' in commands :
+        
+        #make sure there is no json file already present
+        if os.path.exists(config['Service']['EnclaveServiceDatabaseFile']):
+            logger.error('Cannot create a new database with the chosen json filename. File already exists')
+            sys.exit(-1)
+
+        #make sure that there are names for each of the new eservice to add
+        if len(config['Service']['EnclaveServiceNames']) < len(config['Service']['EnclaveServiceURLs']):
+            logger.error('Please provide a name for each eservice to be added to the database')
+            sys.exit(-1)
+
+        #create an empty db
+        db = ServiceDB_Manager(service_type='eservice')
+        
+        names = config['Service']['EnclaveServiceNames']
+        urls = config['Service']['EnclaveServiceURLs']
+
+        # add entries to db
+        for index, url in enumerate(urls):
+            try :
+                client = db.get_serviceclient_by_url(url=url)
+                db.add_new_info(name = names[index], url=url, id = client.enclave_id)
+            except Exception as e:
+                logger.error('Unable to create new database. Error adding new entry for url ' + str(url) + str(e))
+                sys.exit(-1)
+        
+        # save as json file
+        try:
+            db.save_data_to_file(config['Service']['EnclaveServiceDatabaseFile'])
+        except Exception as e:
+            logger.error('Unable to create new database. Failed to save as json file' + str(e))
+            sys.exit(-1)
+
+        logger.info('Created a new database with ' + str(len(urls)) + ' entries.')
+
+    else :
+        # load the data from the json file for add/remove/update operation
+        try:
+            db = ServiceDB_Manager(service_type='eservice', file_name=config['Service']['EnclaveServiceDatabaseFile'])
+        except Exception as e:
+            logger.error('Unable to open existing eservice data file for the add/update/remove operation' + str(e))
+            sys.exit(-1)
+
+    if 'add' in commands :
+        
+        #make sure that there are names for each of the new eservice to add
+        if len(config['Service']['EnclaveServiceNames']) < len(config['Service']['EnclaveServiceURLs']):
+            logger.error('Please provide a name for each eservice to be added to the database')
+            sys.exit(-1)
+
+        names = config['Service']['EnclaveServiceNames']
+        urls = config['Service']['EnclaveServiceURLs']
+
+        # add entries to db
+        for index, url in enumerate(urls):
+            try :
+                client = db.get_serviceclient_by_url(url=url)
+                db.add_new_info(name = names[index], url=url, id = client.enclave_id)
+            except Exception as e:
+                logger.error('Error adding new entry for url ' + str(url) + str(e))
+                sys.exit(-1)
+
+        # save as json file
+        try:
+            db.save_data_to_file()
+        except Exception as e:
+            logger.error('Unable to add new entries: Failed to save as json file' + str(e))
+            sys.exit(-1)
+        
+        logger.info('Added ' + str(len(urls)) + ' entries to the database')
+
+    if 'update' in commands :
+        # names are optional. However, if the name field is nonempty, must provide names for all urls.
+        # if name is provided, will update the url of the entry corresponding name to input url, and also update the service_id
+        # if only url is provided, will update the service_id
+
+        num_updated = 0
+        urls = config['Service']['EnclaveServiceURLs']
+        names = []
+        if config['Service'].get('EnclaveServiceNames'):
+            names = config['Service']['EnclaveServiceNames']
+            if len(config['Service']['EnclaveServiceNames']) < len(config['Service']['EnclaveServiceURLs']):
+                logger.error('Please provide a name for each eservice to be updated to the database.')
+                sys.exit(-1)
+                
+        for index, url in enumerate(urls):
+            client = db.get_serviceclient_by_url(url=url)
+            
+            if len(names) > 0: # you are possibly changing the url for the name as well
+                info_old = db.get_info(name = names[index])
+                db.update_info(name = names[index], url = urls[index], id = client.enclave_id)
+                info_new = db.get_info(name = names[index])
+            else:
+                info_old = db.get_info(url = url)
+                db.update_info(name = info_old['name'], id = client.enclave_id) #url does not change
+                info_new = db.get_info(name = info_old['name'])
+                       
+            num_updated += int(info_old != info_new)
+
+        # save as json file
+        try:
+            db.save_data_to_file()
+        except Exception as e:
+            logger.error('Unable to update entries: Failed to save as json file' + str(e))
+            sys.exit(-1)
+        
+        logger.info('Updated ' + str(num_updated) + ' entries in the database')
+
+    if 'remove' in commands :
+        # removes all entries corresponding to names and urls
+        
+        num_removed = 0 
+
+        if config['Service'].get('EnclaveServiceNames'):
+            names = config['Service']['EnclaveServiceNames']
+            logger.info(names)
+            for name in names:
+                num_removed += db.remove_info(name = name)
+        
+        if config['Service'].get('EnclaveServiceURLs'):
+            urls = config['Service']['EnclaveServiceURLs']
+            logger.info(urls)
+            for url in urls:
+                num_removed +=  db.remove_info(url = url)
+
+        # save as json file
+        try:
+            db.save_data_to_file()
+        except Exception as e:
+            logger.error('Unable to remove entries: Failed to save as json file' + str(e))
+            sys.exit(-1)
+
+        logger.info('Removed ' + str(num_removed) + ' entries from the database')
+
+
+
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+## DO NOT MODIFY BELOW THIS LINE
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+ContractHost = os.environ.get("HOSTNAME", "localhost")
+ContractHome = os.environ.get("PDO_HOME") or os.path.realpath("/opt/pdo")
+ContractEtc = os.path.join(ContractHome, "etc")
+ContractKeys = os.path.join(ContractHome, "keys")
+ContractLogs = os.path.join(ContractHome, "logs")
+ContractData = os.path.join(ContractHome, "data")
+LedgerURL = os.environ.get("PDO_LEDGER_URL", "http://127.0.0.1:8008/")
+ScriptBase = os.path.splitext(os.path.basename(sys.argv[0]))[0]
+
+config_map = {
+    'base' : ScriptBase,
+    'data' : ContractData,
+    'etc'  : ContractEtc,
+    'home' : ContractHome,
+    'host' : ContractHost,
+    'keys' : ContractKeys,
+    'logs' : ContractLogs,
+    'ledger' : LedgerURL
+}
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+def Main(commands) :
+    # parse out the configuration file first
+    conffiles = [ 'pcontract.toml' ]
+    confpaths = [ ".", "./etc", ContractEtc ]
+
+    parser = argparse.ArgumentParser()
+    
+    parser.add_argument('--config', help='configuration file', nargs = '+')
+    parser.add_argument('--config-dir', help='configuration file', nargs = '+')
+
+    parser.add_argument('--eservice-url', help='service urls',  nargs='+')
+    parser.add_argument('--eservice-name', help='service names',  nargs='+')
+    parser.add_argument('--eservice-db', help='json file for database', type=str)
+    parser.add_argument('--loglevel', help='Set the logging level', default='INFO')
+    parser.add_argument('--logfile', help='Name of the log file', default='__screen__')
+
+    options = parser.parse_args()
+
+    # first process the options necessary to load the default configuration
+    if options.config :
+        conffiles = options.config
+
+    if options.config_dir :
+        confpaths = options.config_dir
+
+    global config_map
+    
+    try :
+        config = pconfig.parse_configuration_files(conffiles, confpaths, config_map)
+    except pconfig.ConfigurationException as e :
+        logger.error(str(e))
+        sys.exit(-1)
+
+    # set up the logging configuration
+    if config.get('Logging') is None :
+        config['Logging'] = {
+            'LogFile' : '__screen__',
+            'LogLevel' : 'INFO'
+        }
+    if options.logfile :
+        config['Logging']['LogFile'] = options.logfile
+    if options.loglevel :
+        config['Logging']['LogLevel'] = options.loglevel.upper()
+
+    plogger.setup_loggers(config.get('Logging', {}))
+
+    # process the reset of the command parameters
+
+    # set up the service configuration
+    if config.get('Service') is None :
+        config['Service'] = {
+            'EnclaveServiceURLs' : [],
+            'EnclaveServiceNames' : [],
+            'EnclaveServiceDatabaseFile' : None
+        }
+
+    if options.eservice_url :
+        config['Service']['EnclaveServiceURLs'] = options.eservice_url
+    
+    if options.eservice_name :
+        config['Service']['EnclaveServiceNames'] = options.eservice_name
+
+    if options.eservice_db:
+        config['Service']['EnclaveServiceDatabaseFile'] = options.eservice_db
+    
+   
+    # GO!!!
+    LocalMain(commands, config)
+
+## -----------------------------------------------------------------
+## Entry points
+## -----------------------------------------------------------------
+def Add() :
+    Main(['add'])
+
+def Remove() :
+    Main(['remove'])
+
+def Create() :
+    Main(['create'])
+
+def Update():
+    Main(['update'])    

--- a/client/setup.py
+++ b/client/setup.py
@@ -65,6 +65,10 @@ setup(name='pdo_client',
               'pdo-add-enclave = pdo.client.scripts.CreateCLI:AddEnclave',
               'pdo-update = pdo.client.scripts.UpdateCLI:Main',
               'pdo-shell = pdo.client.scripts.ShellCLI:Main',
+              'pdo-create-eservicedb = pdo.client.scripts.eservicedatabaseCLI:Create',
+              'pdo-add-to-eservicedb = pdo.client.scripts.eservicedatabaseCLI:Add',
+              'pdo-update-eservicedb = pdo.client.scripts.eservicedatabaseCLI:Update',
+              'pdo-remove-from-eservicedb = pdo.client.scripts.eservicedatabaseCLI:Remove'
           ]
       }
 )

--- a/eservice/docs/database.md
+++ b/eservice/docs/database.md
@@ -1,0 +1,60 @@
+<!---
+Licensed under Creative Commons Attribution 4.0 International License
+https://creativecommons.org/licenses/by/4.0/
+--->
+
+A client may maintain a local eservice database that maps known enclave_ids to the corresponding URLs of the hosting eservcies. The database
+can be shared across multiple contracts by the same client. The client maitains database as a json file with each entry being a (key, value). key is a short name for the service, value is a dictonary with entries for 'id' and 'url'. 'id' denotes the id of the enclave hosted by the eservice. 
+
+Database management is possible via command line using the commands pdo-create-eservicedb, pdo-add-to-eservicedb, 
+pdo-update-eservicedb, pdo-remove-from-eservicedb. The default command line options for urls are used from pcontract.toml. The CLI options override the values set in pcontract.toml. The toml file does not have default options for names and the  json file ${ESERVICE_DB}, but may be added before executing the commands. The user must exercise caution while adding default options to the toml file, as this may cause inadvertent behaviour (see the remove command below for additional notes)
+
+Name, id (enclave_id) and url are all synonyms for a given eservice. Exceptions will be raised (especially during information retrieval) if there are violations. To fix a broken database, use the remove command to remove multiple or replicated entries for a given identifier from the database. After remove, use the add command to add a unique entry for a given identifier.
+
+Usage Examples:
+
+# Create a new database with 2 entires. The name e1 (e2) gets assocaited with first (second) url. It is assumed that the json file does not exist previously, else creation will fail. The enclave_id will be automatically populated, as long as the eservice@url hosts an enclave
+pdo-create-eservicedb --eservice-url http://localhost:7101 http://localhost:7102 --eservice-name e1 e2 --eservice-db ${ESERVICE_DB}
+
+# Add a new entry to the database. The enclave_id will be automatically populated, as long as the eservice@url hosts an enclave
+pdo-add-to-eservicedb --eservice-url http://localhost:7103 --eservice-name e3 --eservice-db ${ESERVICE_DB}
+
+# Remove an entry by name from the database. In the below command, an empty field is passed to --eservice-url. This is to override any url values that might be present in the pcontract.toml, so that one does not inadvertently remove an entry from the database 
+pdo-remove-from-eservicedb  --eservice-name e3 --eservice-url [] --eservice-db ${ESERVICE_DB}
+
+# Remove an entry by url from the database. 
+pdo-remove-from-eservicedb  --eservice-url http://localhost:7102 --eservice-db ${ESERVICE_DB}
+
+# Update an entry by name. The url associated with name will replaced with the new url. The enclave_id will be updated as well 
+pdo-update-eservicedb  --eservice-name e1 --eservice-url http://localhost:7102  --eservice-db ${ESERVICE_DB}
+
+# update an entry by url. Use this to update the enclave_id corresponding to eservice@url
+pdo-update-eservicedb  --eservice-url http://localhost:7102  --eservice-db ${ESERVICE_DB}
+
+Pdo test scripts can take advantage of the database to identify an enclave for running the contract. It is enough to provide the eservice name and json file as options. The exact policy for provisioning or chosing enclaves (if more than one name is passed as input) is outside the scope of the database manager functionality. This gets implemeneted as part of the specific test script, see the individual test script for details.
+
+Usage Examples:
+
+# run mock contract contract with test-request. Contract enclave is provisioned @ e1
+pdo-test-request --no-ledger  --eservice-name e1 --eservice-db ${ESERVICE_DB}
+
+# run interger key contract with test-contract. Contract enclave is provisioned @ e2
+pdo-test-contract --no-ledger --contract integer-key --eservice-name e2  --eservice-db ${ESERVICE_DB}
+
+# create a new mock-contract with pdo-create. Provision three enclaves @e1, e2, e3 to contract 
+pdo-create --config ${CONFIG_FILE} --ledger ${PDO_LEDGER_URL} \
+     --identity user1 --save-file ${SAVE_FILE} \
+    --contract mock-contract --source _mock-contract.scm --eservice-name e1 e2 e3 --eservice-db ${ESERVICE_DB}
+
+#update a previously created mock contract. Use enclave @ e3 to run the contract
+pdo-update --config ${CONFIG_FILE} --ledger ${PDO_LEDGER_URL} \
+                       --identity user1 --save-file ${SAVE_FILE} 
+                       --eservice-name e3  --eservice-db ${ESERVICE_DB} "'(inc-value)"
+
+# create a contrac via the pdo-shell. Provision 5 encalves@e1, e2, e3, e4, e5 for the contract
+pdo-shell --ledger $PDO_LEDGER_URL --eservice-name e1 e2 e3 e4 e5 --eservice-db ${ESERVICE_DB} \
+    -s ${SRCDIR}/contracts/exchange/scripts/create.psh -m color red 
+
+# update a contract via the pdo-shell. Use enclave@e4 to run the contract
+pdo-shell --ledger $PDO_LEDGER_URL --eservice-name e${p} --eservice-db ${ESERVICE_DB} \ 
+    -s ${SRCDIR}/contracts/exchange/scripts/issue.psh -m color red -m issuee user$p -m count $(($p * 10))

--- a/eservice/docs/test-scripts.md
+++ b/eservice/docs/test-scripts.md
@@ -98,8 +98,11 @@ the configuration file
 * ``--data <string>`` -- path to directory used for storing data
 * ``--secret-count <integer>`` -- number of secrets to generate if no
   provision service is used
-* ``--eservice <string>`` -- URL for the enclave service
+* ``--eservice-url <string>`` -- URL for the enclave service
 * ``--pservice <string> <string> ...`` -- list of URLs for provisioning
+  ``--eservice-db`` -- json file for eservice database
+  ``--eservice-name`` -- the name of an enclave service as in the client's eservice database 
+
   services
 * ``--logfile <string>`` -- name of the log file to use, ``__screen__``
   dumps the log to the console
@@ -187,4 +190,5 @@ $ python test-request.py --ledger http://localhost:8008 \
     --pservice http://localhost:7101 http://localhost:7102 \
     --eservice http://localhost:7001 \
     --iterations 500
+
 ```

--- a/python/pdo/common/utility.py
+++ b/python/pdo/common/utility.py
@@ -22,13 +22,17 @@ before logging is enabled.
 import os
 import errno
 import pdo.common.crypto as crypto
+import socket
+from urllib.parse import urlparse
+
 
 __all__ = [
     'set_default_data_directory',
     'build_simple_file_name',
     'build_file_name',
     'find_file_in_path',
-    'from_transaction_signature_to_id'
+    'from_transaction_signature_to_id',
+    'are_the_urls_same'
     ]
 
 __DefaultDataDirectory__ = './data'
@@ -115,3 +119,31 @@ def from_transaction_signature_to_id(transaction_signature) :
     """
     id = crypto.byte_array_to_base64(crypto.compute_message_hash(crypto.hex_to_byte_array(transaction_signature)))
     return id
+
+#--------------------------------------------------------------------
+#--------------------------------------------------------------------
+def are_the_urls_same(url1, url2):
+    """Though not a perfect comparison, we make make sure that 
+    http://127.0.0.1:7101/ and http://localhost:7101 are considered the same. 
+    It would be good to first check  if the input is a valid url itself."""
+
+    if url1 is None or url2 is None:
+        return False
+    
+    if (url1 == url2):
+        return True
+
+    url1_parse = urlparse(url1)
+    url2_parse = urlparse(url2)
+
+    url1_hostname_and_port = url1_parse.netloc.split(':')
+    url2_hostname_and_port = url2_parse.netloc.split(':')
+
+    url1_ip = socket.gethostbyname(url1_hostname_and_port[0])
+    url2_ip = socket.gethostbyname(url2_hostname_and_port[0])
+
+    # check ip, port and scheme
+    if url1_ip == url2_ip and url1_hostname_and_port[1] == url2_hostname_and_port[1] and url1_parse.scheme == url2_parse.scheme:
+        return True
+
+    return False

--- a/python/pdo/service_client/__init__.py
+++ b/python/pdo/service_client/__init__.py
@@ -16,5 +16,6 @@ all = [
     'enclave',
     'generic',
     'provisioning',
-    'storage'
+    'storage',
+    'servicedatabase'
 ]

--- a/python/pdo/service_client/servicedatabase.py
+++ b/python/pdo/service_client/servicedatabase.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python
+
+# Copyright 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
+import os
+import sys
+import json
+import copy
+
+import logging
+logger = logging.getLogger(__name__)
+
+from pdo.service_client.enclave import EnclaveServiceClient
+from pdo.service_client.storage import StorageServiceClient
+from pdo.common.utility import are_the_urls_same
+
+
+class ServiceDB_Manager():
+    """ A class to wrap calls to service database manager. 
+    
+    The data is saved as a json file, and is loaded as a dictionary of (key, value) pairs.  Key is a client chosen short name for the service.
+    Value is a dictionary with entries corresponding to id (if service is eservice), url, verifying_key (if service is sservice).  
+    
+    It is also possible to first create an empty dictonary, add entries and then save as a json file.
+    
+    Name, id (enclave_id) and url are all synonyms for a given eservice. Exceptions will be raised if there are violations. To fix a broken database, 
+    use the remove_service method to remove multiple or replicated entries for a given identifier from the database. After remove, use the add_new_entry
+    to add a unique entry for a given identifier"""
+
+    def __init__(self, file_name = None, service_type='eservice'):
+
+        if file_name is not None:
+            self.file_name = file_name
+            try:
+                self.load_data_from_file()
+            except Exception as e:
+                logger.exception('Failed to load database during initialization' + str(e))
+                raise Exception from e
+        else:
+            self.data = dict()
+
+        self._service_type = service_type
+        
+        if (self._service_type is not 'eservice') and (self._service_type is not 'sservice'):
+            logger.exception('Cannot initialize service database manager: service_type must be eservice or sservice')
+            raise Exception('Cannot initialize service database manager: service_type must be eservice or sservice')
+
+
+    #--------------------------------------------
+    #--------------------------------------------
+
+    @staticmethod
+    def get_eservice_client(url):
+        try :
+            client = EnclaveServiceClient(url)
+        except Exception as e :
+            logger.exception('failed to contact enclave service; %s', str(e))
+            raise Exception from e
+        return client
+
+    #--------------------------------------------
+    #--------------------------------------------
+
+    @staticmethod
+    def get_sservice_client(url):
+        try :
+            client = StorageServiceClient(url)
+        except Exception as e :
+            logger.exception('failed to contact storage service; %s', str(e))
+            raise Exception from e
+        return client
+
+    def load_data_from_file(self):
+        """ Load the json data file as a dictionary"""
+
+        if os.path.exists(self.file_name):
+            try:
+                with open(self.file_name, 'r') as fp:
+                    self.data = json.load(fp)
+                    if not isinstance(self.data, dict):
+                        raise Exception('Invalid json file for service database: Json file must be loadable as python dictionary')
+            except Exception as e:
+                logger.exception('Failed to load json file for service database: ' + str(e))
+                raise Exception from e
+        else:
+            raise Exception('Cannot load service database: Data file does not exist')
+    
+    #--------------------------------------------
+    #--------------------------------------------
+    
+    def save_data_to_file(self, new_file_name = None):
+        """ Save the dictionary as a json file. If no new_file_name is provided, the json file used for init will be overwritten"""
+        if new_file_name is not None:
+            self.file_name = new_file_name
+
+        if self.file_name is None:
+            logger.exception('Cannot save service database info without providing json file name')
+            raise Exception('Cannot save service database info without providing json file name')
+        
+        try:
+            with open(self.file_name, 'w') as fp:
+                json.dump(self.data, fp)
+        except Exception as e:
+            logger.exception('Failed to save service database info as a json file: ' + str(e))
+            raise Exception('Failed to save service database info as a json file: ' + str(e))
+
+
+    #--------------------------------------------
+    #--------------------------------------------
+    
+    def get_serviceclient_by_name(self, name):
+        """ Return the service client idenfied by its name"""
+
+        service_info = self.data[name]
+        if service_info['url'] is None:
+            logger.exception('Unable to find service url in datatabase for ' + str(name) + '. Cannot create serivce client without the url')
+            raise Exception('Unable to find service url in datatabase for ' + str(name) + '. Cannot create serivce client without the url')
+        
+        if self._service_type=='eservice':
+            client = self.get_eservice_client(service_info['url'])
+            if service_info.get('id'):
+                if service_info['id'] != client.enclave_id:
+                    logger.exception('Enclave hosted by the eservice does not match the one found in database: Cannot create service client')
+                    raise Exception('Enclave hosted by the eservice does not match the one found in database: Cannot create service client')
+        else:
+            client = self.get_sservice_client(service_info['url'])
+        
+        return client
+    #--------------------------------------------
+    #--------------------------------------------
+    
+    def get_serviceclient_by_url(self, url):
+        """ Return the service client for the service located at url. """
+
+        if self._service_type=='eservice':
+            return self.get_eservice_client(url)
+        else:
+            return self.get_sservice_client(url)
+        
+    #--------------------------------------------
+    #--------------------------------------------
+    
+    def get_serviceclient_by_id(self, id):
+        """ Return the service client identified by its id. An exception will be raised if the id is found multiple times in the database"""
+
+        entries = list(filter(lambda entry: entry['id']==id , self.data.values()))
+        
+        if len(entries) == 0:
+            logger.exception('Cannot create service client : id not found in database')
+            raise Exception('Cannot create service client : id not found in database')
+        elif len(entries) > 1:
+            logger.exception('Cannot create service client : Invalid Database, id found multiple times in the database')
+            raise Exception('Cannot create service client : Invalid Database, id found multiple times in the database')
+        elif entries[0]['url'] is None:
+            logger.exception('Unable to find service url for given id. Cannot create serivce client without the url')
+            raise Exception('Unable to find service url for given id. Cannot create serivce client without the url')
+
+        
+        if self._service_type=='eservice':
+            client =  self.get_eservice_client(entries[0]['url'])
+            service_info = self.get_info(url = entries[0]['url'])
+            if service_info['id'] != id:
+                logger.exception('Enclave hosted by the eservice does not match the one found in database: Cannot create service client')
+                raise Exception('Enclave hosted by the eservice does not match the one found in database: Cannot create service client')
+        else:
+            logger.exception('Unsupported operation. Service client by id is supported only for eservice and not for sservice')
+            raise Exception('Unsupported operation. Service client by id is supported only for eservice and not for sservice')
+
+        return client
+    
+    #--------------------------------------------
+    #--------------------------------------------
+    
+    def add_new_info(self, name, id = None, url = None):
+        """ Add a new entry to the data base. If any one field of the new entry is already in the database, an exception will be raised."""
+
+        if name is None:
+            logger.exception('Cannot add entry to service database: Need a name for the entry')
+            raise Exception('Cannot add entry to service database: Need a name for the entry')
+        elif name in self.data.keys():
+            logger.exception('Cannot add entry to service database: Name already present, give a new name for the entry')
+            raise Exception('Cannot add entry to service database: Name already present, give a new name for the entry')
+        
+        if url is not None:
+            entries = list(filter(lambda entry: are_the_urls_same(entry['url'], url) , self.data.values()))
+            if len(entries) >0:
+                logger.exception('Cannot add entry to service database : url already present in the database')
+                raise Exception('Cannot add entry to service database : url already present in the database')
+
+        if id is not None:
+            entries = list(filter(lambda entry: entry['id']==id , self.data.values()))
+            if len(entries) >0:
+                logger.exception('Cannot add entry to service database : id already present in the database')
+                raise Exception('Cannot add entry to service database : id already present in the database')
+
+        # all good to add the new entry
+        self.data[name] = {'id' : id, 'url': url}
+
+    #--------------------------------------------
+    #--------------------------------------------
+    
+    def get_info(self, name = None, id = None, url = None):
+        """ Get info for an entry: Order of precendence for search : name > url > id.
+        Return a dictonary with all three fields - name, id and url - as found in the database"""
+
+        if name is not None:
+            if name in self.data.keys():
+                info = copy.deepcopy(self.data[name])
+                info.update({'name': name})
+                return info
+        elif url is not None:
+           entries = list(filter(lambda entry: are_the_urls_same(entry[1]['url'], url) , list(self.data.items())))
+           if len(entries) >1:
+                logger.exception('Cannot get info: Invalid Database, url found multiple times in the database')
+                raise Exception('Cannot get info: Invalid Database, url found multiple times in the database')
+           if len(entries) ==1: 
+               info = copy.deepcopy(entries[0][1])
+               info.update({'name': entries[0][0]})
+               return info
+        elif id is not None:
+            entries = list(filter(lambda entry: entry[1]['id']==id , list(self.data.items())))
+            if len(entries) >1:
+                logger.exception('Cannot get info: Invalid Database, id found multiple times in the database')
+                raise Exception('Cannot get info: Invalid Database, id found multiple times in the database')
+            if len(entries) ==1: 
+               info = copy.deepcopy(entries[0][1])
+               info.update({'name': entries[0][0]})
+               return info
+        else:
+            logger.exception('Cannot get info: No corresponding entry in the database')
+            raise Exception('Cannot get info: No corresponding entry in the database')
+
+    #--------------------------------------------
+    #--------------------------------------------
+
+    def update_info(self, name, id = None, url = None):
+        """Update id or url of a specific service identified by name. Return new info"""
+        if name is not None:
+            if name in self.data.keys():
+                if id is not None:
+                    self.data[name]['id'] = id
+                if url is not None:
+                    self.data[name]['url'] = url
+                return self.get_info(name)
+        else:
+            logger.exception('Cannot update info: No corresponding entry in the database for the given name')
+            raise Exception('Cannot update info: No corresponding entry in the database for the given name')
+    
+    #--------------------------------------------
+    #--------------------------------------------
+    
+    def remove_info(self, name = None, id = None, url = None):
+        """Remove all entries corresponding to name & id & url. Return number of entries removed"""
+
+        num_removed = 0
+        # remove by name
+        if self.data.pop(name, None):
+            num_removed+=1
+
+        # remove by id
+        entries = list(filter(lambda entry: entry[1]['id']==id , list(self.data.items())))
+        for entry in entries:
+            self.data.pop(entry[0])
+        num_removed+=len(entries)
+
+        #remove by url
+        entries = list(filter(lambda entry: are_the_urls_same(entry[1]['url'], url) , list(self.data.items()))) 
+        for entry in entries:
+            self.data.pop(entry[0])
+        num_removed+=len(entries)
+
+        return num_removed
+
+        
+  
+    
+        
+
+    

--- a/python/pdo/test/__init__.py
+++ b/python/pdo/test/__init__.py
@@ -16,5 +16,6 @@ __all__ = [
     'helpers',
     'contract',
     'request',
-    'state'
+    'state',
+    'servicedb'
 ]

--- a/python/pdo/test/request.py
+++ b/python/pdo/test/request.py
@@ -19,6 +19,7 @@ import sys
 import time
 import argparse
 import random
+import json
 import pdo.test.helpers.secrets as secret_helper
 import pdo.test.helpers.state as test_state
 
@@ -27,12 +28,17 @@ from pdo.sservice.block_store_manager import BlockStoreManager
 import pdo.eservice.pdo_helper as enclave_helper
 import pdo.service_client.enclave as eservice_helper
 import pdo.service_client.provisioning as pservice_helper
+from pdo.service_client.servicedatabase import ServiceDB_Manager
 
 import pdo.contract as contract_helper
 import pdo.common.crypto as crypto
 import pdo.common.keys as keys
 import pdo.common.secrets as secrets
 import pdo.common.utility as putils
+
+import requests
+from urllib.parse import urlparse
+import socket
 
 import logging
 logger = logging.getLogger(__name__)
@@ -81,14 +87,28 @@ def CreateAndRegisterEnclave(config) :
     # if we are using the eservice then there is nothing to register since
     # the eservice has already registered the enclave
     if use_eservice :
-        try :
-            eservice_url = random.choice(config['Service']['EnclaveServiceURLs'])
-            logger.info('use enclave service at %s', eservice_url)
-            enclave = eservice_helper.EnclaveServiceClient(eservice_url)
-            return enclave
-        except Exception as e :
-            logger.error('failed to contact enclave service; %s', str(e))
-            sys.exit(-1)
+        
+        # Pick an enclave for the creating the contract
+        if config['Service'].get('EnclaveServiceNames'): #use the database to get the enclave
+            logger.info('Using eservice database to look up service URL for the contract enclave')            
+            try:
+                eservice_to_use = random.choice(config['Service']['EnclaveServiceNames'])
+                db = ServiceDB_Manager(service_type='eservice', file_name=config['Service']['EnclaveServiceDatabaseFile'])
+                enclave = db.get_serviceclient_by_name(eservice_to_use)
+            except Exception as e:
+                logger.error('Unable to get the eservice client using the eservice database: ' + str(e)) 
+                sys.exit(-1)   
+        else: # do not use the database, use the url and get the client directly
+            try :
+                eservice_urls = config['Service']['EnclaveServiceURLs']
+                eservice_url = random.choice(eservice_urls)
+                enclave = eservice_helper.EnclaveServiceClient(eservice_url)
+            except Exception as e :
+                logger.error('failed to contact enclave service; %s', str(e))
+                sys.exit(-1)
+        
+        logger.info('use enclave service at %s', enclave.ServiceURL)
+        return enclave
 
     # not using an eservice so build the local enclave
     try :
@@ -448,6 +468,7 @@ def Main() :
     parser.add_argument('--source-dir', help='Directories to search for contract source', nargs='+', type=str)
     parser.add_argument('--key-dir', help='Directories to search for key files', nargs='+')
 
+    parser.add_argument('--eservice-name', help='List of enclave services to use. Give names as in database', nargs='+')
     parser.add_argument('--eservice-url', help='List of enclave service URLs to use', nargs='+')
     parser.add_argument('--pservice-url', help='List of provisioning service URLs to use', nargs='+')
 
@@ -457,6 +478,8 @@ def Main() :
     parser.add_argument('--iterations', help='Number of operations to perform', type=int, default=10)
 
     parser.add_argument('--tamper-block-order', help='Flag for tampering with the order of the state blocks', action='store_true')
+
+    parser.add_argument('--eservice-db', help='json file for eservice database', type=str)
 
     options = parser.parse_args()
 
@@ -520,15 +543,24 @@ def Main() :
     # set up the service configuration
     if config.get('Service') is None :
         config['Service'] = {
+            'EnclaveServiceNames' : [],
             'EnclaveServiceURLs' : [],
-            'ProvisioningServiceURLs' : []
+            'ProvisioningServiceURLs' : [],
+            'EnclaveServiceDatabaseFile' : None
         }
+
+    if options.eservice_name:
+        use_eservice = True
+        config['Service']['EnclaveServiceNames'] = options.eservice_name
+    if options.eservice_db:
+        config['Service']['EnclaveServiceDatabaseFile'] = options.eservice_db
     if options.eservice_url :
         use_eservice = True
         config['Service']['EnclaveServiceURLs'] = options.eservice_url
     if options.pservice_url :
         use_pservice = True
         config['Service']['ProvisioningServiceURLs'] = options.pservice_url
+    
 
     # set up the data paths
     if config.get('Contract') is None :
@@ -564,6 +596,7 @@ def Main() :
     if tamper_block_order :
         config['iterations'] = 1
 
+    
     LocalMain(config)
 
 Main()

--- a/python/pdo/test/servicedb.py
+++ b/python/pdo/test/servicedb.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+
+# Copyright 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+ 
+# this script tests the service database manager implementation. Eservices are assuming to be running.
+
+import os
+import sys
+
+import argparse
+import logging
+logger = logging.getLogger(__name__)
+
+import pdo.common.logger as plogger
+from pdo.service_client.servicedatabase import ServiceDB_Manager
+from pdo.common.utility import are_the_urls_same
+
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--url', help='service urls', required=True,  nargs='+')
+parser.add_argument('--eservice-db', help='json file for database', type=str)
+parser.add_argument('--loglevel', help='Set the logging level', default='INFO')
+parser.add_argument('--logfile', help='Name of the log file', default='__screen__')
+
+options = parser.parse_args()
+plogger.setup_loggers({'LogLevel' : options.loglevel.upper(), 'LogFile' : options.logfile})
+
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+
+#create an empty db
+db = ServiceDB_Manager(service_type='eservice')
+
+# add new entries by urls
+names = []
+for index, url in enumerate(options.url):
+    names.append('e' + str(index))
+    db.add_new_info(name = names[index], url=url)
+
+for e in names:
+    # get service client by name
+    c_name = db.get_serviceclient_by_name(e)
+
+    # get info by name
+    info = db.get_info(name = e)
+   
+    # check info by name
+    assert (info['name'] == e) and are_the_urls_same(info['url'], c_name.ServiceURL) and (info['id'] is None), "Incorrect info by name"
+       
+    # get service client by url, url obtained from info
+    c_url = db.get_serviceclient_by_url(info['url'])
+    
+    # check if the two clients point to the same service url
+    assert are_the_urls_same(c_name.ServiceURL, c_url.ServiceURL), "Not getting the same eservice client using name and url"
+
+    # get info by url
+    info = db.get_info(url = c_url.ServiceURL)
+    
+    # check info by url
+    assert (info['name'] == e) and are_the_urls_same(info['url'], c_name.ServiceURL) and (info['id'] is None), "Incorrect info by url"
+
+    # update info by adding enclave id
+    db.update_info(e, id = c_url.enclave_id)
+
+    # get info by name
+    info = db.get_info(name = e)
+
+    # get info by id
+    info = db.get_info(id = c_url.enclave_id)
+
+    # check info by id
+    assert (info['name'] == e) and are_the_urls_same(info['url'], c_name.ServiceURL) and (info['id'] == c_url.enclave_id), "Incorrect info by url"
+
+    #get client by id
+    c_id = db.get_serviceclient_by_id(info['id'])
+
+    #check client by id
+    # check if the two clients point to the same service url
+    assert are_the_urls_same(c_name.ServiceURL, c_id.ServiceURL), "Not getting the same eservice client using name and url"
+
+#save to file
+db.save_data_to_file(options.eservice_db)
+
+#create new db from file
+db2 = ServiceDB_Manager(file_name = options.eservice_db, service_type='eservice')
+
+#check the two dbs are the same
+assert db.data == db2.data, "Error loading db from json file"
+
+#remove entry for e1, url2
+if len(options.url) > 1:
+    url2 = options.url[1]
+    assert db2.remove_info(name = names[0], url = url2) == 2, "Failed to remove two entries from db"
+    assert len(db2.data) == len(names) - 2, "Failed to remove two entries from db"
+
+#remove entry by name alone:
+assert db.remove_info(name = names[0]) == 1, "Failed to remove one entry from db"
+assert len(db.data) == len(names) -1, "Failed to remove one entry from db"
+
+#save db to file by overwriting old json, no file name given now
+db.save_data_to_file()
+
+#reload db2
+db2.load_data_from_file()
+
+#check that load succeeded
+assert db.data == db2.data
+
+logger.info("All tests passed for service database manager")
+
+
+
+
+
+
+
+
+
+ 
+
+


### PR DESCRIPTION
This PR introduces functionality for eservice database. The database manager is a separate class providing basic db functionality. The data itself is stored as json. CLI is provided via commands such as pdo-create-eservicedb, pdo-update-eservicedb etc. Documentation can be found in eservice/docs/.
A new run-tests-with-database.sh shell script has been added to built/__tools__ to show the usage of the database for pdo test scripts.

Signed-off-by: prakashngit <prakash.narayana.moorthy@intel.com>