### PR TITLE
A number of enhancements to the pdo-shell, prepping to remove other clients

### DIFF
--- a/build/__tools__/run-tests.sh
+++ b/build/__tools__/run-tests.sh
@@ -329,27 +329,10 @@ done
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
-cd ${SCRIPTDIR}
-
-KEYGEN=${SRCDIR}/build/__tools__/make-keys
-if [ ! -f ${PDO_HOME}/keys/red_type_private.pem ]; then
-    for color in red green blue ; do
-        ${KEYGEN} --keyfile ${PDO_HOME}/keys/${color}_type --format pem
-        ${KEYGEN} --keyfile ${PDO_HOME}/keys/${color}_vetting --format pem
-        ${KEYGEN} --keyfile ${PDO_HOME}/keys/${color}_issuer --format pem
-    done
+${SRCDIR}/build/tests/shell-test.psh --loglevel warning | grep 'shell-test result: 1231233123'
+if [ $? != 0 ]; then
+    die shell test failed
 fi
-
-try pdo-shell --logfile $PDO_HOME/logs/client.log --loglevel info  \
-    --eservice-name e1 e2 e3  -s ${SRCDIR}/contracts/exchange/scripts/create.psh -m color red
-
-for p in $(seq 1 3); do
-    pdo-shell --logfile $PDO_HOME/logs/client.log --loglevel info \
-    --eservice-name e${p} -s ${SRCDIR}/contracts/exchange/scripts/issue.psh -m color red -m issuee user$p -m count $(($p * 10))
-done
-
-# clean up the pdo files that are created by the shell
-rm -f ${SCRIPTDIR}/red_issuer.pdo ${SCRIPTDIR}/red_type.pdo ${SCRIPTDIR}/red_vetting.pdo
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------

--- a/build/opt/pdo/etc/template/pcontract.toml
+++ b/build/opt/pdo/etc/template/pcontract.toml
@@ -81,3 +81,12 @@ LogFile  = "__screen__"
 # This key is the contract owner's private elliptic curve PEM key
 SearchPath = [ ".", "./keys", "${keys}" ]
 FileName = "${identity}_private.pem"
+
+# --------------------------------------------------
+# Bindings -- macro expansions for pdo-shell
+# --------------------------------------------------
+[Bindings]
+data = "${data}"
+save = "${data}/__contract_cache__"
+home = "${home}"
+base = "${base}"

--- a/build/tests/shell-test.psh
+++ b/build/tests/shell-test.psh
@@ -1,0 +1,88 @@
+#! /usr/bin/env pdo-shell
+
+## Copyright 2018 Intel Corporation
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+set -q --conditional -s data -v .
+set -q --conditional -s save -v .
+
+## create an eservice db with the known enclave services
+eservice_db clear
+eservice_db add --url http://localhost:7101 --name es7101
+eservice_db add --url http://localhost:7102 --name es7102
+eservice_db add --url http://localhost:7103 --name es7103
+eservice_db add --url http://localhost:7104 --name es7104
+eservice_db add --url http://localhost:7105 --name es7105
+eservice_db save --database ${data}/test-db.json
+
+eservice_db clear
+eservice_db load --database ${data}/test-db.json
+
+## default pservice group
+pservice add --url http://localhost:7001
+pservice add --url http://localhost:7002
+pservice add --url http://localhost:7003
+
+## pservice group p1
+pservice --group p1 add --url http://localhost:7003
+pservice --group p1 add --url http://localhost:7004
+pservice --group p1 add --url http://localhost:7005
+
+## pservice group all
+pservice --group all add --url http://localhost:7001
+pservice --group all add --url http://localhost:7002
+pservice --group all add --url http://localhost:7003
+pservice --group all add --url http://localhost:7004
+pservice --group all add --url http://localhost:7005
+
+## default eservice group
+eservice add --url http://localhost:7101
+eservice add --url http://localhost:7102
+eservice add --url http://localhost:7103
+
+## eservice group e1
+eservice --group e1 add --name es7103 es7104 es7105
+eservice --group e1 use --url http://localhost:7105
+
+## eservice group all
+eservice --group all add --url http://localhost:7101
+eservice --group all add --url http://localhost:7102 http://localhost:7103 --name es7104 es7105
+eservice --group all use --name es7104
+
+## create some contracts
+set -q -s contract1 -r 32
+set -q -s contract2 -r 32
+set -q -s contract3 -r 32
+
+identity -n user1
+create -c mock-contract -s _mock-contract -f ${save}/${contract1}.pdo
+send -f ${save}/${contract1}.pdo "'(inc-value)" -s r1
+send -f ${save}/${contract1}.pdo "'(inc-value)" -s r2
+send -f ${save}/${contract1}.pdo "'(inc-value)" -s r3
+
+identity -n user2
+create -c mock-contract -s _mock-contract -p all -e all -f ${save}/${contract2}.pdo
+send -f ${save}/${contract2}.pdo --wait "'(inc-value)" -s r4
+send -f ${save}/${contract2}.pdo --wait "'(inc-value)" -s r5
+send -f ${save}/${contract2}.pdo --wait "'(inc-value)" -s r6
+send -f ${save}/${contract2}.pdo "'(get-value)" -s r7
+
+identity -n user3
+create -c mock-contract -s _mock-contract -p p1 -e e1 -f ${save}/${contract3}.pdo
+send -f ${save}/${contract3}.pdo "'(inc-value)" -s r8
+send -f ${save}/${contract3}.pdo "'(inc-value)" -s r9
+send -f ${save}/${contract3}.pdo "'(inc-value)" -s r10
+
+echo shell-test result: ${r1}${r2}${r3}${r4}${r5}${r6}${r7}${r8}${r9}${r10}
+exit

--- a/client/MANIFEST
+++ b/client/MANIFEST
@@ -2,6 +2,7 @@
 ./pdo/client/controller/commands/create.py
 ./pdo/client/controller/commands/pservice.py
 ./pdo/client/controller/commands/eservice.py
+./pdo/client/controller/commands/eservice_db.py
 ./pdo/client/controller/commands/contract.py
 ./pdo/client/controller/commands/__init__.py
 ./pdo/client/controller/contract_controller.py

--- a/client/pdo/client/controller/commands/__init__.py
+++ b/client/pdo/client/controller/commands/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__all__ = [ 'contract', 'create', 'eservice', 'pservice', 'send' ]
+__all__ = [ 'contract', 'create', 'eservice', 'eservice_db', 'pservice', 'send' ]
 
 import pdo.client.controller.commands.contract
 contract = contract.command_contract
@@ -22,6 +22,9 @@ create = create.command_create
 
 import pdo.client.controller.commands.eservice
 eservice = eservice.command_eservice
+
+import pdo.client.controller.commands.eservice_db
+eservice_db = eservice_db.command_eservice_db
 
 import pdo.client.controller.commands.pservice
 pservice = pservice.command_pservice

--- a/client/pdo/client/controller/commands/contract.py
+++ b/client/pdo/client/controller/commands/contract.py
@@ -91,18 +91,23 @@ def load_contract(state, contract_file) :
 
 ## -----------------------------------------------------------------
 ## -----------------------------------------------------------------
