### PR TITLE
Eservice database changes addressing comments

### DIFF
--- a/build/__tools__/run-tests.sh
+++ b/build/__tools__/run-tests.sh
@@ -118,18 +118,6 @@ try ${PDO_HOME}/bin/es-start.sh --count ${NUM_SERVICES} --ledger ${PDO_LEDGER_UR
 
 cd ${SRCDIR}/build
 
-say run unit level tests for eservice database 
-cd ${SRCDIR}/python/pdo/test
-try python servicedb.py --logfile $PDO_HOME/logs/client.log --loglevel info \
-    --eservice-db $PDO_HOME/data/db-test.json --url http://localhost:7101/ http://localhost:7102/ http://localhost:7103/ --ledger ${PDO_LEDGER_URL}
-try rm $PDO_HOME/data/db-test.json
-
-cd ${SRCDIR}/build
-
-say create the eservice database using database CLI 
-# add all enclaves listed in pcontract.toml
-try pdo-eservicedb --logfile $PDO_HOME/logs/client.log --loglevel info create
-
 # -----------------------------------------------------------------
 yell start tests without provisioning or enclave services
 # -----------------------------------------------------------------
@@ -300,6 +288,19 @@ fi
 #-----------------------------------------
 yell run tests with the eservice database 
 #------------------------------------------
+
+say run unit tests for eservice database 
+cd ${SRCDIR}/python/pdo/test
+try python servicedb.py --logfile $PDO_HOME/logs/client.log --loglevel info \
+    --eservice-db $PDO_HOME/data/db-test.json --url http://localhost:7101/ http://localhost:7102/ http://localhost:7103/ --ledger ${PDO_LEDGER_URL}
+try rm $PDO_HOME/data/db-test.json
+
+cd ${SRCDIR}/build
+
+say create the eservice database using database CLI 
+# add all enclaves listed in pcontract.toml
+try pdo-eservicedb --logfile $PDO_HOME/logs/client.log --loglevel info create
+
   
 say run various pdo scripts - test-request, test-contract, create, update, shell - using database
 try pdo-test-request --eservice-name e1 --logfile $PDO_HOME/logs/client.log --loglevel info  

--- a/build/__tools__/run-tests.sh
+++ b/build/__tools__/run-tests.sh
@@ -78,6 +78,7 @@ if [ $? == 0 ] ; then
 fi
 
 SAVE_FILE=$(mktemp /tmp/pdo-test.XXXXXXXXX)
+
 declare -i NUM_SERVICES=5 # must be at least 3 for pconntract update test to work
 function cleanup {
     yell "shutdown services"
@@ -116,6 +117,19 @@ try ${PDO_HOME}/bin/ps-start.sh --count ${NUM_SERVICES} --ledger ${PDO_LEDGER_UR
 try ${PDO_HOME}/bin/es-start.sh --count ${NUM_SERVICES} --ledger ${PDO_LEDGER_URL} --clean > /dev/null
 
 cd ${SRCDIR}/build
+
+
+say run unit level tests for eservice database 
+cd ${SRCDIR}/python/pdo/test
+try python servicedb.py --logfile $PDO_HOME/logs/client.log --loglevel info \
+    --eservice-db $PDO_HOME/data/db-test.json --url http://localhost:7101 http://localhost:7102 http://localhost:7103 --ledger ${PDO_LEDGER_URL}
+try rm $PDO_HOME/data/db-test.json
+
+cd ${SRCDIR}/build
+
+say create the eservice database using database CLI 
+# add all enclaves listed in pcontract.toml
+try pdo-eservicedb --command create --logfile $PDO_HOME/logs/client.log --loglevel info 
 
 # -----------------------------------------------------------------
 yell start tests without provisioning or enclave services
@@ -157,25 +171,25 @@ try pdo-test-storage --url http://localhost:7201 --loglevel warn --logfile __scr
 say start request test
 try pdo-test-request --ledger ${PDO_LEDGER_URL} \
     --pservice http://localhost:7001/ http://localhost:7002 http://localhost:7003 \
-    --eservice http://localhost:7101/ \
+    --eservice-url http://localhost:7101/ \
     --logfile __screen__ --loglevel warn
 
 say start integer-key contract test
 try pdo-test-contract --ledger ${PDO_LEDGER_URL} --contract integer-key \
     --pservice http://localhost:7001/ http://localhost:7002 http://localhost:7003 \
-    --eservice http://localhost:7101/ \
+    --eservice-url http://localhost:7101/ \
     --logfile __screen__ --loglevel warn
 
 say start key value store test
 try pdo-test-contract --ledger ${PDO_LEDGER_URL} --contract key-value-test \
     --pservice http://localhost:7001/ http://localhost:7002 http://localhost:7003 \
-    --eservice http://localhost:7101/ \
+    --eservice-url http://localhost:7101/ \
     --logfile __screen__ --loglevel warn
 
 say start memory test
 try pdo-test-contract --ledger ${PDO_LEDGER_URL} --contract memory-test \
     --pservice http://localhost:7001/ http://localhost:7002 http://localhost:7003 \
-    --eservice http://localhost:7101/ \
+    --eservice-url http://localhost:7101/ \
     --logfile __screen__ --loglevel warn
 
 ## -----------------------------------------------------------------
@@ -283,6 +297,65 @@ pdo-update --config ${CONFIG_FILE} --ledger ${PDO_LEDGER_URL} \
 if [ $? == 0 ]; then
     die mock contract test succeeded though it should have failed
 fi
+
+#-----------------------------------------
+yell run tests with the eservice database 
+#------------------------------------------
+  
+say run various pdo scripts - test-request, test-contract, create, update, shell - using database
+try pdo-test-request --eservice-name e1 --logfile $PDO_HOME/logs/client.log --loglevel info  
+try pdo-test-contract --contract integer-key --eservice-name e2 --logfile $PDO_HOME/logs/client.log --loglevel info 
+
+# make sure we have the necessary files in place
+CONFIG_FILE=${PDO_HOME}/etc/pcontract.toml
+if [ ! -f ${CONFIG_FILE} ]; then
+    die missing client configuration file, ${CONFIG_FILE}
+fi
+
+CONTRACT_FILE=${PDO_HOME}/contracts/_mock-contract.scm
+if [ ! -f ${CONTRACT_FILE} ]; then
+    die missing contract source file, ${CONTRACT_FILE}
+fi
+
+try pdo-create --config ${CONFIG_FILE} --ledger ${PDO_LEDGER_URL} \
+     --logfile $PDO_HOME/logs/client.log --loglevel info \
+    --identity user1 --save-file ${SAVE_FILE} \
+    --contract mock-contract --source _mock-contract.scm --eservice-name e1 e2 e3 
+
+# this will invoke the increment operation 5 times on each enclave round robin
+# fashion; the objective of this test is to ensure that the client touches
+# multiple, independent enclave services and pushes missing state correctly
+declare -i pcontract_es=3 #.see ../opt/pdo/etc/template/pcontract.toml
+declare -i n=$((NUM_SERVICES*pcontract_es)) e v value
+for v in $(seq 1 ${n}) ; do
+    e=$((v % pcontract_es + 1))
+    value=$(pdo-update --config ${CONFIG_FILE} --ledger ${PDO_LEDGER_URL} \
+                       --eservice-name e${e} \
+                       --logfile $PDO_HOME/logs/client.log --loglevel info \
+                       --identity user1 --save-file ${SAVE_FILE} \
+                       "'(inc-value)")
+    if [ $value != $v ]; then
+        die "contract has the wrong value ($value instead of $v) for enclave $e"
+    fi
+done
+
+KEYGEN=${SRCDIR}/build/__tools__/make-keys
+if [ ! -f ${PDO_HOME}/keys/red_type_private.pem ]; then
+    for color in red green blue ; do
+        ${KEYGEN} --keyfile ${PDO_HOME}/keys/${color}_type --format pem
+        ${KEYGEN} --keyfile ${PDO_HOME}/keys/${color}_vetting --format pem
+        ${KEYGEN} --keyfile ${PDO_HOME}/keys/${color}_issuer --format pem
+    done
+fi
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+try pdo-shell --logfile $PDO_HOME/logs/client.log --loglevel info  \
+    --eservice-name e1 e2 e3  -s ${SRCDIR}/contracts/exchange/scripts/create.psh -m color red 
+
+for p in $(seq 1 3); do
+    pdo-shell --logfile $PDO_HOME/logs/client.log --loglevel info \
+    --eservice-name e${p} -s ${SRCDIR}/contracts/exchange/scripts/issue.psh -m color red -m issuee user$p -m count $(($p * 10))
+done
 
 yell completed all tests
 exit 0

--- a/build/__tools__/run-tests.sh
+++ b/build/__tools__/run-tests.sh
@@ -118,18 +118,17 @@ try ${PDO_HOME}/bin/es-start.sh --count ${NUM_SERVICES} --ledger ${PDO_LEDGER_UR
 
 cd ${SRCDIR}/build
 
-
 say run unit level tests for eservice database 
 cd ${SRCDIR}/python/pdo/test
 try python servicedb.py --logfile $PDO_HOME/logs/client.log --loglevel info \
-    --eservice-db $PDO_HOME/data/db-test.json --url http://localhost:7101 http://localhost:7102 http://localhost:7103 --ledger ${PDO_LEDGER_URL}
+    --eservice-db $PDO_HOME/data/db-test.json --url http://localhost:7101/ http://localhost:7102/ http://localhost:7103/ --ledger ${PDO_LEDGER_URL}
 try rm $PDO_HOME/data/db-test.json
 
 cd ${SRCDIR}/build
 
 say create the eservice database using database CLI 
 # add all enclaves listed in pcontract.toml
-try pdo-eservicedb --command create --logfile $PDO_HOME/logs/client.log --loglevel info 
+try pdo-eservicedb --logfile $PDO_HOME/logs/client.log --loglevel info create
 
 # -----------------------------------------------------------------
 yell start tests without provisioning or enclave services

--- a/build/opt/pdo/etc/template/pcontract.toml
+++ b/build/opt/pdo/etc/template/pcontract.toml
@@ -31,6 +31,15 @@ LedgerURL = "${ledger}"
 
 PreferredEnclaveService = "http://127.0.0.1:7101"
 
+EnclaveServiceDatabaseFile = "${home}/data/eservice-db.json"
+
+EnclaveServiceNames = [
+    "e1",
+    "e2",
+    "e3"
+]
+
+
 EnclaveServiceURLs = [
     "http://127.0.0.1:7101",
     "http://127.0.0.1:7102",

--- a/client/pdo/client/controller/commands/contract.py
+++ b/client/pdo/client/controller/commands/contract.py
@@ -92,10 +92,8 @@ def load_contract(state, contract_file) :
 ## -----------------------------------------------------------------
 ## -----------------------------------------------------------------
 def get_contract(state, save_file=None) :
-    """create an enclave client for the preferred enclave service; assumes
-    exception handling by the calling procedure
-    """
-
+    """ Get contract object using the save_file. If there is no save_file, try loading contract using config."""
+   
     if save_file is not None :
         return load_contract(state, save_file)
 

--- a/client/pdo/client/controller/commands/create.py
+++ b/client/pdo/client/controller/commands/create.py
@@ -15,6 +15,7 @@
 import argparse
 import logging
 import random
+import sys
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +29,8 @@ from pdo.contract import register_contract
 from pdo.contract import add_enclave_to_contract
 from pdo.service_client.enclave import EnclaveServiceClient
 from pdo.service_client.provisioning import ProvisioningServiceClient
+import pdo.service_client.service_data.eservice as db
+
 
 __all__ = ['command_create']
 
@@ -134,17 +137,27 @@ def command_create(state, bindings, pargs) :
     logger.info('Loaded contract code for %s', contract_class)
 
     # ---------- set up the enclave clients ----------
-    try :
+    enclaveclients = []
+    enclave_names = state.get(['Service', 'EnclaveServiceNames'], [])
+    if len(enclave_names) > 0: #use the database to get the list of enclaves for the contract
+        logger.info('Using eservice database to look up service URL for the contract enclave')
+        try:
+            for name in enclave_names:
+                enclaveclients.append(db.get_client_by_name(name))
+        except Exception as e:
+            raise Exception('Unable to get the eservice clients using the eservice database: %s', str(e)) 
+            
+    else:
         eservice_urls = state.get(['Service', 'EnclaveServiceURLs'], [])
         if len(eservice_urls) == 0 :
             raise Exception('no enclave services specified')
+        try:
+            for url in eservice_urls :
+                enclaveclients.append(EnclaveServiceClient(url))
+        except Exception as e :
+            raise Exception('unable to contact enclave services; {0}'.format(str(e)))
 
-        enclaveclients = []
-        for url in eservice_urls :
-            enclaveclients.append(EnclaveServiceClient(url))
-    except Exception as e :
-        raise Exception('unable to contact enclave services; {0}'.format(str(e)))
-
+    
     # ---------- set up the provisioning service clients ----------
     # This is a dictionary of provisioning service public key : client pairs
     try :

--- a/client/pdo/client/controller/commands/create.py
+++ b/client/pdo/client/controller/commands/create.py
@@ -15,7 +15,6 @@
 import argparse
 import logging
 import random
-import sys
 
 logger = logging.getLogger(__name__)
 

--- a/client/pdo/client/controller/commands/send.py
+++ b/client/pdo/client/controller/commands/send.py
@@ -114,7 +114,7 @@ def command_send(state, bindings, pargs) :
     parser.add_argument('-s', '--symbol', help='Save the result in a symbol for later use', type=str)
     parser.add_argument('--wait', help='Wait for the transaction to commit', action = 'store_true')
     parser.add_argument('message', help='Message to be sent to the contract', type=str)
-            
+
     options = parser.parse_args(pargs)
     message = options.message
     waitflag = options.wait

--- a/client/pdo/client/controller/commands/send.py
+++ b/client/pdo/client/controller/commands/send.py
@@ -114,7 +114,7 @@ def command_send(state, bindings, pargs) :
     parser.add_argument('-s', '--symbol', help='Save the result in a symbol for later use', type=str)
     parser.add_argument('--wait', help='Wait for the transaction to commit', action = 'store_true')
     parser.add_argument('message', help='Message to be sent to the contract', type=str)
-        
+            
     options = parser.parse_args(pargs)
     message = options.message
     waitflag = options.wait

--- a/client/pdo/client/controller/commands/send.py
+++ b/client/pdo/client/controller/commands/send.py
@@ -15,6 +15,7 @@
 import argparse
 import random
 import logging
+import sys
 logger = logging.getLogger(__name__)
 
 from pdo.common.keys import ServiceKeys
@@ -22,6 +23,7 @@ from pdo.service_client.enclave import EnclaveServiceClient
 
 from pdo.client.controller.commands.contract import get_contract
 from pdo.client.controller.commands.eservice import get_enclave_service
+import pdo.service_client.service_data.eservice as db
 
 __all__ = ['command_send']
 
@@ -44,10 +46,20 @@ def send_to_contract(state, save_file, enclave, message, quiet=False, wait=False
         raise Exception('unable to load the contract')
 
     # ---------- set up the enclave service ----------
-    try :
-        enclave_client = get_enclave_service(state, enclave)
-    except Exception as e :
-        raise Exception('unable to connect to enclave service; {0}'.format(str(e)))
+    enclave_names = state.get(['Service', 'EnclaveServiceNames'], [])
+    if len(enclave_names) > 0: #use the database to get the list of enclaves for the contract
+        logger.info('Using eservice database to look up service URL for the contract enclave')
+        try:
+            eservice_to_use = random.choice(state.get(['Service', 'EnclaveServiceNames']))
+            enclave_client = db.get_client_by_name(eservice_to_use)
+        except Exception as e:
+            logger.exception('Unable to get the eservice clients using the eservice database: %s', str(e)) 
+            raise Exception from e
+    else:
+        try :
+            enclave_client = get_enclave_service(state, enclave)
+        except Exception as e :
+            raise Exception('unable to connect to enclave service; {0}'.format(str(e)))
 
     try :
         # this is just a sanity check to make sure the selected enclave
@@ -102,7 +114,7 @@ def command_send(state, bindings, pargs) :
     parser.add_argument('-s', '--symbol', help='Save the result in a symbol for later use', type=str)
     parser.add_argument('--wait', help='Wait for the transaction to commit', action = 'store_true')
     parser.add_argument('message', help='Message to be sent to the contract', type=str)
-
+        
     options = parser.parse_args(pargs)
     message = options.message
     waitflag = options.wait

--- a/client/pdo/client/scripts/CreateCLI.py
+++ b/client/pdo/client/scripts/CreateCLI.py
@@ -18,7 +18,6 @@ import os, sys
 import logging
 import argparse
 import random
-import json
 
 import pdo.common.config as pconfig
 import pdo.common.logger as plogger

--- a/client/pdo/client/scripts/CreateCLI.py
+++ b/client/pdo/client/scripts/CreateCLI.py
@@ -18,6 +18,7 @@ import os, sys
 import logging
 import argparse
 import random
+import json
 
 import pdo.common.config as pconfig
 import pdo.common.logger as plogger
@@ -32,6 +33,7 @@ from pdo.contract import register_contract
 from pdo.contract import add_enclave_to_contract
 from pdo.service_client.enclave import EnclaveServiceClient
 from pdo.service_client.provisioning import ProvisioningServiceClient
+import pdo.service_client.service_data.eservice as db
 
 logger = logging.getLogger(__name__)
 
@@ -133,14 +135,32 @@ def LocalMain(commands, config) :
     logger.info('Loaded contract data for %s', contract_name)
 
     # ---------- set up the enclave clients ----------
-    try :
-        enclaveclients = []
-        for url in service_config['EnclaveServiceURLs'] :
-            enclaveclients.append(EnclaveServiceClient(url))
-    except Exception as e :
-        logger.error('unable to setup enclave services; %s', str(e))
-        sys.exit(-1)
 
+    enclaveclients = []
+    if service_config.get('EnclaveServiceNames'): #use the database to get the list of enclaves for the contract
+        logger.info('Using eservice database to look up service URL for the contract enclave')
+        try:
+            # load the eservice database
+            if os.path.exists(service_config['EnclaveServiceDatabaseFile']):
+                try:
+                    db.load_database(service_config['EnclaveServiceDatabaseFile'])
+                except Exception as e:
+                    logger.error('Error loading eservice database %s', str(e))
+                    sys.exit(-1)
+            for name in service_config['EnclaveServiceNames']:
+                enclaveclients.append(db.get_client_by_name(name))
+        except Exception as e:
+            logger.error('Unable to get the eservice clients using the eservice database: %s', str(e)) 
+            sys.exit(-1)   
+    else: # do not use the database
+        try :
+            for url in service_config['EnclaveServiceURLs'] :
+                enclaveclients.append(EnclaveServiceClient(url))
+        except Exception as e :
+            logger.error('unable to setup enclave services; %s', str(e))
+            sys.exit(-1)
+
+    
     # ---------- set up the provisioning service clients ----------
     # This is a dictionary of provisioning service public key : client pairs
     try :
@@ -243,9 +263,11 @@ def Main(commands) :
     parser.add_argument('--data-dir', help='Path for storing generated files', type=str)
     parser.add_argument('--source-dir', help='Directories to search for contract source', nargs='+', type=str)
 
+    parser.add_argument('--eservice-db', help='json file for eservice database', type=str)
+    parser.add_argument('--eservice-name', help='List of enclave services to use. Give names as in database', nargs='+')
     parser.add_argument('--eservice-url', help='List of enclave service URLs to use', nargs='+')
     parser.add_argument('--pservice-url', help='List of provisioning service URLs to use', nargs='+')
-
+    
     options = parser.parse_args()
 
     # first process the options necessary to load the default configuration
@@ -290,14 +312,23 @@ def Main(commands) :
     if options.ledger :
         config['Sawtooth']['LedgerURL'] = options.ledger
 
-    # set up the service configuration
+   # set up the service configuration
     if config.get('Service') is None :
         config['Service'] = {
+            'EnclaveServiceNames' : [],
             'EnclaveServiceURLs' : [],
-            'ProvisioningServiceURLs' : []
+            'ProvisioningServiceURLs' : [],
+            'EnclaveServiceDatabaseFile' : None
         }
+
+    if options.eservice_name:
+        config['Service']['EnclaveServiceNames'] = options.eservice_name
+    if options.eservice_db:
+        config['Service']['EnclaveServiceDatabaseFile'] = options.eservice_db
     if options.eservice_url :
         config['Service']['EnclaveServiceURLs'] = options.eservice_url
+        # if url is provided, we will not use database
+        config['Service']['EnclaveServiceNames'] = []
     if options.pservice_url :
         config['Service']['ProvisioningServiceURLs'] = options.pservice_url
 

--- a/client/pdo/client/scripts/ShellCLI.py
+++ b/client/pdo/client/scripts/ShellCLI.py
@@ -197,7 +197,7 @@ def Main() :
         config['Contract']['DataDirectory'] = options.data_dir
     if options.source_dir :
         config['Contract']['SourceSearchPath'] = options.source_dir
-    
+        
     putils.set_default_data_directory(config['Contract']['DataDirectory'])
 
     if options.script :

--- a/client/pdo/client/scripts/ShellCLI.py
+++ b/client/pdo/client/scripts/ShellCLI.py
@@ -22,12 +22,22 @@ logger = logging.getLogger(__name__)
 
 from pdo.client.controller.contract_controller import ContractController
 import pdo.common.utility as putils
+import pdo.service_client.service_data.eservice as db
 
 ## -----------------------------------------------------------------
 ## -----------------------------------------------------------------
 def LocalMain(config) :
     shell = ContractController(config)
 
+    # load the eservice database
+    if  os.path.exists(config['Service']['EnclaveServiceDatabaseFile']):
+        try:
+            db.load_database(config['Service']['EnclaveServiceDatabaseFile'])
+            logger.info('Loading the eservice database from json file %s', str(config['Service']['EnclaveServiceDatabaseFile']))
+        except Exception as e:
+            logger.error('Error loading eservice database %s', str(e))
+            sys.exit(-1)
+    
     # load the bindings specified in the configuration
     for (key, val) in config.get("VariableMap", {}).items() :
         shell.bindings.bind(key, val)
@@ -95,6 +105,8 @@ def Main() :
     parser.add_argument('--source-dir', help='Directories to search for contract source', nargs='+', type=str)
     parser.add_argument('--key-dir', help='Directories to search for key files', nargs='+')
 
+    parser.add_argument('--eservice-db', help='json file for eservice database', type=str)
+    parser.add_argument('--eservice-name', help='List of enclave services to use. Give names as in database', nargs='+')
     parser.add_argument('--eservice-url', help='List of enclave service URLs to use', nargs='+')
     parser.add_argument('--pservice-url', help='List of provisioning service URLs to use', nargs='+')
 
@@ -154,14 +166,23 @@ def Main() :
     if options.key_dir :
         config['Key']['SearchPath'] = options.key_dir
 
-    # set up the service configuration
+   # set up the service configuration
     if config.get('Service') is None :
         config['Service'] = {
+            'EnclaveServiceNames' : [],
             'EnclaveServiceURLs' : [],
-            'ProvisioningServiceURLs' : []
+            'ProvisioningServiceURLs' : [],
+            'EnclaveServiceDatabaseFile' : None
         }
+
+    if options.eservice_name:
+        config['Service']['EnclaveServiceNames'] = options.eservice_name
+    if options.eservice_db:
+        config['Service']['EnclaveServiceDatabaseFile'] = options.eservice_db
     if options.eservice_url :
         config['Service']['EnclaveServiceURLs'] = options.eservice_url
+        # we will not use database
+        config['Service']['EnclaveServiceNames'] = []
     if options.pservice_url :
         config['Service']['ProvisioningServiceURLs'] = options.pservice_url
 
@@ -176,7 +197,7 @@ def Main() :
         config['Contract']['DataDirectory'] = options.data_dir
     if options.source_dir :
         config['Contract']['SourceSearchPath'] = options.source_dir
-
+    
     putils.set_default_data_directory(config['Contract']['DataDirectory'])
 
     if options.script :

--- a/client/pdo/client/scripts/ShellCLI.py
+++ b/client/pdo/client/scripts/ShellCLI.py
@@ -197,7 +197,7 @@ def Main() :
         config['Contract']['DataDirectory'] = options.data_dir
     if options.source_dir :
         config['Contract']['SourceSearchPath'] = options.source_dir
-        
+
     putils.set_default_data_directory(config['Contract']['DataDirectory'])
 
     if options.script :

--- a/client/pdo/client/scripts/UpdateCLI.py
+++ b/client/pdo/client/scripts/UpdateCLI.py
@@ -18,7 +18,6 @@ import argparse
 import os
 import sys
 import random
-
 import logging
 logger = logging.getLogger(__name__)
 
@@ -26,6 +25,7 @@ import pdo.common.utility as putils
 from pdo.contract import Contract
 from pdo.common.keys import ServiceKeys
 from pdo.service_client.enclave import EnclaveServiceClient
+import pdo.service_client.service_data.eservice as db
 
 ## -----------------------------------------------------------------
 ## -----------------------------------------------------------------
@@ -56,6 +56,7 @@ class InputIterator(object) :
             return input(self.Prompt)
         except EOFError as e :
             raise StopIteration
+
 
 ## -----------------------------------------------------------------
 ## -----------------------------------------------------------------
@@ -97,20 +98,38 @@ def LocalMain(config, message) :
         sys.exit(-1)
 
     # ---------- set up the enclave service ----------
-    try :
-        enclave_url = service_config['PreferredEnclaveService']
-        enclave_client = EnclaveServiceClient(enclave_url)
-        logger.info('contact enclave service at %s', enclave_url)
-    except KeyError as ke :
-        logger.error('missing configuration parameter %s', str(ke))
-        sys.exit(-1)
-    except Exception as e :
-        logger.error('unable to connect to enclave service; %s', str(e))
-        sys.exit(-1)
+    if service_config.get('EnclaveServiceNames'): #use the database to get the enclave for the contract
+        logger.info('Using eservice database to look up service URL for the contract enclave')
+        try:
+            eservice_to_use = random.choice(service_config['EnclaveServiceNames'])
+            # load the eservice database
+            if os.path.exists(service_config['EnclaveServiceDatabaseFile']):
+                try:
+                    db.load_database(service_config['EnclaveServiceDatabaseFile'])
+                except Exception as e:
+                    logger.error('Error loading eservice database %s', str(e))
+                    sys.exit(-1)
+            enclave_client = db.get_client_by_name(eservice_to_use)
+        except Exception as e:
+            logger.error('Unable to get the eservice client using the eservice database: %s', str(e)) 
+            sys.exit(-1)   
+    else:
+        try:
+            enclave_url = service_config['PreferredEnclaveService'] 
+        except Exception as e:
+            logger.error('missing configuration parameter %s', str(ke))
+            sys.exit(-1)
+        try :
+            enclave_client = EnclaveServiceClient(enclave_url)
+        except Exception as e :
+            logger.error('unable to connect to enclave service; %s', str(e))
+            sys.exit(-1)
+        
+    logger.info('contact enclave service at %s', enclave_client.ServiceURL)
 
     try :
         # this is just a sanity check to make sure the selected enclave
-        # has actually been provisioned
+        # has actually been provisioned.
         contract.get_state_encryption_key(enclave_client.enclave_id)
     except KeyError as ke :
         logger.error('selected enclave is not provisioned')
@@ -217,7 +236,9 @@ def Main() :
     parser.add_argument('--data-dir', help='Path for storing generated files', type=str)
     parser.add_argument('--source-dir', help='Directories to search for contract source', nargs='+', type=str)
 
-    parser.add_argument('--enclave', help='URL of the enclave service to use, or random to pick one randomly', type=str)
+    parser.add_argument('--eservice-name', help='List of enclave services to use. Give names as in database.', nargs='+')
+    parser.add_argument('--enclave', help='URL of the enclave service to use, or say "random" to pick one randomly from pcontract.toml', type=str)
+    parser.add_argument('--eservice-db', help='json file for eservice database', type=str)
 
     parser.add_argument('message', help="Message to evaluate", type=str)
 
@@ -263,16 +284,27 @@ def Main() :
     if options.ledger :
         config['Sawtooth']['LedgerURL'] = options.ledger
 
-    # make sure we have an enclave
+    # set up the service configuration
     if config.get('Service') is None :
         config['Service'] = {
-            'PreferredEnclaveService' : 'http://locahost:7001'
+            'EnclaveServiceNames' : [],
+            'PreferredEnclaveService' : 'http://127.0.0.1:7101',
+            'EnclaveServiceURLs' : [],
+            'ProvisioningServiceURLs' : [],
+            'EnclaveServiceDatabaseFile' : None
         }
+    
+    if options.eservice_name:
+        config['Service']['EnclaveServiceNames'] = options.eservice_name
+    if options.eservice_db:
+        config['Service']['EnclaveServiceDatabaseFile'] = options.eservice_db    
     if options.enclave :
         if options.enclave == 'random' :
             options.enclave = random.choice(config['Service'].get('EnclaveServiceURLs',['http://localhost:7001']))
         config['Service']['PreferredEnclaveService'] = options.enclave
-
+        # we will not use database
+        config['Service']['EnclaveServiceNames'] = []
+    
     # set up the key search paths
     if config.get('Key') is None :
         config['Key'] = {

--- a/client/pdo/client/scripts/UpdateCLI.py
+++ b/client/pdo/client/scripts/UpdateCLI.py
@@ -57,7 +57,6 @@ class InputIterator(object) :
         except EOFError as e :
             raise StopIteration
 
-
 ## -----------------------------------------------------------------
 ## -----------------------------------------------------------------
 def LocalMain(config, message) :
@@ -129,7 +128,7 @@ def LocalMain(config, message) :
 
     try :
         # this is just a sanity check to make sure the selected enclave
-        # has actually been provisioned.
+        # has actually been provisioned
         contract.get_state_encryption_key(enclave_client.enclave_id)
     except KeyError as ke :
         logger.error('selected enclave is not provisioned')

--- a/client/pdo/client/scripts/__init__.py
+++ b/client/pdo/client/scripts/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__all__ = [ 'controller', 'AuctionTestCLI', 'CreateCLI', 'UpdateCLI' ]
+__all__ = [ 'controller', 'AuctionTestCLI', 'CreateCLI', 'UpdateCLI', 'eservicedatabaseCLI' ]

--- a/client/pdo/client/scripts/eservicedatabaseCLI.py
+++ b/client/pdo/client/scripts/eservicedatabaseCLI.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python
+
+# Copyright 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+ 
+import os
+import sys
+
+import argparse
+import logging
+logger = logging.getLogger(__name__)
+
+import pdo.common.config as pconfig
+import pdo.common.logger as plogger
+
+import pdo.service_client.service_data.eservice as db
+
+import argparse
+
+def Add_entries(config):
+    """ Add entries to database. Return number of entries added"""
+
+    ledger_config = config['Sawtooth']
+
+    #make sure that there are names for each of the new eservice to add
+    if len(config['Service']['EnclaveServiceNames']) < len(config['Service']['EnclaveServiceURLs']):
+        logger.error('Please provide a name for each eservice to be added to the database')
+        sys.exit(-1)
+
+    names = config['Service']['EnclaveServiceNames']
+    urls = config['Service']['EnclaveServiceURLs']
+
+     # add entries to db
+    for index, url in enumerate(urls):
+        try :
+            db.add_info_to_database(names[index], url, ledger_config)
+        except Exception as e:
+            logger.error('Error adding new entry for url %s: %s', str(url), str(e))
+            sys.exit(-1)
+    
+    # save as json file
+    try:
+        db.save_database(config['Service']['EnclaveServiceDatabaseFile'], overwrite = True)
+    except Exception as e:
+        logger.error('Unable to create new database. Failed to save as json file : %s ', str(e))
+        sys.exit(-1)
+    
+    num_entries_added = len(urls)
+    return num_entries_added
+
+
+def LocalMain(command, config) :
+
+    if command=='create' :
+        
+        #create an empty db
+        db.clear_all_data()
+        num_entries_added= Add_entries(config)
+        logger.info('Created a new database with  %d entries.',  num_entries_added)
+
+    elif command ==  'add':
+        
+        # load the db to which you want to add to, reload & merge does not hurt
+        db.load_database(config['Service']['EnclaveServiceDatabaseFile'], merge = True)
+        num_entries_added= Add_entries(config)
+        logger.info('Added %d entries to the database', num_entries_added)
+
+    elif command =='update':
+        # names are optional. However, if the name field is nonempty, must provide names for all urls.
+        # if name is provided, will update the url of the entry corresponding name to input url, and also update the service_id
+        # if only url is provided, will update the service_id
+
+        
+        # load the db from which you want to update
+        db.load_database(config['Service']['EnclaveServiceDatabaseFile'], merge = True)
+        
+        ledger_config = config['Sawtooth']
+        num_updated = 0
+        urls = config['Service']['EnclaveServiceURLs']
+        names = []
+
+        if config['Service'].get('EnclaveServiceNames'):
+            names = config['Service']['EnclaveServiceNames']
+            if len(config['Service']['EnclaveServiceNames']) < len(config['Service']['EnclaveServiceURLs']):
+                logger.error('Please provide a name for each eservice to be updated to the database.')
+                sys.exit(-1)
+                
+        for index, url in enumerate(urls):
+                        
+            if len(names) > 0: # you are possibly changing the url for the name as well
+                info_old = db.get_info_by_name(names[index])
+                if not db.update_info_in_database(names[index], url, ledger_config):
+                    logger.error('Failed to update info for name %s and url %s', str(names[index]), str(url) ) 
+                    sys.exit(-1)
+                info_new = db.get_info_by_name(names[index])
+            else:
+                info_old = db.get_info_by_url(url)
+                if not db.update_info_in_database(info_old['name'], url, ledger_config):
+                    logger.error('Failed to update info for url %s', str(url) ) 
+                    sys.exit(-1)
+                info_new = db.get_info_by_name(name = info_old['name'])
+                       
+            num_updated += int(info_old != info_new)
+
+        # save as json file
+        try:
+            db.save_database(config['Service']['EnclaveServiceDatabaseFile'], overwrite = True)
+        except Exception as e:
+            logger.error('Unable to update entries: Failed to save as json file %s', str(e))
+            sys.exit(-1)
+        
+        logger.info('Updated %d entries in the database', num_updated)
+    
+    elif command=='remove':
+        # removes all entries corresponding to names and urls
+        
+        # load the db from which you want to remove
+        db.load_database(config['Service']['EnclaveServiceDatabaseFile'], merge = True)
+        
+        num_removed = 0 
+
+        if config['Service'].get('EnclaveServiceNames'):
+            names = config['Service']['EnclaveServiceNames']
+            for name in names:
+                num_removed += db.remove_info_from_database(name = name)
+        
+        if config['Service'].get('EnclaveServiceURLs'):
+            urls = config['Service']['EnclaveServiceURLs']
+            for url in urls:
+                num_removed +=  db.remove_info_from_database(url = url)
+
+        # save as json file
+        try:
+            db.save_database(config['Service']['EnclaveServiceDatabaseFile'], overwrite = True)
+        except Exception as e:
+            logger.error('Unable to Remove entries: Failed to save as json file %s', str(e))
+            sys.exit(-1)
+
+        logger.info('Removed %d  entries from the database', num_removed)
+    
+    else:
+        logger.error('Unsupported database command')
+        sys.exit(-1)
+    
+    sys.exit(0)
+
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+## DO NOT MODIFY BELOW THIS LINE
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+ContractHost = os.environ.get("HOSTNAME", "localhost")
+ContractHome = os.environ.get("PDO_HOME") or os.path.realpath("/opt/pdo")
+ContractEtc = os.path.join(ContractHome, "etc")
+ContractKeys = os.path.join(ContractHome, "keys")
+ContractLogs = os.path.join(ContractHome, "logs")
+ContractData = os.path.join(ContractHome, "data")
+LedgerURL = os.environ.get("PDO_LEDGER_URL", "http://127.0.0.1:8008/")
+ScriptBase = os.path.splitext(os.path.basename(sys.argv[0]))[0]
+
+config_map = {
+    'base' : ScriptBase,
+    'data' : ContractData,
+    'etc'  : ContractEtc,
+    'home' : ContractHome,
+    'host' : ContractHost,
+    'keys' : ContractKeys,
+    'logs' : ContractLogs,
+    'ledger' : LedgerURL
+}
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+def Main() :
+    # parse out the configuration file first
+    conffiles = [ 'pcontract.toml' ]
+    confpaths = [ ".", "./etc", ContractEtc ]
+
+    parser = argparse.ArgumentParser()
+    
+    parser.add_argument('--config', help='configuration file', nargs = '+')
+    parser.add_argument('--config-dir', help='configuration file', nargs = '+')
+    parser.add_argument('--command', help='database command to execute : Chose one from {create, add, remove, update}', required=True, type=str)
+    parser.add_argument('--eservice-url', help='service urls',  nargs='+')
+    parser.add_argument('--eservice-name', help='service names',  nargs='+')
+    parser.add_argument('--eservice-db', help='json file for database', type=str)
+    parser.add_argument('--loglevel', help='Set the logging level', default='INFO')
+    parser.add_argument('--logfile', help='Name of the log file', default='__screen__')
+    parser.add_argument('--ledger', help='Ledger URL', type=str)
+
+    options = parser.parse_args()
+
+    # first process the options necessary to load the default configuration
+    if options.config :
+        conffiles = options.config
+
+    if options.config_dir :
+        confpaths = options.config_dir
+
+    global config_map
+    
+    try :
+        config = pconfig.parse_configuration_files(conffiles, confpaths, config_map)
+    except pconfig.ConfigurationException as e :
+        logger.error(str(e))
+        sys.exit(-1)
+
+    # set up the logging configuration
+    if config.get('Logging') is None :
+        config['Logging'] = {
+            'LogFile' : '__screen__',
+            'LogLevel' : 'INFO'
+        }
+    if options.logfile :
+        config['Logging']['LogFile'] = options.logfile
+    if options.loglevel :
+        config['Logging']['LogLevel'] = options.loglevel.upper()
+
+    plogger.setup_loggers(config.get('Logging', {}))
+
+    # process the reset of the command parameters
+
+    # set up the service configuration
+    if config.get('Service') is None :
+        config['Service'] = {
+            'EnclaveServiceURLs' : [],
+            'EnclaveServiceNames' : [],
+            'EnclaveServiceDatabaseFile' : None
+        }
+
+    if options.eservice_db:
+        config['Service']['EnclaveServiceDatabaseFile'] = options.eservice_db
+
+    if options.eservice_url :
+        config['Service']['EnclaveServiceURLs'] = options.eservice_url
+    elif options.command == 'remove' or options.command == 'update' or options.command == 'add':
+        config['Service']['EnclaveServiceURLs'] = []
+    
+    if options.eservice_name :
+        config['Service']['EnclaveServiceNames'] = options.eservice_name
+    elif options.command == 'remove' or options.command == 'update' or options.command == 'add':
+        config['Service']['EnclaveServiceNames'] = []
+    
+    # set up the ledger configuration
+    if config.get('Sawtooth') is None :
+        config['Sawtooth'] = {
+            'LedgerURL' : 'http://localhost:8008',
+        }
+    if options.ledger :
+        config['Sawtooth']['LedgerURL'] = options.ledger
+    
+    # GO!!!
+    LocalMain(options.command, config)
+
+## -----------------------------------------------------------------
+## Entry points
+## -----------------------------------------------------------------
+Main()

--- a/client/setup.py
+++ b/client/setup.py
@@ -65,6 +65,7 @@ setup(name='pdo_client',
               'pdo-add-enclave = pdo.client.scripts.CreateCLI:AddEnclave',
               'pdo-update = pdo.client.scripts.UpdateCLI:Main',
               'pdo-shell = pdo.client.scripts.ShellCLI:Main',
+              'pdo-eservicedb = pdo.client.scripts.eservicedatabaseCLI:Main'
           ]
       }
 )

--- a/eservice/docs/database.md
+++ b/eservice/docs/database.md
@@ -1,0 +1,59 @@
+<!---
+Licensed under Creative Commons Attribution 4.0 International License
+https://creativecommons.org/licenses/by/4.0/
+--->
+
+A client may maintain a local eservice database that maps known enclave_ids to the corresponding URLs of the hosting eservcies. The database
+can be shared across multiple contracts by the same client. The client maitains database as a json file with each entry being a (key, value). key is a short name for the service, value is a dictonary with entries for 'id' and 'url'. 'id' denotes the id of the enclave hosted by the eservice. 
+
+Database management is possible via command line using the shell command pdo-eservicedb. Options include create, add, update and remove. The default service_db file name is picked from pcontract.toml. For create, the urls and names are also picked from toml. Any command line option will however override the values in pcontract.toml. For add, update, remove, the urls and names must be provided via command line. The values in toml are not used to prevent inadvertent behaviour. 
+
+Name, id (enclave_id) and url are all synonyms for a given eservice. Exceptions will be raised (especially during information retrieval) if there are violations. To fix a broken database, use the remove command to remove multiple or replicated entries for a given identifier from the database. After remove, use the add command to add a unique entry for a given identifier.
+
+Usage Examples:
+
+# Create a new database with 2 entires. The name e1 (e2) gets assocaited with first (second) url. It is assumed that the json file does not exist previously, else creation will fail. The enclave_id will be automatically populated, as long as the eservice@url hosts an enclave
+pdo-eservicedb --command create --eservice-url http://localhost:7101 http://localhost:7102 --eservice-name e1 e2 
+
+# Add a new entry to the database. The enclave_id will be automatically populated, as long as the eservice@url hosts an enclave
+pdo-eservicedb --command add --eservice-url http://localhost:7103 --eservice-name e3 
+
+# Remove an entry by name from the database. In the below command, an empty field is passed to --eservice-url. This is to override any url values that might be present in the pcontract.toml, so that one does not inadvertently remove an entry from the database 
+pdo-eservicedb --command remove  --eservice-name e3 
+
+# Remove an entry by url from the database. 
+pdo-eservicedb --command remove   --eservice-url http://localhost:7102 
+
+# Update an entry by name. The url associated with name will replaced with the new url. The enclave_id will be updated as well 
+pdo-eservicedb --command update --eservice-name e1 --eservice-url http://localhost:7102  
+
+# update an entry by url. Use this to update the enclave_id corresponding to eservice@url
+pdo-eservicedb --command update  --eservice-url http://localhost:7102  
+
+Pdo test scripts can take advantage of the database to identify an enclave for running the contract. It is enough to provide the eservice name and json file as options. The exact policy for provisioning or chosing enclaves (if more than one name is passed as input) is outside the scope of the database manager functionality. This gets implemeneted as part of the specific test script, see the individual test script for details.
+
+Usage Examples:
+
+# run mock contract contract with test-request. Contract enclave is provisioned @ e1
+pdo-test-request --no-ledger  --eservice-name e1 
+
+# run interger key contract with test-contract. Contract enclave is provisioned @ e2
+pdo-test-contract --no-ledger --contract integer-key --eservice-name e2  
+
+# create a new mock-contract with pdo-create. Provision three enclaves @e1, e2, e3 to contract 
+pdo-create --config ${CONFIG_FILE} --ledger ${PDO_LEDGER_URL} \
+     --identity user1 --save-file ${SAVE_FILE} \
+    --contract mock-contract --source _mock-contract.scm --eservice-name e1 e2 e3 
+
+#update a previously created mock contract. Use enclave @ e3 to run the contract
+pdo-update --config ${CONFIG_FILE} --ledger ${PDO_LEDGER_URL} \
+                       --identity user1 --save-file ${SAVE_FILE} 
+                       --eservice-name e3   "'(inc-value)"
+
+# create a contrac via the pdo-shell. Provision 5 encalves@e1, e2, e3, e4, e5 for the contract
+pdo-shell --ledger $PDO_LEDGER_URL --eservice-name e1 e2 e3 e4 e5  \
+    -s ${SRCDIR}/contracts/exchange/scripts/create.psh -m color red 
+
+# update a contract via the pdo-shell. Use enclave@e4 to run the contract
+pdo-shell --ledger $PDO_LEDGER_URL --eservice-name e${p}  \ 
+    -s ${SRCDIR}/contracts/exchange/scripts/issue.psh -m color red -m issuee user$p -m count $(($p * 10))

--- a/eservice/docs/database.md
+++ b/eservice/docs/database.md
@@ -18,7 +18,7 @@ pdo-eservicedb create --eservice-url http://localhost:7101 http://localhost:7102
 # Add a new entry to the database. The enclave_id will be automatically populated, as long as the eservice@url hosts an enclave
 pdo-eservicedb add --eservice-url http://localhost:7103 --eservice-name e3 
 
-# Remove an entry by name from the database. In the below command, an empty field is passed to --eservice-url. This is to override any url values that might be present in the pcontract.toml, so that one does not inadvertently remove an entry from the database 
+# Remove an entry by name from the database.
 pdo-eservicedb remove  --eservice-name e3 
 
 # Remove an entry by url from the database. 
@@ -30,7 +30,7 @@ pdo-eservicedb update --eservice-name e1 --eservice-url http://localhost:7102
 # update an entry by url. Use this to update the enclave_id corresponding to eservice@url
 pdo-eservicedb update  --eservice-url http://localhost:7102  
 
-Pdo test scripts can take advantage of the database to identify an enclave for running the contract. It is enough to provide the eservice name and json file as options. The exact policy for provisioning or chosing enclaves (if more than one name is passed as input) is outside the scope of the database manager functionality. This gets implemeneted as part of the specific test script, see the individual test script for details.
+Pdo test scripts can take advantage of the database to identify an enclave for running the contract. It is enough to provide the name(s) of the eservice(s) to be used for the contract. The exact policy for provisioning or chosing enclaves (if more than one name is passed as input) is outside the scope of the database manager functionality. This gets implemeneted as part of the specific test script, see the individual test script for details.
 
 Usage Examples:
 

--- a/eservice/docs/database.md
+++ b/eservice/docs/database.md
@@ -13,22 +13,22 @@ Name, id (enclave_id) and url are all synonyms for a given eservice. Exceptions 
 Usage Examples:
 
 # Create a new database with 2 entires. The name e1 (e2) gets assocaited with first (second) url. It is assumed that the json file does not exist previously, else creation will fail. The enclave_id will be automatically populated, as long as the eservice@url hosts an enclave
-pdo-eservicedb --command create --eservice-url http://localhost:7101 http://localhost:7102 --eservice-name e1 e2 
+pdo-eservicedb create --eservice-url http://localhost:7101 http://localhost:7102 --eservice-name e1 e2 
 
 # Add a new entry to the database. The enclave_id will be automatically populated, as long as the eservice@url hosts an enclave
-pdo-eservicedb --command add --eservice-url http://localhost:7103 --eservice-name e3 
+pdo-eservicedb add --eservice-url http://localhost:7103 --eservice-name e3 
 
 # Remove an entry by name from the database. In the below command, an empty field is passed to --eservice-url. This is to override any url values that might be present in the pcontract.toml, so that one does not inadvertently remove an entry from the database 
-pdo-eservicedb --command remove  --eservice-name e3 
+pdo-eservicedb remove  --eservice-name e3 
 
 # Remove an entry by url from the database. 
-pdo-eservicedb --command remove   --eservice-url http://localhost:7102 
+pdo-eservicedb remove   --eservice-url http://localhost:7102 
 
 # Update an entry by name. The url associated with name will replaced with the new url. The enclave_id will be updated as well 
-pdo-eservicedb --command update --eservice-name e1 --eservice-url http://localhost:7102  
+pdo-eservicedb update --eservice-name e1 --eservice-url http://localhost:7102  
 
 # update an entry by url. Use this to update the enclave_id corresponding to eservice@url
-pdo-eservicedb --command update  --eservice-url http://localhost:7102  
+pdo-eservicedb update  --eservice-url http://localhost:7102  
 
 Pdo test scripts can take advantage of the database to identify an enclave for running the contract. It is enough to provide the eservice name and json file as options. The exact policy for provisioning or chosing enclaves (if more than one name is passed as input) is outside the scope of the database manager functionality. This gets implemeneted as part of the specific test script, see the individual test script for details.
 

--- a/eservice/docs/test-scripts.md
+++ b/eservice/docs/test-scripts.md
@@ -98,8 +98,11 @@ the configuration file
 * ``--data <string>`` -- path to directory used for storing data
 * ``--secret-count <integer>`` -- number of secrets to generate if no
   provision service is used
-* ``--eservice <string>`` -- URL for the enclave service
+* ``--eservice-url <string>`` -- URL for the enclave service
 * ``--pservice <string> <string> ...`` -- list of URLs for provisioning
+  ``--eservice-db`` -- json file for eservice database
+  ``--eservice-name`` -- the name of an enclave service as in the client's eservice database 
+
   services
 * ``--logfile <string>`` -- name of the log file to use, ``__screen__``
   dumps the log to the console
@@ -187,4 +190,5 @@ $ python test-request.py --ledger http://localhost:8008 \
     --pservice http://localhost:7101 http://localhost:7102 \
     --eservice http://localhost:7001 \
     --iterations 500
+
 ```

--- a/python/pdo/common/utility.py
+++ b/python/pdo/common/utility.py
@@ -22,13 +22,16 @@ before logging is enabled.
 import os
 import errno
 import pdo.common.crypto as crypto
+import socket
+from urllib.parse import urlparse
 
 __all__ = [
     'set_default_data_directory',
     'build_simple_file_name',
     'build_file_name',
     'find_file_in_path',
-    'from_transaction_signature_to_id'
+    'from_transaction_signature_to_id',
+    'are_the_urls_same'
     ]
 
 __DefaultDataDirectory__ = './data'
@@ -115,3 +118,31 @@ def from_transaction_signature_to_id(transaction_signature) :
     """
     id = crypto.byte_array_to_base64(crypto.compute_message_hash(crypto.hex_to_byte_array(transaction_signature)))
     return id
+
+#--------------------------------------------------------------------
+#--------------------------------------------------------------------
+def are_the_urls_same(url1, url2):
+    """Though not a perfect comparison, we make make sure that 
+    http://127.0.0.1:7101/ and http://localhost:7101 are considered the same. 
+    It would be good to first check  if the input is a valid url itself."""
+
+    if url1 is None or url2 is None:
+        return False
+    
+    if (url1 == url2):
+        return True
+
+    url1_parse = urlparse(url1)
+    url2_parse = urlparse(url2)
+
+    url1_hostname_and_port = url1_parse.netloc.split(':')
+    url2_hostname_and_port = url2_parse.netloc.split(':')
+
+    url1_ip = socket.gethostbyname(url1_hostname_and_port[0])
+    url2_ip = socket.gethostbyname(url2_hostname_and_port[0])
+
+    # check ip, port and scheme
+    if url1_ip == url2_ip and url1_hostname_and_port[1] == url2_hostname_and_port[1] and url1_parse.scheme == url2_parse.scheme:
+        return True
+
+    return False

--- a/python/pdo/service_client/__init__.py
+++ b/python/pdo/service_client/__init__.py
@@ -16,5 +16,6 @@ all = [
     'enclave',
     'generic',
     'provisioning',
-    'storage'
+    'storage',
+    'servicedatabase'
 ]

--- a/python/pdo/service_client/service_data/__init__.py
+++ b/python/pdo/service_client/service_data/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = [ 'eservice']

--- a/python/pdo/service_client/service_data/eservice.py
+++ b/python/pdo/service_client/service_data/eservice.py
@@ -279,14 +279,15 @@ def get_info_by_id(id):
 def get_info_by_url(url):
     """ Get service info as present in database using url. Returns a dictonary with four fields:
     name, id, url, last_verified_time. Return None if there is no matching entry. """
-
-    if __name_by_url__.get(url):
-        name = __name_by_url__[url]
-        info = copy.deepcopy(__data__[name])
-        info['name'] = name
-        return info
-    else:
-        return None
+    
+    for url_in_db in __name_by_url__.keys():
+        if are_the_urls_same(url_in_db, url):
+            name = __name_by_url__[url_in_db]
+            info = copy.deepcopy(__data__[name])
+            info['name'] = name
+            return info
+    
+    return None
 
 #--------------------------------------------
 #--------------------------------------------

--- a/python/pdo/service_client/service_data/eservice.py
+++ b/python/pdo/service_client/service_data/eservice.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python
+
+# Copyright 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import json
+import copy
+import shutil
+import datetime
+
+import logging
+logger = logging.getLogger(__name__)
+
+from sawtooth.helpers.pdo_connect import PdoClientConnectHelper
+from sawtooth.helpers.pdo_connect import ClientConnectException
+from pdo.service_client.enclave import EnclaveServiceClient
+from pdo.common.utility import are_the_urls_same
+import pdo.common.keys as keys
+
+# primary
+__data__ = dict()
+# dervived 
+__url_by_name__ = dict()
+__id_by_name__ = dict()
+__name_by_url__ = dict()
+__name_by_id__ = dict()
+
+
+def clear_all_data():
+    """ clear all dictonaries. Useful to create a fresh database."""
+   
+    global __data__
+
+    __data__ = dict()
+    update_dictionaries(__data__, merge=False)
+
+def load_database(filename, merge = True):
+    
+    global __data__
+    
+    if os.path.exists(filename):
+        try:
+            with open(filename, 'r') as fp:
+                new_data = json.load(fp)
+        except Exception as e:
+            logger.exception('Failed to load json file for service database: %s', str(e))
+            raise Exception from e
+    else:
+        raise Exception('Cannot load service database: File does not exist')
+
+    if not isinstance(new_data, dict) or not are_entries_unique(new_data.values()):
+        raise Exception('Cannot load database: File %s corresponds to an invalid database', str(filename))
+                
+    if merge:
+        # if there are  common names, check that the corresponding infos are the same, else raise conflict during merge
+        names_curr = set(__data__.keys())
+        common_names = names_curr.intersection(set(new_data.keys()))
+        for name in common_names:
+            if not is_info_same(__data__[name], new_data[name]):
+                raise Exception('Cannot load database: Conflict during merge')
+            
+        # do a temp merge and ensure that no two names contain the same id or url
+        temp_merged_data = copy.deepcopy(__data__)
+        temp_merged_data.update(new_data)
+        if not are_entries_unique(temp_merged_data.values()):
+            raise Exception('Cannot load database: Conflicts during merge')
+        
+        # all good, merge
+        __data__.update(new_data)
+    else:
+        __data__ = dict()
+        __data__.update(new_data)
+
+    # update the derived data structures
+    update_dictionaries(new_data, merge)
+
+#--------------------------------------------
+#--------------------------------------------
+
+def save_database(filename, overwrite = False):
+    """ Save the dictionary as a json file. If no new_file_name is provided, the json file used for init will be overwritten"""
+    
+    if os.path.exists(filename) and overwrite is False:
+        raise Exception('Cannot save database to file. File already present')
+    
+    # dump json to temporary file, if write succeeds move to desired file
+    temp_filename = filename + '_temp'
+    try:
+        with open(temp_filename, 'w') as fp:
+            json.dump(__data__, fp)
+        shutil.copyfile(temp_filename, filename)
+    except Exception as e:
+        raise Exception('Failed to save service database info as a json file: %s', str(e))
+    
+    try:
+        os.remove(temp_filename)
+    except Exception as e:
+        logger.exception('failed to remove the temporary file, continuing with the execution however...')
+    
+#--------------------------------------------
+#--------------------------------------------
+
+def add_info_to_database(name,  url, ledger_config):
+    """ Name, url and ledger_config are mandatory, id is automatically found fom the eservice. 
+    Return True if add succeeds, else return False"""
+    
+    global __data__
+    
+    try :
+        client = get_client_by_url(url)
+    except Exception as e :
+        logger.info('Cannot add info to database: %s', str(e))
+        return False
+    
+    id = client.enclave_id
+
+    #make sure that the new entry does not conflict with an existing entry
+    if (get_info_by_name(name) is not None) or (get_info_by_url(url) is not None) or (get_info_by_id(id) is not None):
+        logger.info('Cannot add info to database: new entry conflicts with existing database')
+        return False
+    
+    #verify that the enclave has been registered with the ledger 
+    try:
+        is_info_valid, time_of_verification = verify_info(url, ledger_config, id, txn_keys = None, client = client)
+        if is_info_valid:
+            logger.info('Adding a new entry to eservice database')
+            __data__[name] = {'url': url, 'id': id, 'last_verified_time': time_of_verification}
+        else:
+            logger.info('Cannot add info to database: Verification with ledger failed')
+            return False
+    except Exception as e:
+        logger.info('Cannot add info to database: Unknown error while verifying with ledger: %s', str(e))
+        return False
+
+    update_dictionaries({name:__data__[name]}, merge = True)
+    return True
+
+#--------------------------------------------
+#--------------------------------------------
+
+def update_info_in_database(name, url, ledger_config):
+    """ Update the entry corresponding to name. Replace url with incoming url. 
+    Return True if udpate succeeds, else retrun False. If no entry with name is found, 
+    return False"""
+
+    
+    global __data__
+
+    if not __data__.get(name):
+        return False
+
+    try :
+        client = get_client_by_url(url)
+    except Exception as e :
+        logger.info('Cannot update info in database: %s', str(e))
+        return False
+    
+    id = client.enclave_id
+
+    #make sure that the update info does not conflict with an existing entry. if url is already present, it must be against the same name
+    info_by_url = get_info_by_url(url)
+    if info_by_url is not None:
+        if info_by_url['name'] != name:
+            logger.info('Cannot update info in database: new info conflicts with existing database')
+            return False    
+    
+    # if the id is present, it must be against the same name (if so there is nothing to update)
+    info_by_id = get_info_by_id(id)
+    if info_by_id is not None:
+        if info_by_id['name'] == name:
+            logger.info('Nothing to update. url and id for name have not changed')
+            return True
+        else:
+            logger.info('Cannot update info in database: new info conflicts with existing database')
+            return False
+    
+    # Ok, we now have a new id, first verify that the id has been registered with the ledger 
+    try:
+        is_info_valid, time_of_verification = verify_info(url, ledger_config, id, txn_keys = None, client = client)
+        if is_info_valid:
+            logger.info('Updating entry corresponding to %s in eservice database', str(name))
+            __data__[name] = {'url': url, 'id': id, 'last_verified_time': time_of_verification}
+        else:
+            logger.info('Cannot update info in database: Verification with ledger failed')
+            return False
+    except Exception as e:
+        logger.info('Cannot update info in database: Unknown error while verifying with ledger: %s', str(e))
+        return False
+
+    update_dictionaries({name:__data__[name]}, merge = True)
+    return True
+#--------------------------------------------
+#--------------------------------------------
+
+def remove_info_from_database(name = None, id = None, url = None):
+    """ Remove entries corresponding to name & id & url. Return the number of entries removed"""
+
+    def remove(info):
+        global __url_by_name__
+        global __id_by_name__
+        global __name_by_url__
+        global __name_by_id__
+        global __data__
+        
+        __data__.pop(info['name'])
+        __id_by_name__.pop(info['name'])
+        __url_by_name__.pop(info['name'])
+        __name_by_id__.pop(info['id'])
+        __name_by_url__.pop(info['url'])
+
+    num_removed = 0
+
+    # remove by name
+    info = get_info_by_name(name)
+    if info is not None:
+        remove(info)
+        num_removed+=1
+        
+    # remove by id
+    info = get_info_by_id(id)
+    if info is not None:
+        remove(info)
+        num_removed+=1
+
+    # remove by url
+    info = get_info_by_url(url)
+    if info is not None:
+        remove(info)
+        num_removed+=1
+
+    logger.info('Removed %d entries from the database', num_removed)
+    return num_removed
+
+#--------------------------------------------
+#--------------------------------------------
+
+def get_info_by_name(name):
+    """ Get service info as present in database using name. Returns a dictonary with four fields:
+    name, id, url, last_verified_time. Return None if there is no matching entry. """
+
+    if __data__.get(name):
+        info = copy.deepcopy(__data__[name])
+        info['name'] = name
+        return info
+    else:
+        return None
+
+#--------------------------------------------
+#--------------------------------------------
+    
+def get_info_by_id(id):
+    """ Get service info as present in database using id. Returns a dictonary with four fields:
+    name, id, url, last_verified_time. Return None if there is no matching entry. """
+
+    if __name_by_id__.get(id):
+        name = __name_by_id__[id]
+        info = copy.deepcopy(__data__[name])
+        info['name'] = name
+        return info
+    else:
+        return None
+
+#--------------------------------------------
+#--------------------------------------------
+
+def get_info_by_url(url):
+    """ Get service info as present in database using url. Returns a dictonary with four fields:
+    name, id, url, last_verified_time. Return None if there is no matching entry. """
+
+    if __name_by_url__.get(url):
+        name = __name_by_url__[url]
+        info = copy.deepcopy(__data__[name])
+        info['name'] = name
+        return info
+    else:
+        return None
+
+#--------------------------------------------
+#--------------------------------------------
+
+def get_client_by_name(name):
+    """ get client for eservice identified by name"""
+
+    try:
+        return get_client_by_url(__url_by_name__[name])
+    except Exception as e:
+        raise Exception('Cannot generate client for eservice %s: %s', str(name), str(e))
+
+#--------------------------------------------
+#--------------------------------------------
+
+def get_client_by_url(url):
+    """ get client for eservice@url"""
+
+    try :
+        return EnclaveServiceClient(url)
+    except Exception as e :
+        raise Exception('Cannot generate client for eservice at %s: %s', str(url), str(e))
+        
+
+#--------------------------------------------
+#--------------------------------------------
+
+def get_client_by_id(id):
+    """ get client for eservice identified by id"""
+
+    try:
+        return get_client_by_url(__url_by_name__[__name_by_id__[id]])
+    except Exception as e:
+        raise Exception('Cannot generate client for eservice id %s: %s', str(id), str(e))
+
+#--------------------------------------------
+#--------------------------------------------
+
+def verify_info(url, ledger_config, id, txn_keys = None, client = None):
+    """Verify two things: 1. Check that the eservice@url hosts the id. This check is performed only if client is None. 
+    2. Verify that id is registered with DL. Return the pair (True/Falase, verification_time).  verification_time is None for false verifcation"""
+    
+    if client is None:
+        try :
+            client = EnclaveServiceClient(url)
+        except Exception as e :
+            raise Exception('failed to contact enclave service; %s', str(e))
+
+        # match id with eservice id
+        if id != client.enclave_id: 
+            logger.info('Failed to verify enclave. Database info does match with info from eservice')
+            return (False, None)
+    
+    # check againt ledger info
+    try:
+        if txn_keys is None:
+            txn_keys = keys.TransactionKeys()
+        sawtooth_client = PdoClientConnectHelper(ledger_config['LedgerURL'], key_str = txn_keys.txn_private)
+        enclave_state = sawtooth_client.get_enclave_dict(client.enclave_id)
+    except ClientConnectException as ce :
+        logger.info('failed to verify enclave registration with the ledger; %s', str(ce))
+        return (False, None)
+    except:
+        raise Exception('unknown error occurred while verifying enclave registration with ledger')
+    
+    return (True, str(datetime.datetime.now()))
+    
+#--------------------------------------------
+#--------------------------------------------
+def is_info_same(info1, info2):
+    """ Check is both infos are the same. Return True/False """
+
+    return (info1['id'] == info2['id']) and (info1['last_verified_time'] == info2['last_verified_time']) and are_the_urls_same(info1['url'], info2['url'])
+
+
+def are_entries_unique(infos):
+    """ Check if all urls and ids are distinct in the infos. Return True/False"""
+
+    urls = set()
+    ids = set()
+    
+    for info in infos:
+        
+        add_url = True
+        for url in urls:
+            if are_the_urls_same(url, info['url']):
+                add_url = False
+                break
+        if add_url:
+            urls.add(info['url'])
+
+        ids.add(info['id'])
+
+    return 2*len(infos) == len(urls) + len(ids)
+
+#--------------------------------------------
+#--------------------------------------------
+
+def update_dictionaries(new_data, merge = True):
+    """ Update the derived dictonaries."""
+    
+    global __url_by_name__
+    global __id_by_name__
+    global __name_by_url__
+    global __name_by_id__
+    
+    if merge is False:
+        __url_by_name__ = dict()
+        __id_by_name__ = dict()
+        __name_by_url__ = dict()
+        __name_by_id__ = dict()
+
+    for name, info in new_data.items():
+        __url_by_name__[name] = info['url']
+        __id_by_name__[name] = info['id']
+        __name_by_url__[info['url']] = name
+        __name_by_id__[info['id']] = name
+

--- a/python/pdo/test/__init__.py
+++ b/python/pdo/test/__init__.py
@@ -16,5 +16,7 @@ __all__ = [
     'helpers',
     'contract',
     'request',
-    'state'
+    'state',
+    'servicedb',
+    'eservice_database'
 ]

--- a/python/pdo/test/__init__.py
+++ b/python/pdo/test/__init__.py
@@ -18,5 +18,4 @@ __all__ = [
     'request',
     'state',
     'servicedb',
-    'eservice_database'
 ]

--- a/python/pdo/test/contract.py
+++ b/python/pdo/test/contract.py
@@ -21,7 +21,6 @@ import argparse
 import random
 import csv
 import re
-import json
 
 import pdo.test.helpers.secrets as secret_helper
 

--- a/python/pdo/test/contract.py
+++ b/python/pdo/test/contract.py
@@ -21,6 +21,7 @@ import argparse
 import random
 import csv
 import re
+import json
 
 import pdo.test.helpers.secrets as secret_helper
 
@@ -29,6 +30,7 @@ from pdo.sservice.block_store_manager import BlockStoreManager
 import pdo.eservice.pdo_helper as enclave_helper
 import pdo.service_client.enclave as eservice_helper
 import pdo.service_client.provisioning as pservice_helper
+import pdo.service_client.service_data.eservice as db
 
 import pdo.contract as contract_helper
 import pdo.common.crypto as crypto
@@ -76,14 +78,27 @@ def CreateAndRegisterEnclave(config) :
     global txn_dependencies
 
     if use_eservice :
-        try :
-            eservice_url = random.choice(config['Service']['EnclaveServiceURLs'])
-            logger.info('use enclave service at %s', eservice_url)
-            enclave = eservice_helper.EnclaveServiceClient(eservice_url)
-            return enclave
-        except Exception as e :
-            logger.error('failed to contact enclave service; %s', str(e))
-            sys.exit(-1)
+        
+        # Pick an enclave for the creating the contract
+        if config['Service'].get('EnclaveServiceNames'): #use the database to get the enclave
+            logger.info('Using eservice database to look up service URL for the contract enclave')
+            try:
+                eservice_to_use = random.choice(config['Service']['EnclaveServiceNames'])
+                enclave = db.get_client_by_name(eservice_to_use)
+            except Exception as e:
+                logger.error('Unable to get the eservice client using the eservice database: %s', str(e)) 
+                sys.exit(-1)   
+        else: # do not use the database, use the url and get the client directly
+            try :
+                eservice_urls = config['Service']['EnclaveServiceURLs']
+                eservice_url = random.choice(eservice_urls)
+                enclave = eservice_helper.EnclaveServiceClient(eservice_url)
+            except Exception as e :
+                logger.error('failed to contact enclave service; %s', str(e))
+                sys.exit(-1)
+        
+        logger.info('use enclave service at %s', enclave.ServiceURL)
+        return enclave
 
     # not using an eservice so build the local enclave
     try :
@@ -366,6 +381,15 @@ def LocalMain(config) :
     # keys of the contract creator
     contract_creator_keys = keys.ServiceKeys.create_service_keys()
 
+    # load the eservice database
+    if os.path.exists(config['Service']['EnclaveServiceDatabaseFile']):
+        try:
+            db.load_database(config['Service']['EnclaveServiceDatabaseFile'])
+            logger.info('Loading the eservice database from json file %s', str(config['Service']['EnclaveServiceDatabaseFile']))
+        except Exception as e:
+            logger.error('Error loading eservice database %s', str(e))
+            sys.exit(-1)
+
     # --------------------------------------------------
     logger.info('create and register the enclave')
     # --------------------------------------------------
@@ -457,6 +481,8 @@ def Main() :
     parser.add_argument('--source-dir', help='Directories to search for contract source', nargs='+', type=str)
     parser.add_argument('--key-dir', help='Directories to search for key files', nargs='+')
 
+    parser.add_argument('--eservice-db', help='json file for eservice database', type=str)
+    parser.add_argument('--eservice-name', help='List of enclave services to use. Give names as in database', nargs='+')
     parser.add_argument('--eservice-url', help='List of enclave service URLs to use', nargs='+')
     parser.add_argument('--pservice-url', help='List of provisioning service URLs to use', nargs='+')
 
@@ -528,12 +554,22 @@ def Main() :
     # set up the service configuration
     if config.get('Service') is None :
         config['Service'] = {
+            'EnclaveServiceNames' : [],
             'EnclaveServiceURLs' : [],
-            'ProvisioningServiceURLs' : []
+            'ProvisioningServiceURLs' : [],
+            'EnclaveServiceDatabaseFile' : None
         }
+
+    if options.eservice_name:
+        use_eservice = True
+        config['Service']['EnclaveServiceNames'] = options.eservice_name
+    if options.eservice_db:
+        config['Service']['EnclaveServiceDatabaseFile'] = options.eservice_db
     if options.eservice_url :
         use_eservice = True
         config['Service']['EnclaveServiceURLs'] = options.eservice_url
+        # if url is provided, we will not use database
+        config['Service']['EnclaveServiceNames'] = []
     if options.pservice_url :
         use_pservice = True
         config['Service']['ProvisioningServiceURLs'] = options.pservice_url

--- a/python/pdo/test/request.py
+++ b/python/pdo/test/request.py
@@ -19,7 +19,7 @@ import sys
 import time
 import argparse
 import random
-import json
+
 import pdo.test.helpers.secrets as secret_helper
 import pdo.test.helpers.state as test_state
 

--- a/python/pdo/test/request.py
+++ b/python/pdo/test/request.py
@@ -19,6 +19,7 @@ import sys
 import time
 import argparse
 import random
+import json
 import pdo.test.helpers.secrets as secret_helper
 import pdo.test.helpers.state as test_state
 
@@ -27,6 +28,7 @@ from pdo.sservice.block_store_manager import BlockStoreManager
 import pdo.eservice.pdo_helper as enclave_helper
 import pdo.service_client.enclave as eservice_helper
 import pdo.service_client.provisioning as pservice_helper
+import pdo.service_client.service_data.eservice as db
 
 import pdo.contract as contract_helper
 import pdo.common.crypto as crypto
@@ -81,14 +83,27 @@ def CreateAndRegisterEnclave(config) :
     # if we are using the eservice then there is nothing to register since
     # the eservice has already registered the enclave
     if use_eservice :
-        try :
-            eservice_url = random.choice(config['Service']['EnclaveServiceURLs'])
-            logger.info('use enclave service at %s', eservice_url)
-            enclave = eservice_helper.EnclaveServiceClient(eservice_url)
-            return enclave
-        except Exception as e :
-            logger.error('failed to contact enclave service; %s', str(e))
-            sys.exit(-1)
+        
+        # Pick an enclave for the creating the contract
+        if config['Service'].get('EnclaveServiceNames'): #use the database to get the enclave
+            logger.info('Using eservice database to look up service URL for the contract enclave')            
+            try:
+                eservice_to_use = random.choice(config['Service']['EnclaveServiceNames'])
+                enclave = db.get_client_by_name(eservice_to_use)
+            except Exception as e:
+                logger.error('Unable to get the eservice client using the eservice database: %s',  str(e)) 
+                sys.exit(-1)   
+        else: # do not use the database, use the url and get the client directly
+            try :
+                eservice_urls = config['Service']['EnclaveServiceURLs']
+                eservice_url = random.choice(eservice_urls)
+                enclave = eservice_helper.EnclaveServiceClient(eservice_url)
+            except Exception as e :
+                logger.error('failed to contact enclave service; %s', str(e))
+                sys.exit(-1)
+        
+        logger.info('use enclave service at %s', enclave.ServiceURL)
+        return enclave
 
     # not using an eservice so build the local enclave
     try :
@@ -356,6 +371,15 @@ def LocalMain(config) :
     # keys of the contract creator
     contract_creator_keys = keys.ServiceKeys.create_service_keys()
 
+    # load the eservice database if the file is found
+    if os.path.exists(config['Service']['EnclaveServiceDatabaseFile']):
+        try:
+            db.load_database(config['Service']['EnclaveServiceDatabaseFile'])
+            logger.info('Loading the eservice database from json file %s', str(config['Service']['EnclaveServiceDatabaseFile']))
+        except Exception as e:
+            logger.error('Error loading eservice database %s', str(e))
+            sys.exit(-1)
+            
     # --------------------------------------------------
     logger.info('create and register the enclave')
     # --------------------------------------------------
@@ -448,6 +472,8 @@ def Main() :
     parser.add_argument('--source-dir', help='Directories to search for contract source', nargs='+', type=str)
     parser.add_argument('--key-dir', help='Directories to search for key files', nargs='+')
 
+    parser.add_argument('--eservice-db', help='json file for eservice database', type=str)
+    parser.add_argument('--eservice-name', help='List of enclave services to use. Give names as in database', nargs='+')
     parser.add_argument('--eservice-url', help='List of enclave service URLs to use', nargs='+')
     parser.add_argument('--pservice-url', help='List of provisioning service URLs to use', nargs='+')
 
@@ -520,15 +546,26 @@ def Main() :
     # set up the service configuration
     if config.get('Service') is None :
         config['Service'] = {
+            'EnclaveServiceNames' : [],
             'EnclaveServiceURLs' : [],
-            'ProvisioningServiceURLs' : []
+            'ProvisioningServiceURLs' : [],
+            'EnclaveServiceDatabaseFile' : None
         }
+
+    if options.eservice_name:
+        use_eservice = True
+        config['Service']['EnclaveServiceNames'] = options.eservice_name
+    if options.eservice_db:
+        config['Service']['EnclaveServiceDatabaseFile'] = options.eservice_db
     if options.eservice_url :
         use_eservice = True
         config['Service']['EnclaveServiceURLs'] = options.eservice_url
+        # if url is provided, we will not use database
+        config['Service']['EnclaveServiceNames'] = []
     if options.pservice_url :
         use_pservice = True
         config['Service']['ProvisioningServiceURLs'] = options.pservice_url
+    
 
     # set up the data paths
     if config.get('Contract') is None :
@@ -564,6 +601,7 @@ def Main() :
     if tamper_block_order :
         config['iterations'] = 1
 
+    
     LocalMain(config)
 
 Main()

--- a/python/pdo/test/servicedb.py
+++ b/python/pdo/test/servicedb.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+
+# Copyright 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+ 
+# this is the unit test for eservice database module implementation. Eservices are assuming to be running.
+
+import os
+import sys
+import copy
+
+import argparse
+import logging
+logger = logging.getLogger(__name__)
+
+import pdo.common.logger as plogger
+import pdo.service_client.service_data.eservice as db
+from pdo.common.utility import are_the_urls_same
+
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--url', help='eservice urls', required=True,  nargs='+')
+parser.add_argument('--eservice-db', help='json file for database', required=True, type=str)
+parser.add_argument('--loglevel', help='Set the logging level', default='INFO')
+parser.add_argument('--logfile', help='Name of the log file', default='__screen__')
+parser.add_argument('--ledger', help='Ledger URLName of the log file', required=True, type=str)
+
+options = parser.parse_args()
+plogger.setup_loggers({'LogLevel' : options.loglevel.upper(), 'LogFile' : options.logfile})
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+
+ledger_config = {'LedgerURL':options.ledger}
+
+# add new entries by urls
+names = []
+for index, url in enumerate(options.url):
+    names.append('e' + str(index))
+    db.add_info_to_database(names[index], url, ledger_config)
+
+#save  file
+db.save_database(options.eservice_db, overwrite = True)
+
+for e in names:
+    # get service client by name
+    c_name = db.get_client_by_name(e)
+
+    # get info by name
+    info = db.get_info_by_name(e)
+   
+    # check info by name
+    assert (info['name'] == e) and are_the_urls_same(info['url'], c_name.ServiceURL) and (info['id'] == c_name.enclave_id), "Incorrect info by name"
+       
+    # get service client by id, id obtained from info
+    c_id = db.get_client_by_id(info['id'])
+    
+    # check if the two clients point to the same service url
+    assert are_the_urls_same(c_name.ServiceURL, c_id.ServiceURL), "Not getting the same eservice client using name and id"
+
+    # get info by url
+    info = db.get_info_by_url(url = c_id.ServiceURL)
+    
+    # check info by url
+    assert (info['name'] == e) and are_the_urls_same(info['url'], c_name.ServiceURL) and (info['id'] == c_id.enclave_id), "Incorrect info by url"
+
+    # test update info without any change in info
+    assert db.update_info_in_database(e, c_name.ServiceURL, ledger_config) is True, "Error while updating same info"
+
+#save  file
+db.save_database(options.eservice_db, overwrite = True)
+
+# make a local copy for testing
+data_copy = copy.deepcopy(db.__data__)
+
+#load db freshly and check
+db.load_database(options.eservice_db, merge = False)
+
+assert db.__data__ == data_copy, "Error loading database"
+
+#reload db again and check
+db.load_database(options.eservice_db, merge = True)
+
+assert db.__data__ == data_copy, "Error reloading database with merge"
+
+#remove entry for e1
+info = db.get_info_by_name(names[0])
+assert db.remove_info_from_database(name = names[0]) == 1, "Error removing entry"
+assert db.get_info_by_name(names[0]) is None, "Error removing entry"
+assert db.get_info_by_url(info['url']) is None, "Error removing entry"
+assert db.get_info_by_id(info['id']) is None, "Error removing entry"
+
+#save file after remove
+db.save_database(options.eservice_db, overwrite = True)
+
+# force data to empty 
+db.__data__ = {}
+# add entry for e1
+db.add_info_to_database(info['name'], info['url'], ledger_config)
+#merge with rest of the entries from file
+db.load_database(options.eservice_db, merge = True)
+# the following comparison should fail, since e0's last verification time is different. Expect for this field, everything else is same
+assert db.__data__ != data_copy, "Expected the two dbs to be different"
+
+#test update with change in info
+info = db.get_info_by_name(names[0])
+db.remove_info_from_database(name = names[0])
+#change entry of e1 to that of e0
+assert db.update_info_in_database(names[1], info['url'], ledger_config) is True, "Error while updating same info"
+info2 = db.get_info_by_name(names[1])
+assert info['url']==info2['url'] and info['id'] == info2['id'], "error while updating info"
+
+logger.info("All tests passed for service database manager")


### PR DESCRIPTION
The eservice database functionality is now provided via a functional interface instead of as a class as in the last PR. This PR replaces the last PR.  The data is stored as json. CLI is provided via the shell command pdo-eservicedb with command parameters such as create, add, remove, update.  Documentation can be found in eservice/docs/. New tests have been added to run-tests.sh to show the usage of the database for pdo test scripts.

Signed-off-by: prakashngit <prakash.narayana.moorthy@intel.com>