### PR TITLE
More robust service scripts

### DIFF
--- a/build/__tools__/run-perf-tests.sh
+++ b/build/__tools__/run-perf-tests.sh
@@ -91,20 +91,6 @@ while true ; do
     esac
 done
 
-# check for existing enclave and storage services, we are not
-# using the provisioning services for this particular test
-# to handle some docker oddities, define our own pgrep rather than the normal one ..
-pgrep() { ps -ef | egrep -v '<defunct>|grep' | grep "$1"; }
-pgrep eservice
-if [ $? == 0 ] ; then
-    die existing enclave services detected, please shutdown
-fi
-
-pgrep sservice
-if [ $? == 0 ] ; then
-    die existing storage services detected, please shutdown
-fi
-
 function cleanup {
     yell "shutdown services"
     ${PDO_HOME}/bin/es-stop.sh --count ${F_SERVICES} > /dev/null

--- a/build/__tools__/run-tests.sh
+++ b/build/__tools__/run-tests.sh
@@ -66,19 +66,6 @@ SRCDIR="$(realpath ${SCRIPTDIR}/../..)"
 : "${PDO_HOME:-$(die Missing environment variable PDO_HOME)}"
 : "${PDO_LEDGER_URL:-$(die Missing environment variable PDO_LEDGER_URL)}"
 
-# check for existing enclave and provisioning services
-# to handle some docker oddities, define our own pgrep rather than the normal one ..
-pgrep() { ps -ef | egrep -v '<defunct>|grep' | grep "$1"; }
-pgrep eservice
-if [ $? == 0 ] ; then
-    die existing enclave services detected, please shutdown
-fi
-
-pgrep pservice
-if [ $? == 0 ] ; then
-    die existing provisioning services detected, please shutdown
-fi
-
 SAVE_FILE=$(mktemp /tmp/pdo-test.XXXXXXXXX)
 
 declare -i NUM_SERVICES=5 # must be at least 3 for pconntract update test to work

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -78,7 +78,7 @@ test-env-setup-with-no-build:
 	   exec validator sawset proposal create --url http://rest-api:8008 --key /root/.sawtooth/keys/my_key.priv sawtooth.validator.transaction_families='[{"family": "intkey", "version": "1.0"}, {"family":"sawtooth_settings", "version":"1.0"}, {"family": "pdo_contract_enclave_registry", "version": "1.0"}, {"family":  "pdo_contract_instance_registry", "version": "1.0"}, {"family": "ccl_contract", "version": "1.0"}]'
 	if [ "$(SGX_MODE)" = "HW" ]; then \
 	   $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS) \
-	      exec pdo-build bash -c 'source /etc/environment; export PDO_SGX_KEY_ROOT=/project/pdo/build/opt/pdo/etc/keys/sgx/; unset PDO_SPID PDO_SPID_KEY_CERT_FILE_PEM PDO_IAS_KEY_PEM; source /project/pdo/src/private-data-objects/build/common-config.sh; make -C /project/pdo/src/private-data-objects/build conf register'; \
+	      exec pdo-build bash -c 'source /etc/bash.bashrc; export PDO_SGX_KEY_ROOT=/project/pdo/build/opt/pdo/etc/keys/sgx/; unset PDO_SPID PDO_SPID_KEY_CERT_FILE_PEM PDO_IAS_KEY_PEM; source /project/pdo/src/private-data-objects/build/common-config.sh; make -C /project/pdo/src/private-data-objects/build conf register'; \
 	fi
 
 test-with-no-build: test-env-setup-with-no-build

