### PR TITLE
Use the tinyscheme source to build the gipsy development interpreter.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -210,6 +210,40 @@ licenses.
 
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
+tinyscheme
+
+Copyright (c) 2000, Dimitrios Souflis
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+Neither the name of Dimitrios Souflis nor the names of the
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 parson
 
 For project details see: https://github.com/kgabis/parson
@@ -312,4 +346,3 @@ operation of ;this software will be error-free, and I am under no obligation to
 conjunction with products arising from the use of this ;material, there shall be
 no use of my name in any advertising, ;promotional, or sales literature without
 prior written consent in ;each case.
-

--- a/build/__tools__/clean.sh
+++ b/build/__tools__/clean.sh
@@ -27,6 +27,9 @@ SRCDIR="$(realpath ${SCRIPTDIR}/../..)"
 cd $SRCDIR/common/crypto/verify_ias_report
 rm -f ias-certificates.cpp
 
+cd $SRCDIR/common/interpreter/gipsy_scheme/packages
+rm -f package.h package.scm
+
 cd $SRCDIR/common
 rm -rf build
 

--- a/build/__tools__/verify.sh
+++ b/build/__tools__/verify.sh
@@ -90,7 +90,7 @@ try command -v cmake
 try command -v swig
 try command -v make
 try command -v g++
-try command -v tinyscheme
+try command -v ${TINY_SCHEME_SRC}/scheme
 
 if [ ! -d "${PDO_INSTALL_ROOT}" ]; then
     warn "PDO_INSTALL_ROOT directory does not exist"

--- a/common/interpreter/gipsy_scheme/packages/build-init-package.sh
+++ b/common/interpreter/gipsy_scheme/packages/build-init-package.sh
@@ -21,6 +21,45 @@
 F_PACKAGE_NAME='_init_package'
 
 # -----------------------------------------------------------------