+__contract_cache__ = {}
+
 def get_contract(state, save_file=None) :
     """ Get contract object using the save_file. If there is no save_file, try loading contract using config."""
-   
-    if save_file is not None :
-        return load_contract(state, save_file)
 
-    current_contract = state.get(['Contract', 'Contract'], None)
-    if current_contract is not None :
-        return current_contract
+    global __contract_cache__
 
-    current_save_file = state.get(['Contract', 'SaveFile'], None)
-    if current_save_file is None :
-        raise Exception('no contract specified')
+    if save_file is None :
+        current_contract = state.get(['Contract', 'Contract'], None)
+        if current_contract is not None :
+            return current_contract
 
-    return load_contract(current_save_file)
+        save_file = state.get(['Contract', 'SaveFile'], None)
+        if save_file is None :
+            raise Exception('no contract specified')
+
+    if save_file not in __contract_cache__ :
+        __contract_cache__[save_file] = load_contract(state, save_file)
+
+    return __contract_cache__[save_file]

--- a/client/pdo/client/controller/commands/eservice.py
+++ b/client/pdo/client/controller/commands/eservice.py
@@ -13,96 +13,148 @@
 # limitations under the License.
 
 import argparse
-import logging
+import random
 
+import logging
 logger = logging.getLogger(__name__)
 
 from pdo.service_client.enclave import EnclaveServiceClient
+import pdo.service_client.service_data.eservice as eservice_db
 
-__all__ = ['command_eservice']
+__all__ = ['command_eservice', 'get_eservice', 'get_eservice_list']
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def __expand_eservice_names__(names) :
+    result = set()
+    if names :
+        for name in names :
+            eservice_info = eservice_db.get_info_by_name(name)
+            logger.info('eservice_info: %s', eservice_info)
+            if eservice_info is None :
+                raise Exception('unknown eservice name {0}'.format(name))
+            result.add(eservice_info['url'])
+
+    return result
 
 ## -----------------------------------------------------------------
 ## -----------------------------------------------------------------
 def command_eservice(state, bindings, pargs) :
     """controller command to manage the list of enclave services
     """
-    subcommands = ['add', 'remove', 'set', 'use', 'info', 'list']
+    subcommands = ['add', 'remove', 'set', 'list', 'create-group', 'use' ]
 
     parser = argparse.ArgumentParser(prog='eservice')
+    parser.add_argument('--group', help='Name of the eservice group', type=str, default="default")
+
     subparsers = parser.add_subparsers(dest='command')
-    add_parser = subparsers.add_parser('add')
-    add_parser.add_argument('--url', help='URLs for the enclave service', type=str, nargs='+', required=True)
 
-    remove_parser = subparsers.add_parser('remove')
-    remove_parser.add_argument('--url', help='URLs for the enclave service', type=str, nargs='+', required=True)
+    subparser = subparsers.add_parser('add')
+    subparser.add_argument('--url', help='URLs for enclave services', type=str, nargs='+')
+    subparser.add_argument('--name', help='EService DB name for enclave services', type=str, nargs='+')
 
-    set_parser = subparsers.add_parser('set')
-    set_parser.add_argument('--url', help='URLs for the enclave service', type=str, nargs='+', required=True)
+    subparser = subparsers.add_parser('remove')
+    subparser.add_argument('--url', help='URLs for enclave services', type=str, nargs='+')
+    subparser.add_argument('--name', help='EService DB name for enclave services', type=str, nargs='+')
 
-    info_parser = subparsers.add_parser('use')
-    info_parser.add_argument('--url', help='URLs for the enclave service', type=str, required=True)
+    subparser = subparsers.add_parser('set')
+    subparser.add_argument('--url', help='URLs for enclave services', type=str, nargs='+')
+    subparser.add_argument('--name', help='EService DB name for enclave services', type=str, nargs='+')
 
-    info_parser = subparsers.add_parser('info')
-    info_parser.add_argument('--url', help='URLs for the enclave service', type=str, nargs='+')
+    subparser = subparsers.add_parser('list')
 
-    list_parser = subparsers.add_parser('list')
+    subparser = subparsers.add_parser('use')
+    eservice_group = subparser.add_mutually_exclusive_group(required=True)
+    eservice_group.add_argument('--url', help='URLs for enclave services', type=str)
+    eservice_group.add_argument('--name', help='EService DB name for enclave services', type=str)
+    eservice_group.add_argument('--random', help='No preferred enclave service', action='store_true')
 
     options = parser.parse_args(pargs)
 
     if options.command == 'add' :
-        services = set(state.get(['Service', 'EnclaveServiceURLs'], []))
-        services = services.union(options.url)
-        state.set(['Service', 'EnclaveServiceURLs'], list(services))
+        services = set(state.get(['Service', 'EnclaveServiceGroups', options.group, 'urls'], []))
+        if options.url :
+            services = services.union(options.url)
+        if options.name :
+            services = services.union(__expand_eservice_names__(options.name))
+        state.set(['Service', 'EnclaveServiceGroups', options.group, 'urls'], list(services))
         return
 
     if options.command == 'remove' :
-        services = set(state.get(['Service', 'EnclaveServiceURLs'], []))
-        services = services.difference(options.url)
-        state.set(['Service', 'EnclaveServiceURLs'], list(services))
+        services = set(state.get(['Service', 'EnclaveServiceGroups', options.group, 'urls'], []))
+        if options.url :
+            services = services.difference(options.url)
+        if options.name :
+            services = services.difference(__expand_eservice_names__(options.name))
+        state.set(['Service', 'EnclaveServiceGroups', options.group, 'urls'], list(services))
         return
 
     if options.command == 'set' :
-        state.set(['Service', 'EnclaveServiceURLs'], options.url)
+        services = set()
+        if options.url :
+            services = services.union(options.url)
+        if options.name :
+            services = services.union(__expand_eservice_names__(options.name))
+        state.set(['Service', 'EnclaveServiceGroups', options.group, 'urls'], list(services))
         return
 
     if options.command == 'use' :
-        state.set(['Service', 'PreferredEnclaveService'], options.url)
-        return
+        if options.random :
+            state.set(['Service', 'EnclaveServiceGroups', options.group, 'preferred'], 'random')
+            return
 
-    if options.command == 'info' :
-        services = state.get(['Service', 'EnclaveServiceURLs'])
+        service_url = None
         if options.url :
-            services = options.url
+            service_url = options.url
+        if options.name :
+            service_info = eservice_db.get_info_by_name(options.name)
+            service_url = service_info['url']
 
-        for url in services :
-            try :
-                client = EnclaveServiceClient(url)
-                print("{0} --> {1}".format(url, client.verifying_key))
-            except :
-                print('unable to retreive information from {0}'.format(url))
+        services = state.get(['Service', 'EnclaveServiceGroups', options.group, 'urls'], [])
+        if service_url in services :
+            state.set(['Service', 'EnclaveServiceGroups', options.group, 'preferred'], service_url)
+        else :
+            print('preferred URL not in the service group')
         return
 
     if options.command == 'list' :
-        services = set(state.get(['Service', 'EnclaveServiceURLs'], []))
+        preferred = state.get(['Service', 'EnclaveServiceGroups', options.group, 'preferred'], 'random')
+        services = state.get(['Service', 'EnclaveServiceGroups', options.group, 'urls'], [])
+        print("preferred: {0}".format(preferred))
         for service in services :
             print(service)