--- a/docker/README.md
+++ b/docker/README.md
@@ -36,8 +36,7 @@ If you define the PDO_DEBUG_BUILD environment variable, the make commands will (
 the code with debugging and and run docker containers such that gdb/sgx-gdb-based debugging is possible.
 Note though, that due to some docker(-compose)ism, terminating daemon processes such as the ones started
 by ps-start/es-start will run in zombie processes. They don't hold any resources such as sockets or alike
-and subseequent ps-start/es-start will run successfully.  However, note that run-tests.sh will fail
-due to some pgrep statements in the script ...
+and subseequent \*-start/\*-status/\*-stop script should work as expected.
 
 While you can run end-to-end tests inside docker, sometimes it might be easier to test outside so you can, e.g., monitor localhost traffic with wireshark which seems challenging with docker. Note that with 'make test-env-setup' (or 'make test-env-setup-with-no-build' if you are sure container images for PDO-TP and other components are already properly built) you get a fresh sawtooth setup where ledger rest API is also exposed to the host, i.e., the default localhost:8008 does also work from the host and you can test client and {e,s,p}services on the host with a fresh and self-contained/single machine installation.
 

--- a/eservice/bin/common.sh
+++ b/eservice/bin/common.sh
@@ -1,0 +1,24 @@
+F_LOGDIR=$F_SERVICEHOME/logs
+F_CONFDIR=$F_SERVICEHOME/etc
+
+# to handle some docker oddities, define our own pgrep rather than the normal one ..
+pgrepf() { PLIST=$(ps -ef | egrep -v '<defunct>|egrep|awk' | egrep "$1"); rc=$?; echo "${PLIST}" | awk '{ print $2 }'; return $rc; }
+
+# get url base from config
+get_url_base() {
+    IDENTITY=$1
+
+    config_file="${F_CONFDIR}/${IDENTITY}.toml"
+    host=$(perl -n -e'/^\s*Host\s*=\s*"([a-zA-Z0-9-]+)"/ && print $1' ${config_file})
+    [ ! -z "${host}" ] || { echo "no valide host found for service $IDENTITY"; exit 1; }
+    port=$(perl -n -e'/^\s*HttpPort\s*=\s*([0-9]+)/ && print $1' ${config_file})
+    [ ! -z "${port}" ] || { echo "no valide port found for service $IDENTITY"; exit 1; }
+    url_base="http://${host}:${port}"
+    echo $url_base
+}
+
+# curl command for liveness test
+# - expects URL as additional argument
+# - will return HTTP return code & exist 0 if successfull, string "000" and non-zero error return code
+# Note: --ipv4 is crucial as retry logic with --retry-connrefuse doesn't work as expected for IPv6
+CURL_CMD='curl --ipv4 --retry-connrefuse --retry 10 --retry-max-time 50 --connect-timeout 5 --max-time 10  -sL -w %{http_code} -o /dev/null'

--- a/eservice/bin/es-status.sh
+++ b/eservice/bin/es-status.sh
@@ -14,7 +14,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PLIST=$(pgrep -u ${USER:-$(whoami)} -f eservice)
+F_SERVICEHOME="$( cd -P "$( dirname ${BASH_SOURCE[0]} )/.." && pwd )"
+source ${F_SERVICEHOME}/bin/common.sh
+
+F_USAGE='-b|--base name'
+F_BASENAME='eservice'
+
+# -----------------------------------------------------------------
+# Process command line arguments
+# -----------------------------------------------------------------
+TEMP=`getopt -o b:h --long base:,help \
+     -n 'es-status.sh' -- "$@"`
+
+if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
+
+eval set -- "$TEMP"
+while true ; do
+    case "$1" in
+        -b|--base) F_BASENAME="$2" ; shift 2 ;;
+        --help) echo $F_USAGE ; exit 1 ;;
+	--) shift ; break ;;
+	*) echo "Internal error!" ; exit 1 ;;
+    esac
+done
+
+PLIST=$(pgrepf  "\beservice .* --config ${F_BASENAME}[0-9].toml\b")
 if [ -n "$PLIST" ] ; then
-    ps -h --format cmd -p $PLIST
+    ps -h --format pid,start,cmd -p $PLIST
 fi