+# -----------------------------------------------------------------
+cred=`tput setaf 1`
+cgrn=`tput setaf 2`
+cblu=`tput setaf 4`
+cmag=`tput setaf 5`
+cwht=`tput setaf 7`
+cbld=`tput bold`
+bred=`tput setab 1`
+bgrn=`tput setab 2`
+bblu=`tput setab 4`
+bwht=`tput setab 7`
+crst=`tput sgr0`
+
+function recho () {
+    echo "${cbld}${cred}" $@ "${crst}" >&2
+}
+
+function becho () {
+    echo "${cbld}${cblu}" $@ "${crst}" >&2
+}
+
+function say () {
+    echo "$(basename $0): $*" >&2;
+}
+
+function yell () {
+    becho "$(basename $0): $*" >&2;
+}
+
+function die() {
+    recho "$(basename $0): $*" >&2
+    exit 111
+}
+
+try() {
+    "$@" || die "test failed: $*"
+}
+
+# -----------------------------------------------------------------
 # Process command line arguments
 # -----------------------------------------------------------------
 TEMP=`getopt -o p: --long package: \
@@ -33,7 +72,7 @@ while true ; do
     case "$1" in
         -p|--package) F_PACKAGE_NAME="$2" ; shift 2 ;;
 	--) shift ; break ;;
-	*) echo "Internal error!" ; exit 1 ;;
+	*) die "Internal error!" ;;
     esac
 done
 
@@ -55,6 +94,5 @@ function cleanup {
 
 trap cleanup EXIT
 
-
-tinyscheme -1 $SCRIPTFILE $@ > ${F_PACKAGE_NAME}.scm
-xxd -i ${F_PACKAGE_NAME}.scm ${F_PACKAGE_NAME}.h
+TINYSCHEMEINIT=${TINY_SCHEME_SRC}/init.scm try ${TINY_SCHEME_SRC}/scheme -1 $SCRIPTFILE $@ > ${F_PACKAGE_NAME}.scm
+try xxd -i ${F_PACKAGE_NAME}.scm ${F_PACKAGE_NAME}.h

--- a/common/interpreter/gipsy_scheme/packages/init-package.scm
+++ b/common/interpreter/gipsy_scheme/packages/init-package.scm
@@ -451,12 +451,6 @@
 
 (define (acons x y z) (cons (cons x y) z))
 
-;;;; Handy for imperative programs
-;;;; Used as: (define-with-return (foo x y) .... (return z) ...)
-(macro (define-with-return form)
-     `(define ,(cadr form)
-          (call/cc (lambda (return) ,@(cddr form)))))
-
 ;;;;; Definition of MAKE-ENVIRONMENT, to be used with two-argument EVAL
 
 (macro (make-environment form)

--- a/contracts/auction/Makefile
+++ b/contracts/auction/Makefile
@@ -16,7 +16,7 @@ PDO_HOME ?= /opt/pdo
 
 SRCDIR?=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 ROOTDIR := $(abspath $(SRCDIR)/../..)
-EXTENSIONPATH := $(ROOTDIR)/common/build
+GIPSY_SCHEME := $(ROOTDIR)/contracts/bin/gipsyscheme
 INSTALLDIR = $(PDO_HOME)/contracts
 
 CONTRACTS := _integer-key-auction.scm
@@ -32,13 +32,13 @@ test : $(TESTS)
 	@echo No automated tests defined
 
 _integer-key-auction.scm : integer-key-auction.bld integer-key-auction.scm
-	LD_LIBRARY_PATH=$(EXTENSIONPATH) tinyscheme -1 integer-key-auction.bld
+	$(GIPSY_SCHEME) -1 integer-key-auction.bld
 
 _debug_integer-key-auction.scm : integer-key-auction.bld integer-key-auction.scm auction-test.scm
-	LD_LIBRARY_PATH=$(EXTENSIONPATH) tinyscheme -1 integer-key-auction.bld debug test-auction
+	$(GIPSY_SCHEME) -1 integer-key-auction.bld debug test-auction
 
 _aptest.scm : aptest.bld auction-protocol-test.scm ../integer-key/integer-key.scm integer-key-auction.scm
-	LD_LIBRARY_PATH=$(EXTENSIONPATH) tinyscheme -1 aptest.bld debug aptest
+	$(GIPSY_SCHEME) -1 aptest.bld debug aptest
 
 install : $(CONTRACTS)
 	@echo copy $(CONTRACTS) to $(INSTALLDIR)

--- a/contracts/bin/gipsyscheme
+++ b/contracts/bin/gipsyscheme
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script performs several tests on the environment to ensure
+# that it is set up correctly. It should be run prior to building
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+cred=`tput setaf 1`
+cgrn=`tput setaf 2`
+cblu=`tput setaf 4`
+cmag=`tput setaf 5`
+cwht=`tput setaf 7`
+cbld=`tput bold`
+bred=`tput setab 1`
+bgrn=`tput setab 2`
+bblu=`tput setab 4`
+bwht=`tput setab 7`
+crst=`tput sgr0`
+
+function recho () {
+    echo "${cbld}${cred}" $@ "${crst}" >&2
+}
+
+function becho () {
+    echo "${cbld}${cblu}" $@ "${crst}" >&2
+}
+
+function say () {
+    echo "$(basename $0): $*" >&2;
+}
+
+function yell () {
+    becho "$(basename $0): $*" >&2;
+}
+
+function die() {
+    recho "$(basename $0): $*" >&2
+    exit 111
+}
+
+: "${TINY_SCHEME_SRC:-$(die Missing environment variable TINY_SCHEME_SRC)}"
+
+INIT_FILE=$(mktemp /tmp/pdo-init.XXXXXXXXX)
+function cleanup {
+    rm -f ${INIT_FILE}
+}
+
+trap cleanup EXIT
+
+SCRIPT_DIR="$(dirname $(readlink --canonicalize ${BASH_SOURCE}))"
+PDO_SOURCE_ROOT="$(realpath ${SCRIPT_DIR}/../..)"
+
+EXTENSION_PATH=${PDO_SOURCE_ROOT}/common/build
+if [ ! -f ${EXTENSION_PATH}/pcontract.so ]; then
+   die unable to locate pcontract.so, please build first
+fi
+
+GIPSY_INIT_FILE=${PDO_SOURCE_ROOT}/contracts/packages/init.scm
+if [ ! -f ${GIPSY_INIT_FILE} ]; then
+   die unable to locate gipsy init file
+fi
+
+GIPSY_PACKAGE_DIR=${PDO_SOURCE_ROOT}/common/interpreter/gipsy_scheme/packages/
+sed "s@PACKAGE_DIRECTORY@${GIPSY_PACKAGE_DIR}@" ${GIPSY_INIT_FILE} > ${INIT_FILE}
+
+LD_LIBRARY_PATH=${EXTENSION_PATH} TINYSCHEMEINIT=${INIT_FILE} ${TINY_SCHEME_SRC}/scheme $@

--- a/contracts/exchange/Makefile
+++ b/contracts/exchange/Makefile
@@ -16,7 +16,7 @@ PDO_HOME ?= /opt/pdo
 
 SRCDIR?=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 ROOTDIR := $(abspath $(SRCDIR)/../..)
-EXTENSIONPATH := $(ROOTDIR)/common/build
+GIPSY_SCHEME := $(ROOTDIR)/contracts/bin/gipsyscheme
 INSTALLDIR = $(PDO_HOME)/contracts
 
 CONTRACT_SRC := auction.scm asset_type.scm exchange.scm issuer.scm vetting_organization.scm
@@ -43,34 +43,34 @@ debug :
 
 test : $(TEST_CONTRACTS)
 	@echo Run exchange contract tests
-	@LD_LIBRARY_PATH=$(EXTENSIONPATH) tinyscheme -1 _issuer_test.scm loglevel 2
-	@LD_LIBRARY_PATH=$(EXTENSIONPATH) tinyscheme -1 _exchange_test.scm loglevel 2
-	@LD_LIBRARY_PATH=$(EXTENSIONPATH) tinyscheme -1 _auction_test.scm loglevel 2
+	@$(GIPSY_SCHEME) -1 _issuer_test.scm loglevel 2
+	@$(GIPSY_SCHEME) -1 _exchange_test.scm loglevel 2
+	@$(GIPSY_SCHEME) -1 _auction_test.scm loglevel 2
 	@rm -f exchange-test.mdb exchange-test.mdb-lock
 
 _auction_test.scm : tests/auction_test.bld tests/auction_test.scm $(CONTRACT_SRC) $(PACKAGE_SRC) $(TEST_PACKAGE_SRC)
-	LD_LIBRARY_PATH=$(EXTENSIONPATH) tinyscheme -1 tests/auction_test.bld debug
+	$(GIPSY_SCHEME) -1 tests/auction_test.bld debug
 
 _exchange_test.scm : tests/exchange_test.bld tests/exchange_test.scm $(CONTRACT_SRC) $(PACKAGE_SRC) $(TEST_PACKAGE_SRC)
-	LD_LIBRARY_PATH=$(EXTENSIONPATH) tinyscheme -1 tests/exchange_test.bld debug
+	$(GIPSY_SCHEME) -1 tests/exchange_test.bld debug
 
 _issuer_test.scm : tests/issuer_test.bld tests/issuer_test.scm $(CONTRACT_SRC) $(PACKAGE_SRC) $(TEST_PACKAGE_SRC)
-	LD_LIBRARY_PATH=$(EXTENSIONPATH) tinyscheme -1 tests/issuer_test.bld debug
+	$(GIPSY_SCHEME) -1 tests/issuer_test.bld debug
 
 _asset_type.scm : asset_type.bld asset_type.scm $(PACKAGE_SRC)
-	LD_LIBRARY_PATH=$(EXTENSIONPATH) tinyscheme -1 asset_type.bld
+	$(GIPSY_SCHEME) -1 asset_type.bld
 
 _auction.scm : auction.bld auction.scm $(PACKAGE_SRC)
-	LD_LIBRARY_PATH=$(EXTENSIONPATH) tinyscheme -1 auction.bld
+	$(GIPSY_SCHEME) -1 auction.bld
 
 _exchange.scm : exchange.bld exchange.scm $(PACKAGE_SRC)
-	LD_LIBRARY_PATH=$(EXTENSIONPATH) tinyscheme -1 exchange.bld
+	$(GIPSY_SCHEME) -1 exchange.bld
 
 _issuer.scm : issuer.bld issuer.scm $(PACKAGE_SRC)
-	LD_LIBRARY_PATH=$(EXTENSIONPATH) tinyscheme -1 issuer.bld
+	$(GIPSY_SCHEME) -1 issuer.bld
 
 _vetting_organization.scm : vetting_organization.bld vetting_organization.scm $(PACKAGE_SRC)
-	LD_LIBRARY_PATH=$(EXTENSIONPATH) tinyscheme -1 vetting_organization.bld
+	$(GIPSY_SCHEME) -1 vetting_organization.bld
 
 install : $(CONTRACTS) $(PLUGINS)
 	@echo copy $(CONTRACTS) to $(INSTALLDIR)

--- a/contracts/integer-key/Makefile
+++ b/contracts/integer-key/Makefile
@@ -16,7 +16,7 @@ PDO_HOME ?= /opt/pdo
 
 SRCDIR?=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 ROOTDIR := $(abspath $(SRCDIR)/../..)
-EXTENSIONPATH := $(ROOTDIR)/common/build
+GIPSY_SCHEME := $(ROOTDIR)/contracts/bin/gipsyscheme
 INSTALLDIR = $(PDO_HOME)/contracts
 
 CONTRACTS := _integer-key.scm
@@ -31,10 +31,10 @@ test :
 	@echo No automated tests defined
 
 _integer-key.scm : integer-key.bld integer-key.scm
-	LD_LIBRARY_PATH=$(EXTENSIONPATH) tinyscheme -1 integer-key.bld
+	$(GIPSY_SCHEME) -1 integer-key.bld
 
 _debug_integer-key.scm : integer-key.bld integer-key.scm integer-key-test.scm
-	LD_LIBRARY_PATH=$(EXTENSIONPATH) tinyscheme -1 integer-key.bld debug test-integer-key
+	$(GIPSY_SCHEME) -1 integer-key.bld debug test-integer-key
 
 install : $(CONTRACTS)
 	@echo copy $(CONTRACTS) to $(INSTALLDIR)

--- a/contracts/packages/debug.scm
+++ b/contracts/packages/debug.scm
@@ -12,15 +12,6 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-;; scheme code to incorporate Gipsy interpreter setup in a tinyscheme
-;; interpreter that runs outside the enclave
-
-(load-extension "pcontract")
-
-(require "init-package.scm")
-(require "catch-package.scm")
-(require "oops-package.scm")
-
 ;; -----------------------------------------------------------------
 ;; NAME: catch-success
 ;;

--- a/contracts/packages/init.scm
+++ b/contracts/packages/init.scm
@@ -1,0 +1,191 @@
+;; Portions Copyright 2019 Intel Corporation
+;; Portions Copyright (c) 2000, Dimitrios Souflis, All rights reserved.
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+;; scheme code to incorporate Gipsy interpreter setup in a tinyscheme
+;; interpreter that runs outside the enclave
+
+(load-extension "pcontract")
+
+;; replace PACKAGE_DIRECTORY with the path to the gipsy init packages
+(define package_directory "PACKAGE_DIRECTORY")
+
+(load (string-append package_directory "init-package.scm"))
+
+;;;; Handy for imperative programs
+;;;; Used as: (define-with-return (foo x y) .... (return z) ...)
+(macro (define-with-return form)
+     `(define ,(cadr form)
+          (call/cc (lambda (return) ,@(cddr form)))))
+
+;;;;;Dynamic-wind by Tom Breton (Tehom)
+
+;;Guarded because we must only eval this once, because doing so
+;;redefines call/cc in terms of old call/cc
+(unless (defined? 'dynamic-wind)
+   (let
+      ;;These functions are defined in the context of a private list of
+      ;;pairs of before/after procs.
+      (  (*active-windings* '())
+         ;;We'll define some functions into the larger environment, so
+         ;;we need to know it.
+         (outer-env (current-environment)))
+
+      ;;Poor-man's structure operations
+      (define before-func car)
+      (define after-func  cdr)
+      (define make-winding cons)
+
+      ;;Manage active windings
+      (define (activate-winding! new)
+         ((before-func new))
+         (set! *active-windings* (cons new *active-windings*)))
+      (define (deactivate-top-winding!)
+         (let ((old-top (car *active-windings*)))
+            ;;Remove it from the list first so it's not active during its
+            ;;own exit.
+            (set! *active-windings* (cdr *active-windings*))
+            ((after-func old-top))))
+
+      (define (set-active-windings! new-ws)
+         (unless (eq? new-ws *active-windings*)
+            (let ((shared (shared-tail new-ws *active-windings*)))
+
+               ;;Define the looping functions.
+               ;;Exit the old list.  Do deeper ones last.  Don't do
+               ;;any shared ones.
+               (define (pop-many)
+                  (unless (eq? *active-windings* shared)
+                     (deactivate-top-winding!)
+                     (pop-many)))
+               ;;Enter the new list.  Do deeper ones first so that the
+               ;;deeper windings will already be active.  Don't do any
+               ;;shared ones.
+               (define (push-many new-ws)
+                  (unless (eq? new-ws shared)
+                     (push-many (cdr new-ws))
+                     (activate-winding! (car new-ws))))
+
+               ;;Do it.
+               (pop-many)
+               (push-many new-ws))))
+
+      ;;The definitions themselves.
+      (eval
+         `(define call-with-current-continuation
+             ;;It internally uses the built-in call/cc, so capture it.
+             ,(let ((old-c/cc call-with-current-continuation))
+                 (lambda (func)
+                    ;;Use old call/cc to get the continuation.
+                    (old-c/cc
+                       (lambda (continuation)
+                          ;;Call func with not the continuation itself
+                          ;;but a procedure that adjusts the active
+                          ;;windings to what they were when we made
+                          ;;this, and only then calls the
+                          ;;continuation.
+                          (func
+                             (let ((current-ws *active-windings*))
+                                (lambda (x)
+                                   (set-active-windings! current-ws)
+                                   (continuation x)))))))))
+         outer-env)
+      ;;We can't just say "define (dynamic-wind before thunk after)"
+      ;;because the lambda it's defined to lives in this environment,
+      ;;not in the global environment.
+      (eval
+         `(define dynamic-wind
+             ,(lambda (before thunk after)
+                 ;;Make a new winding
+                 (activate-winding! (make-winding before after))
+                 (let ((result (thunk)))
+                    ;;Get rid of the new winding.
+                    (deactivate-top-winding!)
+                    ;;The return value is that of thunk.
+                    result)))
+         outer-env)))
+
+(define call/cc call-with-current-continuation)
+
+;;;;; I/O
+
+(define (input-output-port? p)
+     (and (input-port? p) (output-port? p)))
+
+(define (close-port p)
+     (cond
+          ((input-output-port? p) (close-input-port (close-output-port p)))
+          ((input-port? p) (close-input-port p))
+          ((output-port? p) (close-output-port p))
+          (else (throw "Not a port" p))))
+
+(define (call-with-input-file s p)
+     (let ((inport (open-input-file s)))
+          (if (eq? inport #f)
+               #f
+               (let ((res (p inport)))
+                    (close-input-port inport)
+                    res))))
+
+(define (call-with-output-file s p)
+     (let ((outport (open-output-file s)))
+          (if (eq? outport #f)
+               #f
+               (let ((res (p outport)))
+                    (close-output-port outport)
+                    res))))
+
+(define (with-input-from-file s p)
+     (let ((inport (open-input-file s)))
+          (if (eq? inport #f)
+               #f
+               (let ((prev-inport (current-input-port)))
+                    (set-input-port inport)
+                    (let ((res (p)))
+                         (close-input-port inport)
+                         (set-input-port prev-inport)
+                         res)))))
+
+(define (with-output-to-file s p)
+     (let ((outport (open-output-file s)))
+          (if (eq? outport #f)
+               #f
+               (let ((prev-outport (current-output-port)))
+                    (set-output-port outport)
+                    (let ((res (p)))
+                         (close-output-port outport)
+                         (set-output-port prev-outport)
+                         res)))))
+
+(define (with-input-output-from-to-files si so p)
+     (let ((inport (open-input-file si))
+           (outport (open-input-file so)))
+          (if (not (and inport outport))
+               (begin
+                    (close-input-port inport)
+                    (close-output-port outport)
+                    #f)
+               (let ((prev-inport (current-input-port))
+                     (prev-outport (current-output-port)))
+                    (set-input-port inport)
+                    (set-output-port outport)
+                    (let ((res (p)))
+                         (close-input-port inport)
+                         (close-output-port outport)
+                         (set-input-port prev-inport)
+                         (set-output-port prev-outport)
+                         res)))))
+
+(load (string-append package_directory "catch-package.scm"))
+(load (string-append package_directory "oops-package.scm"))

--- a/contracts/test-contracts/Makefile
+++ b/contracts/test-contracts/Makefile
@@ -16,7 +16,7 @@ PDO_HOME ?= /opt/pdo
 
 SRCDIR?=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 ROOTDIR := $(abspath $(SRCDIR)/../..)
-EXTENSIONPATH := $(ROOTDIR)/common/build
+GIPSY_SCHEME := $(ROOTDIR)/contracts/bin/gipsyscheme
 INSTALLDIR = $(PDO_HOME)/contracts
 
 CONTRACTS := _mock-contract.scm _mock-contract-bad.scm _key-value-test.scm _memory-test.scm
@@ -30,28 +30,28 @@ test:
 	@echo No automated tests defined
 
 _mock-contract.scm : mock-contract.bld mock-contract.scm
-	LD_LIBRARY_PATH=$(EXTENSIONPATH) tinyscheme -1 mock-contract.bld
+	$(GIPSY_SCHEME) -1 mock-contract.bld
 
 _debug_mock-contract.scm : mock-contract.bld mock-contract.scm
-	LD_LIBRARY_PATH=$(EXTENSIONPATH) tinyscheme -1 mock-contract.bld debug
+	$(GIPSY_SCHEME) -1 mock-contract.bld debug
 
 _mock-contract-bad.scm : mock-contract-bad.bld mock-contract-bad.scm
-	LD_LIBRARY_PATH=$(EXTENSIONPATH) tinyscheme -1 mock-contract-bad.bld
+	$(GIPSY_SCHEME) -1 mock-contract-bad.bld
 
 _debug_mock-contract-bad.scm : mock-contract-bad.bld mock-contract-bad.scm
-	LD_LIBRARY_PATH=$(EXTENSIONPATH) tinyscheme -1 mock-contract-bad.bld debug
+	$(GIPSY_SCHEME) -1 mock-contract-bad.bld debug
 
 _key-value-test.scm : key-value-test.bld key-value-test.scm
-	LD_LIBRARY_PATH=$(EXTENSIONPATH) tinyscheme -1 key-value-test.bld
+	$(GIPSY_SCHEME) -1 key-value-test.bld
 
 _debug_key-value-test.scm : key-value-test.bld key-value-test.scm
-	LD_LIBRARY_PATH=$(EXTENSIONPATH) tinyscheme -1 key-value-test.bld debug
+	$(GIPSY_SCHEME) -1 key-value-test.bld debug
 
 _memory-test.scm : memory-test.bld memory-test.scm
-	LD_LIBRARY_PATH=$(EXTENSIONPATH) tinyscheme -1 memory-test.bld
+	$(GIPSY_SCHEME) -1 memory-test.bld
 
 _debug_memory-test.scm : memory-test.bld memory-test.scm
-	LD_LIBRARY_PATH=$(EXTENSIONPATH) tinyscheme -1 memory-test.bld debug
+	$(GIPSY_SCHEME) -1 memory-test.bld debug
 
 install : $(CONTRACTS)
 	@echo copy $(CONTRACTS) to $(INSTALLDIR)

--- a/docker/Dockerfile.pdo-dev
+++ b/docker/Dockerfile.pdo-dev
@@ -91,7 +91,6 @@ RUN apt-get update \
     software-properties-common \
     swig \
     tar \
-    tinyscheme \
     unzip \
     virtualenv \
     wget \
@@ -177,7 +176,7 @@ RUN wget https://downloads.sourceforge.net/project/tinyscheme/tinyscheme/tinysch
  && unzip tinyscheme-1.41.zip \
  && rm tinyscheme-1.41.zip  \
  && cd tinyscheme-1.41  \
- && make \
+ && make FEATURES='-DUSE_DL=1 -DUSE_PLIST=1' \
  && echo "export TINY_SCHEME_SRC=$(pwd)" >> /etc/profile.d/pdo.sh
 
 # environment setup as required by PDO


### PR DESCRIPTION
We have required three separate tinyscheme packages, one for gipsy
inside the enclave, one source install to build pcontract.so and
one for contract development outside the enclave. This update uses
the source install to build a scheme package that can be used for
development out of the enclave. A script (gipsyscheme) invokes the
scheme interpreter with the appropriate parameters & load files to
mimic (as closely as possible) the environment inside an enclave.

Signed-off-by: Mic Bowman <mic.bowman@intel.com>