### PR TITLE
Forced configuration regeneration

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -120,6 +120,10 @@ PSERVICE_CONF := $(ETCDIR)/pservice1.toml
 
 conf : $(ESERVICE_CONF) $(SSERVICE_CONF) $(PSERVICE_CONF) $(ETCDIR)/enclave.toml $(ETCDIR)/pcontract.toml
 
+force-conf : 
+	- rm $(ESERVICE_CONF) $(SSERVICE_CONF) $(PSERVICE_CONF) $(ETCDIR)/enclave.toml $(ETCDIR)/pcontract.toml
+	${MAKE} conf
+
 $(ESERVICE_CONF) : $(SCRIPTDIR)/opt/pdo/etc/template/eservice.toml
 	@ echo create configuration files for $(basename $(notdir $<))
 	@ . $(abspath $(DSTDIR)/bin/activate) ; \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -78,7 +78,7 @@ test-env-setup-with-no-build:
 	   exec validator sawset proposal create --url http://rest-api:8008 --key /root/.sawtooth/keys/my_key.priv sawtooth.validator.transaction_families='[{"family": "intkey", "version": "1.0"}, {"family":"sawtooth_settings", "version":"1.0"}, {"family": "pdo_contract_enclave_registry", "version": "1.0"}, {"family":  "pdo_contract_instance_registry", "version": "1.0"}, {"family": "ccl_contract", "version": "1.0"}]'
 	if [ "$(SGX_MODE)" = "HW" ]; then \
 	   $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS) \
-	      exec pdo-build bash -c 'source /etc/bash.bashrc; export PDO_SGX_KEY_ROOT=/project/pdo/build/opt/pdo/etc/keys/sgx/; unset PDO_SPID PDO_SPID_API_KEY PDO_IAS_KEY_PEM; source /project/pdo/src/private-data-objects/build/common-config.sh; make -C /project/pdo/src/private-data-objects/build conf register'; \
+	      exec pdo-build bash -c 'source /etc/bash.bashrc; export PDO_SGX_KEY_ROOT=/project/pdo/build/opt/pdo/etc/keys/sgx/; unset PDO_SPID PDO_SPID_API_KEY PDO_IAS_KEY_PEM; source /project/pdo/src/private-data-objects/build/common-config.sh; make -C /project/pdo/src/private-data-objects/build force-conf register'; \
 	fi
 
 test-with-no-build: test-env-setup-with-no-build


### PR DESCRIPTION
- add new target "force-conf" which forces new conf regardless whether files exist or not so we can force re-configuration if some variables like SPID has changed
- necessary, e.g., to make docker with SGX HW mode work again (of course, if i would have tested yesterday's PR not only with SIM but also HW, i would have found this issue already before i gave greenlight to merge that PR :-)