-
         return
 
     raise Exception('unknown subcommand')
 
 ## -----------------------------------------------------------------
 ## -----------------------------------------------------------------
-def get_enclave_service(state, enclave_url=None) :
+def get_eservice(state, eservice_url=None, eservice_group="default") :
     """create an enclave client for the preferred enclave service; assumes
     exception handling by the calling procedure
     """
-    if enclave_url is None :
-        enclave_url = state.get(['Service', 'PreferredEnclaveService'], None)
-        if enclave_url is None :
-            enclave_url = random.choice(state.get(['Service', 'EnclaveServiceURLs'], []))
+    if eservice_url is None :
+        eservice_url = state.get(['Service', 'EnclaveServiceGroups', eservice_group, 'preferred'], None)
+        logger.debug('preferred eservice: %s', eservice_url)
 
-    if enclave_url is None :
+        if eservice_url == 'random' or eservice_url is None :
+            eservice_url = random.choice(state.get(['Service', 'EnclaveServiceGroups', eservice_group, 'urls'], []))
+
+    if eservice_url is None :
         raise Exception('no enclave service specified')
 
-    return EnclaveServiceClient(enclave_url)
+    logger.debug('get client for %s', eservice_url)
+    return EnclaveServiceClient(eservice_url)
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def get_eservice_list(state, eservice_group="default") :
+    """create a list of eservice clients from the specified eservice group; assumes
+    exception handling by the calling procedure
+    """
+    eservice_url_list = state.get(['Service', 'EnclaveServiceGroups', eservice_group, 'urls'], [])
+    eservice_client_list = []
+    for eservice_url in eservice_url_list :
+        eservice_client_list.append(EnclaveServiceClient(eservice_url))
+
+    return eservice_client_list

--- a/client/pdo/client/controller/commands/eservice_db.py
+++ b/client/pdo/client/controller/commands/eservice_db.py
@@ -1,0 +1,90 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import logging
+
+logger = logging.getLogger(__name__)
+
+import pdo.service_client.service_data.eservice as eservice_db
+
+__all__ = ['command_eservice_db']
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def command_eservice_db(state, bindings, pargs) :
+    """controller command to manage the enclave service database
+    """
+
+    parser = argparse.ArgumentParser(prog='eservice')
+
+    subparsers = parser.add_subparsers(dest='command')
+
+    add_parser = subparsers.add_parser('add', description='add an eservice to the database')
+    add_parser.add_argument('--url', help='URL for the enclave service to add', type=str, required=True)
+    add_parser.add_argument('--name', help='Short name for the enclave service', type=str, required=True)
+
+    clear_parser = subparsers.add_parser('clear', description='remove all eservices in the database')
+    list_parser = subparsers.add_parser('list', description='list eservices in the database')
+
+    load_parser = subparsers.add_parser('load', description='load an eservice database')
+    load_parser.add_argument('--database', help='Name of the eservice database to use', type=str, required=True)
+    merge_group = load_parser.add_mutually_exclusive_group(required=False)
+    merge_group.add_argument('--merge', help='Merge new database with current db', dest='merge', action='store_true')
+    merge_group.add_argument('--no-merge', help='Overwrite current db with new database', dest='merge', action='store_false')
+    load_parser.set_defaults(merge=False)
+
+    remove_parser = subparsers.add_parser('remove', description='remove eservice from the database')
+    remove_group = remove_parser.add_mutually_exclusive_group(required=True)
+    remove_group.add_argument('--url', help='URL for enclave service to remove', type=str)
+    remove_group.add_argument('--name', help='Short name for enclave service to remove', type=str)
+
+    save_parser = subparsers.add_parser('save', description='save the current eservice database')
+    save_parser.add_argument('--database', help='Name of the eservice database to use', type=str, required=True)
+
+    options = parser.parse_args(pargs)
+
+    default_database = state.get(['Service', 'EnclaveServiceDatabaseFile'])
+    ledger_config = state.get(['Sawtooth'])
+
+    if options.command == 'add' :
+        if not eservice_db.add_info_to_database(options.name, options.url, ledger_config) :
+            print('failed to add eservice to the database')
+        return
+
+    if options.command == 'clear' :
+        eservice_db.clear_all_data()
+        return
+
+    if options.command == 'list' :
+        for url in eservice_db.__name_by_url__.keys() :
+            print("{0} --> {1}".format(eservice_db.__name_by_url__[url], url))
+        return
+
+    if options.command == 'load' :
+        eservice_db.load_database(options.database, options.merge)
+        return
+
+    if options.command == 'remove' :
+        if options.name :
+            eservice_db.remove_info_from_database(name=options.name)
+        else :
+            eservice_db.remove_info_from_database(url=options.url)
+        return
+
+    if options.command == 'save' :
+        eservice_db.save_database(options.database, True)
+        return
+
+    raise Exception('unknown subcommand')

--- a/contracts/auction/integer-key-auction.py
+++ b/contracts/auction/integer-key-auction.py
@@ -71,14 +71,14 @@ def __command_auction__(state, bindings, pargs) :
 
     if options.command == 'get_signing_key' :
         message = "'(get-public-signing-key)"
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         if result and options.symbol :
             bindings.bind(options.symbol, result)
         return
 
     if options.command == 'initialize' :
         message = "'(initialize \"{0}\")".format(options.key)
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     if options.command == 'prime' :
@@ -87,7 +87,7 @@ def __command_auction__(state, bindings, pargs) :
         dependencies = str(attestation.nth(1))
         signature = str(attestation.nth(2))
         message = "'(prime-auction* {0} {1} {2})".format(bidinfo, dependencies, signature)
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     if options.command == 'submit_bid' :
@@ -96,44 +96,44 @@ def __command_auction__(state, bindings, pargs) :
         dependencies = str(attestation.nth(1))
         signature = str(attestation.nth(2))
         message = "'(submit-bid* {0} {1} {2})".format(bidinfo, dependencies, signature)
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     if options.command == 'get_offered_asset' :
         message = "'(get-offered-asset)"
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     if options.command == 'cancel_bid' :
         message = "'(cancel-bid)"
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     if options.command == 'check_bid' :
         message = "'(check-bid)"
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     if options.command == 'max_bid' :
         message = "'(max-bid)"
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     if options.command == 'close_bidding' :
         message = "'(close-bidding)"
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     if options.command == 'cancel_attestation' :
         message = "'(cancel-attestation)"
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         if result and options.symbol :
             bindings.bind(options.symbol, result)
         return
 
     if options.command == 'exchange_attestation' :
         message = "'(exchange-attestation)"
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         if result and options.symbol :
             bindings.bind(options.symbol, result)
         return

--- a/contracts/exchange/asset_type.py
+++ b/contracts/exchange/asset_type.py
@@ -51,14 +51,14 @@ def __command_asset_type__(state, bindings, pargs) :
     # -------------------------------------------------------
     if options.command == 'initialize' :
         message = "'(initialize \"{0}\" \"{1}\" \"{2}\")".format(options.name, options.description, options.link)
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     # -------------------------------------------------------
     if options.command == 'get_identifier' :
         extraparams['commit'] = False
         message = "'(get-identifier)"
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         if result and options.symbol :
             bindings.bind(options.symbol, result)
         return