--- a/eservice/bin/ss-status.sh
+++ b/eservice/bin/ss-status.sh
@@ -14,7 +14,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PLIST=$(pgrep -u ${USER:-$(whoami)} -f sservice)
+F_SERVICEHOME="$( cd -P "$( dirname ${BASH_SOURCE[0]} )/.." && pwd )"
+source ${F_SERVICEHOME}/bin/common.sh
+
+F_USAGE='-b|--base name'
+F_BASENAME='sservice'
+
+# -----------------------------------------------------------------
+# Process command line arguments
+# -----------------------------------------------------------------
+TEMP=`getopt -o b:h --long base:,help \
+     -n 'ss-status.sh' -- "$@"`
+
+if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
+
+eval set -- "$TEMP"
+while true ; do
+    case "$1" in
+        -b|--base) F_BASENAME="$2" ; shift 2 ;;
+        --help) echo $F_USAGE ; exit 1 ;;
+	--) shift ; break ;;
+	*) echo "Internal error!" ; exit 1 ;;
+    esac
+done
+
+PLIST=$(pgrepf  "\bsservice .* --config ${F_BASENAME}[0-9].toml\b")
 if [ -n "$PLIST" ] ; then
-    ps -h --format cmd -p $PLIST
+    ps -h --format pid,start,cmd -p $PLIST
 fi

--- a/eservice/bin/ss-stop.sh
+++ b/eservice/bin/ss-stop.sh
@@ -14,22 +14,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-F_USAGE='-b|--base port -c|--count services'
-F_BASE=7201
+F_SERVICEHOME="$( cd -P "$( dirname ${BASH_SOURCE[0]} )/.." && pwd )"
+source ${F_SERVICEHOME}/bin/common.sh
+
+F_USAGE='-c|--count services -b|--base name'
 F_COUNT=1
+F_BASENAME='sservice'
 
 # -----------------------------------------------------------------
 # Process command line arguments
 # -----------------------------------------------------------------
 TEMP=`getopt -o b:c:h --long base:,count:,help \
-     -n 'stop.sh' -- "$@"`
+     -n 'ss-stop.sh' -- "$@"`
 
 if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
 
 eval set -- "$TEMP"
 while true ; do
     case "$1" in
-        -b|--base) F_BASE="$2" ; shift 2 ;;
+        -b|--base) F_BASENAME="$2" ; shift 2 ;;
         -c|--count) F_COUNT="$2" ; shift 2 ;;
         --help) echo $F_USAGE ; exit 1 ;;
 	--) shift ; break ;;
@@ -37,6 +40,16 @@ while true ; do
     esac
 done
 
-for port in `seq $F_BASE $(($F_BASE+$F_COUNT))` ; do
-    curl -s "http://localhost:$port/shutdown"
+rc=0
+for index in `seq 1 $F_COUNT` ; do
+    IDENTITY="${F_BASENAME}$index"
+    echo stopping storage service $IDENTITY
+
+    url="$(get_url_base $IDENTITY)/shutdown" || { echo "no url found for storage service"; exit 1; }
+    resp=$(curl -sL -w "%{http_code}\\n" ${url} -o /dev/null)
+    if [ $? != 0 ]; then # shutdown results in 500 error, so do not test also || [ $resp != "200" ]
+	echo "storage service $IDENTITY not running or not properly shut down"
+	rc=1
+    fi
 done
+exit $rc

--- a/eservice/setup.py
+++ b/eservice/setup.py
@@ -45,6 +45,7 @@ data_files = [
     (bin_dir, [
         'bin/es-start.sh', 'bin/es-stop.sh', 'bin/es-status.sh',
         'bin/ss-start.sh', 'bin/ss-stop.sh', 'bin/ss-status.sh',
+        'bin/common.sh'
         ]),
     (dat_dir, []),
     (etc_dir, [ 'etc/sample_eservice.toml', 'etc/sample_sservice.toml' ]),

--- a/pservice/bin/ps-start.sh
+++ b/pservice/bin/ps-start.sh
@@ -20,23 +20,22 @@ if [[ $PY3_VERSION -lt 5 ]]; then
     exit
 fi
 
-F_USAGE='-c|--count services --cfile config -l|--loglevel [debug|info|warn]'
-F_LOGLEVEL='info'
-F_COUNT=1
-F_OUTPUTDIR=''
-F_BASENAME='pservice'
-
 F_SERVICEHOME="$( cd -P "$( dirname ${BASH_SOURCE[0]} )/.." && pwd )"
-F_LOGDIR=$F_SERVICEHOME/logs
-F_CONFDIR=$F_SERVICEHOME/etc
+source ${F_SERVICEHOME}/bin/common.sh # from ../../eservice/bin/
+
+F_USAGE='-c|--count services -b|--base name --ledger url -o|--output dir --clean -l|--loglevel [debug|info|warn]'
+F_COUNT=1
+F_BASENAME='pservice'
 F_LEDGERURL=''
+F_OUTPUTDIR=''
 F_CLEAN='no'
+F_LOGLEVEL='info'
 
 # -----------------------------------------------------------------
 # Process command line arguments
 # -----------------------------------------------------------------
 TEMP=`getopt -o b:c:l:o: --long base:,clean,count:,help,loglevel:,output:,ledger: \
