### PR TITLE
Docker related improvement

### DIFF
--- a/build/__tools__/run-perf-tests.sh
+++ b/build/__tools__/run-perf-tests.sh
@@ -93,6 +93,8 @@ done
 
 # check for existing enclave and storage services, we are not
 # using the provisioning services for this particular test
+# to handle some docker oddities, define our own pgrep rather than the normal one ..
+pgrep() { ps -ef | egrep -v '<defunct>|grep' | grep "$1"; }
 pgrep eservice
 if [ $? == 0 ] ; then
     die existing enclave services detected, please shutdown

--- a/build/__tools__/run-tests.sh
+++ b/build/__tools__/run-tests.sh
@@ -67,6 +67,8 @@ SRCDIR="$(realpath ${SCRIPTDIR}/../..)"
 : "${PDO_LEDGER_URL:-$(die Missing environment variable PDO_LEDGER_URL)}"
 
 # check for existing enclave and provisioning services
+# to handle some docker oddities, define our own pgrep rather than the normal one ..
+pgrep() { ps -ef | egrep -v '<defunct>|grep' | grep "$1"; }
 pgrep eservice
 if [ $? == 0 ] ; then
     die existing enclave services detected, please shutdown

--- a/docker/Dockerfile.pdo-build
+++ b/docker/Dockerfile.pdo-build
@@ -103,20 +103,20 @@ ARG PDO_DEBUG_BUILD=0
 ENV PDO_DEBUG_BUILD=${PDO_DEBUG_BUILD}
 
 RUN \
-# read environment explicitly as build shell doesn't do automatically (aargh ..)
-     . /etc/environment \
+# read pdo environmentexplicitly as build shell doesn't do automatically (aargh ..). see comment in Dockerfile.pdo-dev
+     . /etc/profile.d/pdo.sh \
 # .. and overwrite auto-detection of SGX_MODE with whatever we compile below ...
- && echo "export SGX_MODE=${SGX_MODE}" >> /root/.bashrc \
+ && echo "export SGX_MODE=${SGX_MODE}" >> /etc/profile.d/pdo.sh \
 # finally set up other env variables via config script based on
 # previously defined PDO_HOME, PDO_INSTALL_ROOT, PDO_ENCLAVE_CODE_SIGN_PEM
 # and default ledger url ..
  && export PDO_LEDGER_URL=http://rest-api:8008 \
  && `/project/pdo/src/private-data-objects/build/common-config.sh -e`  \
 # configs are mostly stored in config file but also persist them as environment variables ...
- && env | grep PDO | egrep -v 'PDO_ENCLAVE_CODE_SIGN_PEM|PDO_INSTALL_ROOT|PDO_HOME' | sed 's/^PDO/export PDO/g' >> /etc/environment \
+ && env | grep PDO | egrep -v 'PDO_ENCLAVE_CODE_SIGN_PEM|PDO_INSTALL_ROOT|PDO_HOME' | sed 's/^PDO/export PDO/g' >> /etc/profile.d/pdo.sh \
 # Build PDO usuing the standard build scripts
  && make -C /project/pdo/src/private-data-objects/build/ NO_SGX_RUN_DURING_BUILD=true \
- && echo '. /project/pdo/build/bin/activate' >> /root/.bashrc \
+ && echo '. /project/pdo/build/bin/activate' >> /etc/profile.d/pdo.sh \
  && . /project/pdo/build/bin/activate \
 # - build script install in virtualenv. For docker this seems a bit overkill but easier than to
 #   duplicate all build instructions.

--- a/docker/Dockerfile.pdo-dev
+++ b/docker/Dockerfile.pdo-dev
@@ -101,17 +101,14 @@ RUN apt-get update \
     fi \
  && apt-get -y -q upgrade \
  && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