@@ -68,11 +68,11 @@ def __command_asset_type__(state, bindings, pargs) :
         extraparams['quiet'] = True
         extraparams['commit'] = False
         message = "'(get-name)"
-        name = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        name = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         message = "'(get-description)"
-        description = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        description = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         message = "'(get-link)"
-        link = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        link = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         print("NAME: {0}".format(name))
         print("DESC: {1}".format(description))
         print("LINK: {2}".format(link))

--- a/contracts/exchange/auction.py
+++ b/contracts/exchange/auction.py
@@ -79,7 +79,7 @@ def __command_auction__(state, bindings, pargs) :
     if options.command == 'get_verifying_key' :
         extraparams['commit'] = False
         message = "'(get-verifying-key)"
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         if result and options.symbol :
             bindings.bind(options.symbol, result)
         return
@@ -88,34 +88,34 @@ def __command_auction__(state, bindings, pargs) :
     if options.command == 'get_offered_asset' :
         extraparams['commit'] = False
         message = "'(examine-offered-asset)"
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     # -------------------------------------------------------
     if options.command == 'get_requested_asset' :
         extraparams['commit'] = False
         message = "'(examine-requested-asset)"
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     # -------------------------------------------------------
     if options.command == 'initialize' :
         asset_request = "(\"{0}\" {1} \"{2}\")".format(options.type_id, options.count, options.owner)
         message = "'(initialize {0} \"{1}\")".format(asset_request, options.root)
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     # -------------------------------------------------------
     if options.command == 'offer' :
         message = "'(offer-asset {0})".format(options.asset)
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     # -------------------------------------------------------
     if options.command == 'claim_offer' :
         extraparams['commit'] = False
         message = "'(claim-offer)"
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         if result and options.symbol :
             bindings.bind(options.symbol, result)
         return
@@ -123,11 +123,11 @@ def __command_auction__(state, bindings, pargs) :
     # -------------------------------------------------------
     if options.command == 'cancel_auction' :
         message = "'(cancel-auction)"
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         if result == "#t" :
             extraparams['commit'] = False
             message = "'(cancel-auction-attestation)"
-            send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+            send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
             if result and options.symbol :
                 bindings.bind(options.symbol, result)
         return
@@ -135,40 +135,40 @@ def __command_auction__(state, bindings, pargs) :
     # -------------------------------------------------------
     if options.command == 'close_auction' :
         message = "'(close-auction)"
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     # -------------------------------------------------------
     if options.command == 'confirm_close' :
         message = "'(confirm-close)"
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     # -------------------------------------------------------
     if options.command == 'submit_bid' :
         message = "'(submit-bid {0})".format(options.asset)
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     # -------------------------------------------------------
     if options.command == 'max_bid' :
         extraparams['commit'] = False
         message = "'(max-bid)"
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     # -------------------------------------------------------
     if options.command == 'check_bid' :
         extraparams['commit'] = False
         message = "'(check-bid)"
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     # -------------------------------------------------------
     if options.command == 'claim_bid' :
         extraparams['commit'] = False
         message = "'(claim-bid)"
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         if result and options.symbol :
             bindings.bind(options.symbol, result)
         return
@@ -176,11 +176,11 @@ def __command_auction__(state, bindings, pargs) :
     # -------------------------------------------------------
     if options.command == 'cancel_bid' :
         message = "'(cancel-bid)"
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         if result == "#t" :
             extraparams['commit'] = False
             message = "'(cancel-bid-attestation)"
-            result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+            result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
             if result and options.symbol :
                 bindings.bind(options.symbol, result)
 

--- a/contracts/exchange/exchange.py
+++ b/contracts/exchange/exchange.py
@@ -71,7 +71,7 @@ def __command_exchange__(state, bindings, pargs) :
     if options.command == 'get_verifying_key' :
         extraparams['commit'] = False
         message = "'(get-verifying-key)"
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         if result and options.symbol :
             bindings.bind(options.symbol, result)
         return
@@ -80,34 +80,34 @@ def __command_exchange__(state, bindings, pargs) :
     if options.command == 'get_offered_asset' :
         extraparams['commit'] = False
         message = "'(examine-offered-asset)"
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     # -------------------------------------------------------
     if options.command == 'get_requested_asset' :
         extraparams['commit'] = False
         message = "'(examine-requested-asset)"
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     # -------------------------------------------------------
     if options.command == 'initialize' :
         asset_request = "(\"{0}\" {1} \"{2}\")".format(options.type_id, options.count, options.owner)
         message = "'(initialize {0} \"{1}\")".format(asset_request, options.root)
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     # -------------------------------------------------------
     if options.command == 'offer' :
         message = "'(offer-asset {0})".format(options.asset)
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     # -------------------------------------------------------
     if options.command == 'claim_offer' :
         extraparams['commit'] = False
         message = "'(claim-offer)"
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         if result and options.symbol :
             bindings.bind(options.symbol, result)
         return
@@ -115,14 +115,14 @@ def __command_exchange__(state, bindings, pargs) :
     # -------------------------------------------------------
     if options.command == 'exchange' :
         message = "'(exchange-asset {0})".format(options.asset)
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     # -------------------------------------------------------
     if options.command == 'claim_exchange' :
         extraparams['commit'] = False
         message = "'(claim-exchange)"
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         if result and options.symbol :
             bindings.bind(options.symbol, result)
         return
@@ -130,14 +130,14 @@ def __command_exchange__(state, bindings, pargs) :
     # -------------------------------------------------------
     if options.command == 'cancel' :
         message = "'(cancel)"
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     # -------------------------------------------------------
     if options.command == 'cancel_attestation' :
         extraparams['commit'] = False
         message = "'(cancel-attestation)"
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         if result and options.symbol :
             bindings.bind(options.symbol, result)
         return

--- a/contracts/exchange/issuer.py
+++ b/contracts/exchange/issuer.py
@@ -71,7 +71,7 @@ def __command_issuer__(state, bindings, pargs) :
     if options.command == 'get_verifying_key' :
         extraparams['commit'] = False
         message = "'(get-verifying-key)"
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         if result and options.symbol :
             bindings.bind(options.symbol, result)
         return
@@ -80,7 +80,7 @@ def __command_issuer__(state, bindings, pargs) :
     if options.command == 'get_balance' :
         extraparams['commit'] = False
         message = "'(get-balance)"
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         if result and options.symbol :
             bindings.bind(options.symbol, result)
         return
@@ -88,19 +88,19 @@ def __command_issuer__(state, bindings, pargs) :
     # -------------------------------------------------------
     if options.command == 'initialize' :
         message = "'(initialize \"{0}\" {1})".format(options.type_id, options.authority)
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     # -------------------------------------------------------
     if options.command == 'issue' :
         message = "'(issue \"{0}\" {1})".format(options.owner, options.count)
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     # -------------------------------------------------------
     if options.command == 'transfer' :
         message = "'(transfer \"{0}\" {1})".format(options.new_owner, options.count)
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     # -------------------------------------------------------
@@ -108,12 +108,12 @@ def __command_issuer__(state, bindings, pargs) :
         extraparams['commit'] = True
         extraparams['wait'] = True
         message = "'(escrow \"{0}\")".format(options.agent)
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
 
         extraparams['commit'] = False
         extraparams['wait'] = False
         message = "'(escrow-attestation)"
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         if result and options.symbol :
             bindings.bind(options.symbol, result)
         return