-     -n 'launch.sh' -- "$@"`
+     -n 'ps-start.sh' -- "$@"`
 
 if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
 
@@ -46,15 +45,23 @@ while true ; do
         -b|--base) F_BASENAME="$2" ; shift 2 ;;
         --clean) F_CLEAN="yes" ; shift 1 ;;
         -c|--count) F_COUNT="$2" ; shift 2 ;;
-        -l|--loglevel) F_LOGLEVEL="$2" ; shift 2 ;;
         --ledger) F_LEDGERURL="--ledger $2" ; shift 2 ;;
+        -l|--loglevel) F_LOGLEVEL="$2" ; shift 2 ;;
         -o|--output) F_OUTPUTDIR="$2" ; shift 2 ;;
         --help) echo $F_USAGE ; exit 1 ;;
-    --) shift ; break ;;
-    *) echo "Internal error!" ; exit 1 ;;
+	--) shift ; break ;;
+	*) echo "Internal error!" ; exit 1 ;;
     esac
 done
 
+# (1) do not start if service already running
+pgrepf  "\bpservice .* --config ${F_BASENAME}[0-9].toml\b"
+if [ $? == 0 ] ; then
+    echo existing provisioning services detected, please shutdown first
+    exit 1
+fi
+
+# (2) prepare output
 if [ "$F_OUTPUTDIR" != "" ] ; then
     mkdir -p $F_OUTPUTDIR
     rm -f $F_OUTPUTDIR/*
@@ -63,6 +70,7 @@ else
     OFILE=/dev/null
 fi
 
+# (3) start services asynchronously
 for index in `seq 1 $F_COUNT` ; do
     IDENTITY="${F_BASENAME}$index"
     echo start provisioning service $IDENTITY
@@ -84,4 +92,17 @@ for index in `seq 1 $F_COUNT` ; do
     pservice --identity ${IDENTITY} --config ${IDENTITY}.toml enclave.toml --config-dir ${F_CONFDIR} ${F_LEDGERURL} \
              --loglevel ${F_LOGLEVEL} --logfile ${F_LOGDIR}/${IDENTITY}.log 2> $EFILE > $OFILE &
 
+done
+
+# (4) wait for successfull start of the services
+for index in `seq 1 $F_COUNT` ; do
+    IDENTITY="${F_BASENAME}$index"
+    echo waiting for startup completion of provisioning service $IDENTITY
+
+    url="$(get_url_base $IDENTITY)/info" || { echo "no url found for provisioning service"; exit 1; }
+    resp=$(${CURL_CMD} ${url})
+    if [ $? != 0 ] || [ $resp != "200" ]; then
+	echo "provisioning service $IDENTITY not properly running"
+	exit 1
+    fi
 done

--- a/pservice/bin/ps-status.sh
+++ b/pservice/bin/ps-status.sh
@@ -14,7 +14,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PLIST=$(pgrep -u ${USER:-$(whoami)} -f pservice)
+F_SERVICEHOME="$( cd -P "$( dirname ${BASH_SOURCE[0]} )/.." && pwd )"
+source ${F_SERVICEHOME}/bin/common.sh # from ../../eservice/bin/
+
+F_USAGE='-b|--base name'
+F_BASENAME='pservice'
+
+# -----------------------------------------------------------------
+# Process command line arguments
+# -----------------------------------------------------------------
+TEMP=`getopt -o b:h --long base:,help \
+     -n 'ps-status.sh' -- "$@"`
+
+if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
+
+eval set -- "$TEMP"
+while true ; do
+    case "$1" in
+        -b|--base) F_BASENAME="$2" ; shift 2 ;;
+        --help) echo $F_USAGE ; exit 1 ;;
+	--) shift ; break ;;
+	*) echo "Internal error!" ; exit 1 ;;
+    esac
+done
+
+PLIST=$(pgrepf  "\bpservice .* --config ${F_BASENAME}[0-9].toml\b")
 if [ -n "$PLIST" ] ; then
-    ps -h --format cmd -p $PLIST
+    ps -h --format pid,start,cmd -p $PLIST
 fi

--- a/pservice/bin/ps-stop.sh
+++ b/pservice/bin/ps-stop.sh
@@ -14,22 +14,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-F_USAGE='-b|--base port -c|--count services'
-F_BASE=7000
+F_SERVICEHOME="$( cd -P "$( dirname ${BASH_SOURCE[0]} )/.." && pwd )"
+source ${F_SERVICEHOME}/bin/common.sh # from ../../eservice/bin/
+
+F_USAGE='-c|--count services -b|--base name'
 F_COUNT=1
+F_BASENAME='pservice'
 
 # -----------------------------------------------------------------
 # Process command line arguments
 # -----------------------------------------------------------------
 TEMP=`getopt -o b:c:h --long base:,count:,help \
-     -n 'stop.sh' -- "$@"`
+     -n 'ps-stop.sh' -- "$@"`
 
 if [ $? != 0 ] ; then echo "Terminating..." >&2 ; exit 1 ; fi
 
 eval set -- "$TEMP"
 while true ; do
     case "$1" in
-        -b|--base) F_BASE="$2" ; shift 2 ;;
+        -b|--base) F_BASENAME="$2" ; shift 2 ;;
         -c|--count) F_COUNT="$2" ; shift 2 ;;
         --help) echo $F_USAGE ; exit 1 ;;
 	--) shift ; break ;;
@@ -37,6 +40,16 @@ while true ; do
     esac
 done
 
-for port in `seq $F_BASE $(($F_BASE+$F_COUNT))` ; do
-    curl -s "http://localhost:$port/shutdown"
+rc=0
+for index in `seq 1 $F_COUNT` ; do
+    IDENTITY="${F_BASENAME}$index"
+    echo stopping provisioning service $IDENTITY
+
+    url="$(get_url_base $IDENTITY)/shutdown" || { echo "no url found for enclave service"; exit 1; }
+    resp=$(curl -sL -w "%{http_code}\\n" ${url} -o /dev/null)
+    if [ $? != 0 ]; then # shutdown results in 500 error, so do not test also || [ $resp != "200" ]
+	echo "provisioning service $IDENTITY not running or not properly shut down"
+	rc=1
+    fi
 done
+exit $rc

--- a/pservice/pdo/pservice/scripts/PServiceCLI.py
+++ b/pservice/pdo/pservice/scripts/PServiceCLI.py
@@ -226,6 +226,11 @@ class ProvisioningServer(resource.Resource):
     ## -----------------------------------------------------------------
     def render_GET(self, request) :
         logger.warn('GET REQUEST: %s', request.uri)
+        if request.uri == b'/info':
+            logger.info('info request received')
+            request.setHeader(b"content-type", b"text/plain")
+            request.setResponseCode(http.OK)
+            return "I'm up and running ..".encode("ascii")
         if request.uri == b'/shutdown' :
             logger.warn('shutdown request received')
             reactor.callLater(1, reactor.stop)


### PR DESCRIPTION
Address issue #182 and #164 :
- start detects already running service(s) and returns only
  either after service(s) are up and running or a failure
 - stop does work also with non-default ports and config-files

- fixes small bug in docker Makefile where wrong environment file was sourced
  (omission from commit 7e4f29fe6883bfb43b1d4cf339ff1c8c66c35103)