-
-# Install Tinyscheme
-RUN mkdir -p /opt/tinyscheme
-WORKDIR /opt/tinyscheme
-RUN wget https://downloads.sourceforge.net/project/tinyscheme/tinyscheme/tinyscheme-1.41/tinyscheme-1.41.zip \
- && unzip tinyscheme-1.41.zip \
- && rm tinyscheme-1.41.zip  \
- && cd tinyscheme-1.41  \
- && make \
- && echo "export TINY_SCHEME_SRC=$(pwd)" >> /etc/environment
+ && rm -rf /var/lib/apt/lists/* \
+# environment variables
+# we keep all definitions in '/etc/profile.d/pdo.sh'. Alas, this is called only for login shells
+# so add it at least to /etc/bash.bashrc. Nothing equivalent seems to exist for dash/sh, which is used
+# during build, so in that case we will have to explicitly '. /etc/profile.d/pdo.sh'.
+# NOTE: There seems to be _nothing_ which is guaranteed to be always called, e.g., /etc/environment
+#   also does not work as it is not always called
+ && sed -i '1s;^;. /etc/profile.d/pdo.sh\n;' /etc/bash.bashrc
 
 # Install SGX SDK
 # we install from source as with binary distribution it's difficult to get library dependencies correct
@@ -138,11 +135,11 @@ RUN git clone --branch ${SGX_SDK} https://github.com/01org/linux-sgx.git \
  && echo "yes" | ./linux-sgx/linux/installer/bin/sgx_linux_x64_sdk_*.bin \
  && ./linux-sgx/linux/installer/bin/sgx_linux_x64_psw_*.bin \
  && rm -rf linux-sgx \
- && echo ". /opt/intel/sgxsdk/environment" >> /etc/environment
+ && echo ". /opt/intel/sgxsdk/environment" >> /etc/profile.d/pdo.sh
 
 # ("Untrusted") OpenSSL
 WORKDIR /tmp
-RUN wget https://www.openssl.org/source/openssl-${OPENSSL}.tar.gz #\
+RUN wget https://www.openssl.org/source/openssl-${OPENSSL}.tar.gz
 # && tar -zxvf openssl-${OPENSSL}.tar.gz \
 # && cd openssl-${OPENSSL}/ \
 # && ./config \
@@ -171,7 +168,17 @@ RUN git clone  --branch ${SGXSSL} https://github.com/intel/intel-sgx-ssl.git \
  && (cd intel-sgx-ssl/Linux; make SGX_MODE=SIM DESTDIR=/opt/intel/sgxssl all test ) \
  && (cd intel-sgx-ssl/Linux; make install ) \
  && rm -rf /tmp/intel-sgx-ssl \
- && echo "export SGX_SSL=/opt/intel/sgxssl" >> /etc/environment
+ && echo "export SGX_SSL=/opt/intel/sgxssl" >> /etc/profile.d/pdo.sh
+
+# Install Tinyscheme
+RUN mkdir -p /opt/tinyscheme
+WORKDIR /opt/tinyscheme
+RUN wget https://downloads.sourceforge.net/project/tinyscheme/tinyscheme/tinyscheme-1.41/tinyscheme-1.41.zip \
+ && unzip tinyscheme-1.41.zip \
+ && rm tinyscheme-1.41.zip  \
+ && cd tinyscheme-1.41  \
+ && make \
+ && echo "export TINY_SCHEME_SRC=$(pwd)" >> /etc/profile.d/pdo.sh
 
 # environment setup as required by PDO
 # Note
@@ -181,11 +188,10 @@ RUN git clone  --branch ${SGXSSL} https://github.com/intel/intel-sgx-ssl.git \
 # - make sure /etc/environment is always included for bash
 RUN \
     mkdir -p /project/pdo \
- && echo "export PDO_INSTALL_ROOT=/project/pdo/build" >> /etc/environment \
- && echo "export PDO_HOME=/project/pdo/build/opt/pdo" >> /etc/environment \
- && echo "export PDO_ENCLAVE_CODE_SIGN_PEM=/project/pdo/enclave.pem" >> /etc/environment \
+ && echo "export PDO_INSTALL_ROOT=/project/pdo/build" >> /etc/profile.d/pdo.sh \
+ && echo "export PDO_HOME=/project/pdo/build/opt/pdo" >> /etc/profile.d/pdo.sh \
+ && echo "export PDO_ENCLAVE_CODE_SIGN_PEM=/project/pdo/enclave.pem" >> /etc/profile.d/pdo.sh \
  && openssl genrsa -3 3072 > /project/pdo/enclave.pem \
- && sed -i '1s;^;source /etc/environment\nexport $(grep -v "^. " /etc/environment| cut -d= -f1)\n;' /root/.bashrc \
  && echo "if ([ -c /dev/isgx ] && [ -S /var/run/aesmd/aesm.socket ]); then export SGX_MODE=HW; else export SGX_MODE=SIM; fi;" >> /root/.bashrc
 
 WORKDIR /project/pdo/

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -51,6 +51,12 @@ DOCKER_COMPOSE_OPTS=$(foreach cf, $(DOCKER_COMPOSE_FILES), -f $(cf))
 all:
 
 pdo-dev-image:
+	# sparse lmdb files cause docker to run out of disk space. As we include ..
+	# as git root for build of pdo-build docker file, we should  not have run tests
+	# inside the default build location
+	if [ -x ../build/_dev/opt/pdo/data ]; then \
+		echo -e "\n\nWARNING: you have a local "bare-metal" build in ../build/_dev. If that includes lmdb-files, below docker-compose might run out of disk space!!\n\n"; \
+	fi
 	# unconditionally build, count on docker caching to not rebuild if not necessary
 	docker build $(DOCKER_BUILD_OPTS) -f Dockerfile.pdo-dev -t pdo-dev .
 

--- a/eservice/bin/es-status.sh
+++ b/eservice/bin/es-status.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PLIST=$(pgrep -u $USER -f eservice)
+PLIST=$(pgrep -u ${USER:-$(whoami)} -f eservice)
 if [ -n "$PLIST" ] ; then
     ps -h --format cmd -p $PLIST
 fi

--- a/eservice/bin/ss-status.sh
+++ b/eservice/bin/ss-status.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PLIST=$(pgrep -u $USER -f sservice)
+PLIST=$(pgrep -u ${USER:-$(whoami)} -f sservice)
 if [ -n "$PLIST" ] ; then
     ps -h --format cmd -p $PLIST
 fi

--- a/pservice/bin/ps-status.sh
+++ b/pservice/bin/ps-status.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PLIST=$(pgrep -u $USER -f pservice)
+PLIST=$(pgrep -u ${USER:-$(whoami)} -f pservice)
 if [ -n "$PLIST" ] ; then
     ps -h --format cmd -p $PLIST
 fi


### PR DESCRIPTION
- make scripts a bit more robust and docker-friendly
- some cleanup of docker files
- warning that running docker test from a repo might run out of diskspace if you have (a) in-repo-built (build/_dev/...) installation and (b) run some tests with lingering lmdb-files

Signed-off-by: Michael Steiner <michael.steiner@intel.com>