@@ -124,7 +124,7 @@ def __command_issuer__(state, bindings, pargs) :
         dependencies = str(attestation.nth(0))
         signature = str(attestation.nth(1))
         message = "'(disburse {0} {1})".format(dependencies, signature)
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     # -------------------------------------------------------
@@ -134,7 +134,7 @@ def __command_issuer__(state, bindings, pargs) :
         dependencies = str(attestation.nth(1))
         signature = str(attestation.nth(2))
         message = "'(claim {0} {1} {2})".format(old_owner_identity, dependencies, signature)
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
 ## -----------------------------------------------------------------

--- a/contracts/exchange/scripts/auction.psh
+++ b/contracts/exchange/scripts/auction.psh
@@ -1,3 +1,5 @@
+#! /usr/bin/env pdo-shell
+
 ## Copyright 2018 Intel Corporation
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +19,6 @@
 ## object.
 ##
 ## The following shell variables are assumed:
-##    path -- the path where the contract objects are stored (default = '.')
 ##    auction_user -- the identity of the user initiating the auction (default = user1)
 ##    auction_color -- the color to use for the offered marbles (default = 'green')
 ##    bidder[1-5] -- the identity of the user responding to the auction (default = user[6-10])
@@ -26,12 +27,10 @@
 
 ## $ pdo-shell -s auction.psh
 
-load_plugin -c asset_type
-load_plugin -c vetting
-load_plugin -c issuer
-load_plugin -c auction
+set -q --conditional -s data -v .
+set -q --conditional -s save -v .
+script -f ${path}/init.psh
 
-set -q --conditional -s path -v .
 set -q --conditional -s auction_user -v user1
 set -q --conditional -s auction_color -v green
 set -q --conditional -s bidder1 -v user6
@@ -46,106 +45,106 @@ set -q --conditional -s minimum_bid -v 50
 echo ${auction_user} creates an auction to trade ${auction_color} marbles for at least ${minimum_bid} ${bid_color} marbles
 ## =================================================================
 identity -n ${auction_user}
-create -c auction-contract -s _auction -f ${path}/auction.pdo
+create -c auction-contract -s _auction -f ${save}/auction.pdo
 
 ## Get some information that will be used later
 ## auction_vk -- auction contract verifying key/identity
 ## request_vk -- vetting organization identity for requested asset
 ## request_type_id -- type identifier for the requested marble type
-auction -q -f ${path}/auction.pdo get_verifying_key -s auction_vk
-vetting -q -f ${path}/${bid_color}_vetting.pdo get_verifying_key -s request_vk
-asset_type -q -f ${path}/${bid_color}_type.pdo get_identifier -s request_type_id
+auction -q -f ${save}/auction.pdo get_verifying_key -s auction_vk
+vetting -q -f ${save}/${bid_color}_vetting.pdo get_verifying_key -s request_vk
+asset_type -q -f ${save}/${bid_color}_type.pdo get_identifier -s request_type_id
 
 ## Initialize the auction with the request parameters
-auction -q -w -f ${path}/auction.pdo initialize -r ${request_vk} -t ${request_type_id} -c ${minimum_bid}
+auction -q -w -f ${save}/auction.pdo initialize -r ${request_vk} -t ${request_type_id} -c ${minimum_bid}
 
 ## =================================================================
 echo escrow ${auction_color} marbles for ${auction_user} and add to the auction
 ## =================================================================
 identity -n ${auction_user}
-issuer -f ${path}/${auction_color}_issuer.pdo get_balance
-issuer -q -w -f ${path}/${auction_color}_issuer.pdo escrow -a ${auction_vk} -s escrow
-auction -q -w -f ${path}/auction.pdo offer -a '${escrow}'
+issuer -f ${save}/${auction_color}_issuer.pdo get_balance
+issuer -q -w -f ${save}/${auction_color}_issuer.pdo escrow -a ${auction_vk} -s escrow
+auction -q -w -f ${save}/auction.pdo offer -a '${escrow}'
 
 ## =================================================================
 echo escrow ${bid_color} marbles and submit the bid to the auction
 ## =================================================================
 identity -n ${bidder1}
-issuer -f ${path}/${bid_color}_issuer.pdo get_balance
-issuer -q -w -f ${path}/${bid_color}_issuer.pdo escrow -a ${auction_vk} -s escrow
-auction -q -w -f ${path}/auction.pdo submit_bid -a '${escrow}'
-auction -f ${path}/auction.pdo max_bid
+issuer -f ${save}/${bid_color}_issuer.pdo get_balance
+issuer -q -w -f ${save}/${bid_color}_issuer.pdo escrow -a ${auction_vk} -s escrow
+auction -q -w -f ${save}/auction.pdo submit_bid -a '${escrow}'
+auction -f ${save}/auction.pdo max_bid
 
 identity -n ${bidder2}
-issuer -f ${path}/${bid_color}_issuer.pdo get_balance
-issuer -q -w -f ${path}/${bid_color}_issuer.pdo escrow -a ${auction_vk} -s escrow
-auction -q -w -f ${path}/auction.pdo submit_bid -a '${escrow}'
-auction -f ${path}/auction.pdo max_bid
+issuer -f ${save}/${bid_color}_issuer.pdo get_balance
+issuer -q -w -f ${save}/${bid_color}_issuer.pdo escrow -a ${auction_vk} -s escrow
+auction -q -w -f ${save}/auction.pdo submit_bid -a '${escrow}'
+auction -f ${save}/auction.pdo max_bid
 
 identity -n ${bidder3}
-issuer -f ${path}/${bid_color}_issuer.pdo get_balance
-issuer -q -w -f ${path}/${bid_color}_issuer.pdo escrow -a ${auction_vk} -s escrow
-auction -q -w -f ${path}/auction.pdo submit_bid -a '${escrow}'
-auction -f ${path}/auction.pdo max_bid
+issuer -f ${save}/${bid_color}_issuer.pdo get_balance
+issuer -q -w -f ${save}/${bid_color}_issuer.pdo escrow -a ${auction_vk} -s escrow
+auction -q -w -f ${save}/auction.pdo submit_bid -a '${escrow}'
+auction -f ${save}/auction.pdo max_bid
 
 identity -n ${bidder4}
-issuer -f ${path}/${bid_color}_issuer.pdo get_balance
-issuer -q -w -f ${path}/${bid_color}_issuer.pdo escrow -a ${auction_vk} -s escrow
-auction -q -w -f ${path}/auction.pdo submit_bid -a '${escrow}'
-auction -f ${path}/auction.pdo max_bid
+issuer -f ${save}/${bid_color}_issuer.pdo get_balance
+issuer -q -w -f ${save}/${bid_color}_issuer.pdo escrow -a ${auction_vk} -s escrow
+auction -q -w -f ${save}/auction.pdo submit_bid -a '${escrow}'
+auction -f ${save}/auction.pdo max_bid
 
 identity -n ${bidder5}
-issuer -f ${path}/${bid_color}_issuer.pdo get_balance
-issuer -q -w -f ${path}/${bid_color}_issuer.pdo escrow -a ${auction_vk} -s escrow
-auction -q -w -f ${path}/auction.pdo submit_bid -a '${escrow}'
-auction -f ${path}/auction.pdo max_bid
+issuer -f ${save}/${bid_color}_issuer.pdo get_balance
+issuer -q -w -f ${save}/${bid_color}_issuer.pdo escrow -a ${auction_vk} -s escrow
+auction -q -w -f ${save}/auction.pdo submit_bid -a '${escrow}'
+auction -f ${save}/auction.pdo max_bid
 
 ## =================================================================
 echo close the auction
 ## =================================================================
 identity -n ${auction_user}
-auction -q -w -f ${path}/auction.pdo close_auction
+auction -q -w -f ${save}/auction.pdo close_auction
 
 identity -n ${bidder5}
-auction -q -w -f ${path}/auction.pdo confirm_close
+auction -q -w -f ${save}/auction.pdo confirm_close
 
 ## =================================================================
 echo claim resources
 ## =================================================================
 identity -n ${auction_user}
-auction -q -w -f ${path}/auction.pdo claim_bid -s asset
-issuer -q -w -f ${path}/${bid_color}_issuer.pdo claim -a '${asset}'
+auction -q -w -f ${save}/auction.pdo claim_bid -s asset
+issuer -q -w -f ${save}/${bid_color}_issuer.pdo claim -a '${asset}'
 
 identity -n ${bidder5}
-auction -q -w -f ${path}/auction.pdo claim_offer -s asset
-issuer -q -w -f ${path}/${auction_color}_issuer.pdo claim -a '${asset}'
+auction -q -w -f ${save}/auction.pdo claim_offer -s asset
+issuer -q -w -f ${save}/${auction_color}_issuer.pdo claim -a '${asset}'
 
 ## =================================================================
 echo cancel losing bids
 ## =================================================================
 identity -n ${bidder1}
-auction -q -w -f ${path}/auction.pdo cancel_bid -s cancel
-issuer -q -w -f ${path}/${bid_color}_issuer.pdo disburse -a '${cancel}'
-issuer -f ${path}/${bid_color}_issuer.pdo get_balance
+auction -q -w -f ${save}/auction.pdo cancel_bid -s cancel
+issuer -q -w -f ${save}/${bid_color}_issuer.pdo disburse -a '${cancel}'
+issuer -f ${save}/${bid_color}_issuer.pdo get_balance
 
 identity -n ${bidder2}
-auction -q -w -f ${path}/auction.pdo cancel_bid -s cancel
-issuer -q -w -f ${path}/${bid_color}_issuer.pdo disburse -a '${cancel}'
-issuer -f ${path}/${bid_color}_issuer.pdo get_balance
+auction -q -w -f ${save}/auction.pdo cancel_bid -s cancel
+issuer -q -w -f ${save}/${bid_color}_issuer.pdo disburse -a '${cancel}'
+issuer -f ${save}/${bid_color}_issuer.pdo get_balance
 
 identity -n ${bidder3}
-auction -q -w -f ${path}/auction.pdo cancel_bid -s cancel
-issuer -q -w -f ${path}/${bid_color}_issuer.pdo disburse -a '${cancel}'
-issuer -f ${path}/${bid_color}_issuer.pdo get_balance
+auction -q -w -f ${save}/auction.pdo cancel_bid -s cancel
+issuer -q -w -f ${save}/${bid_color}_issuer.pdo disburse -a '${cancel}'
+issuer -f ${save}/${bid_color}_issuer.pdo get_balance
 
 identity -n ${bidder4}
-auction -q -w -f ${path}/auction.pdo cancel_bid -s cancel
-issuer -q -w -f ${path}/${bid_color}_issuer.pdo disburse -a '${cancel}'
-issuer -f ${path}/${bid_color}_issuer.pdo get_balance
+auction -q -w -f ${save}/auction.pdo cancel_bid -s cancel
+issuer -q -w -f ${save}/${bid_color}_issuer.pdo disburse -a '${cancel}'
+issuer -f ${save}/${bid_color}_issuer.pdo get_balance
 
 echo attempt to cancel the winning bid, this should fail
 identity -n ${bidder5}
-auction -q -w -f ${path}/auction.pdo cancel_bid -s cancel
-issuer -f ${path}/${bid_color}_issuer.pdo get_balance
+auction -q -w -f ${save}/auction.pdo cancel_bid -s cancel
+issuer -f ${save}/${bid_color}_issuer.pdo get_balance
 
 exit

--- a/contracts/exchange/scripts/create.psh
+++ b/contracts/exchange/scripts/create.psh
@@ -1,3 +1,5 @@
+#! /usr/bin/env pdo-shell
+
 ## Copyright 2018 Intel Corporation
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,46 +23,46 @@
 ##
 ## Two shell variables are used:
 ##    color -- the color to use for the marble
-##    path -- the path where the contract objects are stored
+##    data -- the directory where the contract objects are stored
+##    path -- the directory where the PSH scripts are stored
 ##
 ## $ pdo-shell -s create.psh -m color <color> -m path <contract path>
 
-load_plugin -c asset_type
-load_plugin -c vetting
-load_plugin -c issuer
+set -q --conditional -s data -v .
+set -q --conditional -s save -v .
+script -f ${path}/init.psh
 
-set -q --conditional -s path -v .
 set -q --conditional -s color -v green
 
 ## =================================================================
 echo create the asset type for ${color} marbles
 ## =================================================================
 identity -n ${color}_type
-create -c asset-type-contract -s _asset_type -f ${path}/${color}_type.pdo
-asset_type -q -w -f ${path}/${color}_type.pdo initialize -n "${color} marbles" -d "${color} marble description" -l "http://"
-asset_type -q -f ${path}/${color}_type.pdo get_identifier -s type_id
+create -c asset-type-contract -s _asset_type -f ${save}/${color}_type.pdo
+asset_type -q -w -f ${save}/${color}_type.pdo initialize -n "${color} marbles" -d "${color} marble description" -l "http://"
+asset_type -q -f ${save}/${color}_type.pdo get_identifier -s type_id
 echo created type ${type_id}
 
 ## =================================================================
 echo create the ${color} marble vetting organization
 ## =================================================================
 identity -n ${color}_vetting
-create -c vetting-organization-contract -s _vetting_organization -f ${path}/${color}_vetting.pdo
-vetting -q -w -f ${path}/${color}_vetting.pdo initialize -t ${type_id}
+create -c vetting-organization-contract -s _vetting_organization -f ${save}/${color}_vetting.pdo
+vetting -q -w -f ${save}/${color}_vetting.pdo initialize -t ${type_id}
 echo created the vetting organization
 
 ## =================================================================
 echo create ${color} marble issuers
 ## =================================================================
 identity -n ${color}_issuer
-create -c issuer-contract -s _issuer -f ${path}/${color}_issuer.pdo
-issuer -q -f ${path}/${color}_issuer.pdo get_verifying_key -s issuer_key
+create -c issuer-contract -s _issuer -f ${save}/${color}_issuer.pdo
+issuer -q -f ${save}/${color}_issuer.pdo get_verifying_key -s issuer_key
 
 identity -n ${color}_vetting
-vetting -q -w -f ${path}/${color}_vetting.pdo approve -i ${issuer_key}
+vetting -q -w -f ${save}/${color}_vetting.pdo approve -i ${issuer_key}
 
 identity -n ${color}_issuer
-vetting -q -f ${path}/${color}_vetting.pdo get_authority -i ${issuer_key} -s auth
-issuer -q -w -f ${path}/${color}_issuer.pdo initialize -t ${type_id} -a '${auth}'
+vetting -q -f ${save}/${color}_vetting.pdo get_authority -i ${issuer_key} -s auth
+issuer -q -w -f ${save}/${color}_issuer.pdo initialize -t ${type_id} -a '${auth}'
 
 exit

--- a/contracts/exchange/scripts/create_eservice_db.psh
+++ b/contracts/exchange/scripts/create_eservice_db.psh
@@ -14,22 +14,15 @@
 ## See the License for the specific language governing permissions and
 ## limitations under the License.
 
-load_plugin -c asset_type
-load_plugin -c vetting
-load_plugin -c issuer
-load_plugin -c exchange
-load_plugin -c auction
-
 set -q --conditional -s dbfile -v ${data}/eservice-db.json
-eservice_db load --database ${dbfile}
 
-## default pservice group
-pservice add --url http://localhost:7001 http://localhost:7002 http://localhost:7003
+eservice_db clear
+eservice_db add --url http://localhost:7101 --name es7101
+eservice_db add --url http://localhost:7102 --name es7102
+eservice_db add --url http://localhost:7103 --name es7103
+eservice_db add --url http://localhost:7104 --name es7104
+eservice_db add --url http://localhost:7105 --name es7105
 
-## default eservice group
-eservice add --url http://localhost:7101 http://localhost:7102 http://localhost:7103
-eservice use --url http://localhost:7101
+eservice_db save --database ${dbfile}
 
-## alternate eservice group
-eservice --group altgroup add --url http://localhost:7103 http://localhost:7104 http://localhost:7105
-eservice --group altgroup use --url http://localhost:7105
+exit

--- a/contracts/exchange/scripts/exchange.psh
+++ b/contracts/exchange/scripts/exchange.psh
@@ -1,3 +1,5 @@
+#! /usr/bin/env pdo-shell
+
 ## Copyright 2018 Intel Corporation
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +19,6 @@
 ## object.
 ##
 ## The following shell variables are assumed:
-##    path -- the path where the contract objects are stored (default = '.')
 ##    offer_user -- the identity of the user initiating the exchange (default = user1)
 ##    offer_color -- the color to use for the offered marbles (default = 'green')
 ##    exchange_user -- the identity of the user responding to the exchange (default = user6)
@@ -26,12 +27,10 @@
 
 ## $ pdo-shell -s exchange.psh
 
-load_plugin -c asset_type
-load_plugin -c vetting
-load_plugin -c issuer
-load_plugin -c exchange
+set -q --conditional -s data -v .
+set -q --conditional -s save -v .
+script -f ${path}/init.psh
 
-set -q --conditional -s path -v .
 set -q --conditional -s offer_user -v user1
 set -q --conditional -s offer_color -v green
 set -q --conditional -s exchange_user -v user6
@@ -42,44 +41,68 @@ set -q --conditional -s request_count -v 60
 echo ${offer_user} creates exchange to trade ${offer_color} marbles for ${request_count} ${exchange_color} marbles
 ## =================================================================
 identity -n ${offer_user}
-create -c exchange-contract -s _exchange -f ${path}/exch.pdo
+create -c exchange-contract -s _exchange -f ${save}/exch.pdo
 
 ## Get some information that will be used later
 ## exchange_vk -- exchange contract verifying key/identity
 ## request_vk -- vetting organization identity for requested asset
 ## request_type_id -- type identifier for the requested marble type
-exchange -q -f ${path}/exch.pdo get_verifying_key -s exchange_vk
-vetting -q -f ${path}/${exchange_color}_vetting.pdo get_verifying_key -s request_vk
-asset_type -q -f ${path}/${exchange_color}_type.pdo get_identifier -s request_type_id
+exchange -q -f ${save}/exch.pdo get_verifying_key -s exchange_vk
+vetting -q -f ${save}/${exchange_color}_vetting.pdo get_verifying_key -s request_vk
+asset_type -q -f ${save}/${exchange_color}_type.pdo get_identifier -s request_type_id
 
 ## Initialize the exchange with the request parameters
-exchange -q -w -f ${path}/exch.pdo initialize -r ${request_vk} -t ${request_type_id} -c ${request_count}
+exchange -q -w -f ${save}/exch.pdo initialize -r ${request_vk} -t ${request_type_id} -c ${request_count}
+
+## =================================================================
+echo initial balances: ${offer_color}, ${exchange_color}
+## =================================================================
+identity -n ${offer_user}
+echo offer balances
+issuer -f ${save}/${offer_color}_issuer.pdo get_balance
+issuer -f ${save}/${exchange_color}_issuer.pdo get_balance
+
+identity -n ${exchange_user}
+echo exchange balances
+issuer -f ${save}/${offer_color}_issuer.pdo get_balance
+issuer -f ${save}/${exchange_color}_issuer.pdo get_balance
 
 ## =================================================================
 echo escrow ${offer_color} marbles for ${offer_user} and add to the exchange
 ## =================================================================
 identity -n ${offer_user}
-issuer -f ${path}/${offer_color}_issuer.pdo get_balance
-issuer -q -w -f ${path}/${offer_color}_issuer.pdo escrow -a ${exchange_vk} -s escrow
-exchange -q -w -f ${path}/exch.pdo offer -a '${escrow}'
+issuer -q -w -f ${save}/${offer_color}_issuer.pdo escrow -a ${exchange_vk} -s escrow
+exchange -q -w -f ${save}/exch.pdo offer -a '${escrow}'
 
 ## =================================================================
 echo escrow ${exchange_color} marbles for ${exchange_user} and add to the exchange
 ## =================================================================
 identity -n ${exchange_user}
-issuer -f ${path}/${exchange_color}_issuer.pdo get_balance
-issuer -q -w -f ${path}/${exchange_color}_issuer.pdo escrow -a ${exchange_vk} -s escrow
-exchange -q -w -f ${path}/exch.pdo exchange -a '${escrow}'
+issuer -q -w -f ${save}/${exchange_color}_issuer.pdo escrow -a ${exchange_vk} -s escrow
+exchange -q -w -f ${save}/exch.pdo exchange -a '${escrow}'
 
 ## =================================================================
 echo exchange should be closed, claim ownership of the assets
 ## =================================================================
 identity -n ${offer_user}
-exchange -q -w -f ${path}/exch.pdo claim_exchange -s asset
-issuer -q -w -f ${path}/${exchange_color}_issuer.pdo claim -a '${asset}'
+exchange -q -w -f ${save}/exch.pdo claim_exchange -s asset
+issuer -q -w -f ${save}/${exchange_color}_issuer.pdo claim -a '${asset}'
 
 identity -n ${exchange_user}
-exchange -q -w -f ${path}/exch.pdo claim_offer -s asset
-issuer -q -w -f ${path}/${offer_color}_issuer.pdo claim -a '${asset}'
+exchange -q -w -f ${save}/exch.pdo claim_offer -s asset
+issuer -q -w -f ${save}/${offer_color}_issuer.pdo claim -a '${asset}'
+
+## =================================================================
+echo final balances: ${offer_color}, ${exchange_color}
+## =================================================================
+identity -n ${offer_user}
+echo offer balances
+issuer -f ${save}/${offer_color}_issuer.pdo get_balance
+issuer -f ${save}/${exchange_color}_issuer.pdo get_balance
+
+identity -n ${exchange_user}
+echo exchange balances
+issuer -f ${save}/${offer_color}_issuer.pdo get_balance
+issuer -f ${save}/${exchange_color}_issuer.pdo get_balance
 
 exit

--- a/contracts/exchange/scripts/issue.psh
+++ b/contracts/exchange/scripts/issue.psh
@@ -1,3 +1,5 @@
+#! /usr/bin/env pdo-shell
+
 ## Copyright 2018 Intel Corporation
 ##
 ## Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,17 +24,15 @@
 ##
 ## The following shell variables are assumed:
 ##    color -- the color to use for the marble (default = 'green')
-##    path -- the path where the contract objects are stored (default = '.')
 ##    issuee -- name of the issuee, there must be a public key in the path (required)
 ##    count -- number of assets to issue (default = 100)
 
-## $ pdo-shell -s issue.psh -m color <color> -m path <contract path> -m issuee <identity> -m count <count>
+## $ pdo-shell issue.psh -m color <color> -m issuee <identity> -m count <count>
 
-load_plugin -c asset_type
-load_plugin -c vetting
-load_plugin -c issuer
+set -q --conditional -s data -v .
+set -q --conditional -s save -v .
+script -f ${path}/init.psh
 
-set -q --conditional -s path -v .
 set -q --conditional -s color -v green
 set -q --conditional -s count -v 100
 
@@ -42,6 +42,6 @@ identity -n ${color}_issuer
 echo issue ${count} ${color} marbles to ${issuee}
 ## =================================================================
 set -q -s issuee_key -i ${issuee}
-issuer -q -w -f ${path}/${color}_issuer.pdo issue -o '${issuee_key}' -c ${count}
+issuer -q -w -f ${save}/${color}_issuer.pdo issue -o '${issuee_key}' -c ${count}
 
 exit

--- a/contracts/exchange/scripts/setup.sh
+++ b/contracts/exchange/scripts/setup.sh
@@ -68,13 +68,19 @@ fi
 # -----------------------------------------------------------------
 : "${PDO_LEDGER_URL?Missing environment variable PDO_LEDGER_URL}"
 
-try pdo-shell --ledger $PDO_LEDGER_URL -s scripts/create.psh -m color red
-try pdo-shell --ledger $PDO_LEDGER_URL -s scripts/create.psh -m color green
+if [ ! -f ${PDO_HOME}/data/eservice-db.json ]; then
+    scripts/create_eservice_db.psh
+fi
+
+try scripts/create.psh --loglevel warn --ledger $PDO_LEDGER_URL -m color red
+try scripts/create.psh --loglevel warn --ledger $PDO_LEDGER_URL -m color green
 
 for p in $(seq 1 5); do
-    pdo-shell --ledger $PDO_LEDGER_URL -s scripts/issue.psh -m color green -m issuee user$p -m count $(($p * 10))
+    scripts/issue.psh --loglevel warn --ledger $PDO_LEDGER_URL \
+                      -m color green -m issuee user$p -m count $(($p * 10))
 done
 
 for p in $(seq 6 10); do
-    pdo-shell --ledger $PDO_LEDGER_URL -s scripts/issue.psh -m color red -m issuee user$p -m count $(($p * 10))
+    scripts/issue.psh --loglevel warn --ledger $PDO_LEDGER_URL \
+                      -m color red -m issuee user$p -m count $(($p * 10))
 done

--- a/contracts/exchange/vetting.py
+++ b/contracts/exchange/vetting.py
@@ -56,7 +56,7 @@ def __command_vetting__(state, bindings, pargs) :
     if options.command == 'get_verifying_key' :
         extraparams['commit'] = False
         message = "'(get-verifying-key)"
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         if result and options.symbol :
             bindings.bind(options.symbol, result)
         return
@@ -66,21 +66,21 @@ def __command_vetting__(state, bindings, pargs) :
     if options.command == 'initialize' :
 
         message = "'(initialize \"{0}\")".format(options.type_id)
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     # -------------------------------------------------------
     if options.command == 'approve' :
 
         message = "'(add-approved-key \"{0}\")".format(options.issuer)
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
    # -------------------------------------------------------
     if options.command == 'get_authority' :
         extraparams['commit'] = False
         message = "'(get-authority \"{0}\")".format(options.issuer)
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         if result and options.symbol :
             bindings.bind(options.symbol, result)
         return

--- a/contracts/integer-key/integer-key.py
+++ b/contracts/integer-key/integer-key.py
@@ -77,45 +77,45 @@ def __command_integer_key__(state, bindings, pargs) :
 
     if options.command == 'get_signing_key' :
         message = "'(get-public-signing-key)"
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         if result and options.symbol :
             bindings.bind(options.symbol, result)
         return
 
     if options.command == 'create' :
         message = "'(create \"{0}\" {1})".format(options.key, options.value)
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     if options.command == 'inc' :
         message = "'(inc \"{0}\" {1})".format(options.key, options.value)
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     if options.command == 'dec' :
         message = "'(dec \"{0}\" {1})".format(options.key, options.value)
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     if options.command == 'get' :
         extraparams['commit'] = False
         message = "'(get-value \"{0}\")".format(options.key)
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     if options.command == 'transfer' :
         message = "'(transfer-ownership \"{0}\" \"{1}\")".format(options.key, options.owner)
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     if options.command == 'escrow' :
         message = "'(escrow \"{0}\" \"{1}\")".format(options.key, options.agent)
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     if options.command == 'attestation' :
         message = "'(escrow-attestation \"{0}\")".format(options.key)
-        result = send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         if result and options.symbol :
             bindings.bind(options.symbol, result)
         return
@@ -126,7 +126,7 @@ def __command_integer_key__(state, bindings, pargs) :
         dependencies = str(attestation.nth(1))
         signature = str(attestation.nth(2))
         message = "'(disburse \"{0}\" {1} {2})".format(assetkey, dependencies, signature)
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
     if options.command == 'exchange' :
@@ -136,7 +136,7 @@ def __command_integer_key__(state, bindings, pargs) :
         dependencies = str(attestation.nth(2))
         signature = str(attestation.nth(3))
         message = "'(exchange-ownership \"{0}\" \"{1}\" {2} {3})".format(offered, maxbid, dependencies, signature)
-        send_to_contract(state, options.save_file, options.enclave, message, **extraparams)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
         return
 
 ## -----------------------------------------------------------------


### PR DESCRIPTION
In preparation to remove the create, update and eservice database clients (so we only have one client to manager), this PR adds significant functionality to the pdo-shell. First, it incorporates the eservice database cleanly into the flow of the application (and adds operations to manage an eservice database). Second, it makes the shell "executable" (meaning that PSH scripts can be self-executing). Finally, it replaces a few of the existing scripts (specifically tests) with cleaner implementations.