### PR TITLE
Implement Change Set Replication

### DIFF
--- a/build/__tools__/run-tests.sh
+++ b/build/__tools__/run-tests.sh
@@ -351,6 +351,25 @@ done
 # clean up the pdo files that are created by the shell
 rm -f ${SCRIPTDIR}/red_issuer.pdo ${SCRIPTDIR}/red_type.pdo ${SCRIPTDIR}/red_vetting.pdo
 
+
+cd ${SRCDIR}/build
+
+yell run tests for state replication 
+say start mock-contract test with replication 3 eservices 2 replicas needed before txn. 
+
+try pdo-test-request --ledger ${PDO_LEDGER_URL} \
+    --pservice http://localhost:7001/ http://localhost:7002 http://localhost:7003 \
+    --eservice-name e1 e2 e3 \
+    --logfile __screen__ --loglevel warn --iterations 10 \
+    --num-provable-replicas 2 --availability-duration 100 --randomize-eservice True
+
+say start memory test test with replication 3 eservices 2 replicas needed before txn 
+try pdo-test-contract --ledger ${PDO_LEDGER_URL} --contract memory-test \
+    --pservice http://localhost:7001/ http://localhost:7002 http://localhost:7003 \
+    --eservice-name e1 e2 e3 \
+    --logfile __screen__ --loglevel warn \
+    --num-provable-replicas 2 --availability-duration 100 --randomize-eservice True
+
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
 yell completed all tests

--- a/build/opt/pdo/etc/template/pcontract.toml
+++ b/build/opt/pdo/etc/template/pcontract.toml
@@ -46,11 +46,27 @@ EnclaveServiceURLs = [
     "http://127.0.0.1:7103"
 ]
 
+StorageServiceURLs = [
+    "http://127.0.0.1:7201",
+    "http://127.0.0.1:7202",
+    "http://127.0.0.1:7203"
+]
+
 ProvisioningServiceURLs = [
     "http://127.0.0.1:7001",
     "http://127.0.0.1:7002",
     "http://127.0.0.1:7003"
 ]
+
+
+#--------------------------------------------------
+#Replication -- to maintain state availability 
+#-------------------------------------------------
+[Replication]
+Enable="False"
+MaxNumReplicas=3
+NumProvableReplicas=2
+Duration=120 #seconds
 
 # --------------------------------------------------
 # Contract -- Contract configuration

--- a/build/opt/pdo/etc/template/pcontract.toml
+++ b/build/opt/pdo/etc/template/pcontract.toml
@@ -46,12 +46,6 @@ EnclaveServiceURLs = [
     "http://127.0.0.1:7103"
 ]
 
-StorageServiceURLs = [
-    "http://127.0.0.1:7201",
-    "http://127.0.0.1:7202",
-    "http://127.0.0.1:7203"
-]
-
 ProvisioningServiceURLs = [
     "http://127.0.0.1:7001",
     "http://127.0.0.1:7002",
@@ -63,8 +57,6 @@ ProvisioningServiceURLs = [
 #Replication -- to maintain state availability 
 #-------------------------------------------------
 [Replication]
-Enable="False"
-MaxNumReplicas=3
 NumProvableReplicas=2
 Duration=120 #seconds
 

--- a/client/pdo/client/controller/commands/send.py
+++ b/client/pdo/client/controller/commands/send.py
@@ -71,7 +71,7 @@ def send_to_contract(state, save_file, enclave, message, quiet=False, wait=False
 
     # ---------- send the message to the enclave service ----------
     try :
-        update_request = contract.create_update_request(client_keys, enclave_client, message)
+        update_request = contract.create_update_request(client_keys, message, enclave_client)
         update_response = update_request.evaluate()
         if update_response.status :
             if not quiet : print(update_response.result)

--- a/client/pdo/client/scripts/AuctionTestCLI.py
+++ b/client/pdo/client/scripts/AuctionTestCLI.py
@@ -76,7 +76,7 @@ def SendMessageAsIdentity(config, contract, invoker_keys, message, fmt = 'python
         enclave_id = random.choice(contract.provisioned_enclaves)
         enclave_service = enclave_services[enclave_id]
 
-        request = contract.create_update_request(invoker_keys, enclave_service, message)
+        request = contract.create_update_request(invoker_keys, message, enclave_service)
         response = request.evaluate()
         logger.info('result: %s, ', response.result)
     except Exception as e :

--- a/client/pdo/client/scripts/UpdateCLI.py
+++ b/client/pdo/client/scripts/UpdateCLI.py
@@ -70,6 +70,15 @@ def LocalMain(config, message) :
         logger.error('missing configuration section %s', str(ke))
         sys.exit(-1)
 
+    # ---------- load the eservice database ----------
+    if os.path.exists(service_config['EnclaveServiceDatabaseFile']):
+        logger.info('loading eservice database')
+        try:
+            db.load_database(service_config['EnclaveServiceDatabaseFile'])
+        except Exception as e:
+            logger.error('Error loading eservice database %s', str(e))
+            sys.exit(-1)
+
     # ---------- load the contract information file ----------
     try:
         save_file = contract_config['SaveFile']
@@ -101,13 +110,6 @@ def LocalMain(config, message) :
         logger.info('Using eservice database to look up service URL for the contract enclave')
         try:
             eservice_to_use = random.choice(service_config['EnclaveServiceNames'])
-            # load the eservice database
-            if os.path.exists(service_config['EnclaveServiceDatabaseFile']):
-                try:
-                    db.load_database(service_config['EnclaveServiceDatabaseFile'])
-                except Exception as e:
-                    logger.error('Error loading eservice database %s', str(e))
-                    sys.exit(-1)
             enclave_client = db.get_client_by_name(eservice_to_use)
         except Exception as e:
             logger.error('Unable to get the eservice client using the eservice database: %s', str(e)) 
@@ -147,7 +149,7 @@ def LocalMain(config, message) :
         logger.info('send message <%s> to contract', msg)
 
         try :
-            update_request = contract.create_update_request(contract_invoker_keys, enclave_client, msg)
+            update_request = contract.create_update_request(contract_invoker_keys, msg, enclave_client)
             update_response = update_request.evaluate()
             if update_response.status :
                 print(update_response.result)

--- a/python/pdo/contract/__init__.py
+++ b/python/pdo/contract/__init__.py
@@ -20,7 +20,9 @@ __all__ = [
     "ContractResponse",
     "ContractRequest",
     "register_contract",
-    "add_enclave_to_contract"
+    "add_enclave_to_contract",
+    "Replicator",
+    "ReplicationException"
 ]
 
 from pdo.contract.code import ContractCode
@@ -29,3 +31,6 @@ from pdo.contract.message import ContractMessage
 from pdo.contract.request import ContractRequest
 from pdo.contract.response import ContractResponse
 from pdo.contract.state import ContractState
+from pdo.contract.replication import ReplicationException
+from pdo.contract.replication import Replicator
+

--- a/python/pdo/contract/replication.py
+++ b/python/pdo/contract/replication.py
@@ -1,0 +1,214 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import sys
+import concurrent.futures
+import queue
+import threading
+
+from pdo.contract.state import ContractState
+from pdo.common.utility import are_the_urls_same
+
+import logging
+logger = logging.getLogger(__name__)
+
+class ReplicationException(Exception) :
+    """
+    A class to capture replication exceptions
+    """
+    pass
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+
+class Replicator(object):
+    """ implements the replicator class functionality : used for change-set replication after contract update, before commiting transaction."""
+    
+    __urls_of_storage_services_to_ignore__ = []
+    __max_num_replicator_threads__ = 2 # max number of replication tasks will be carried out concurrently.
+    __queue_of_SSURLS_raising_exceptions__ = queue.Queue()
+    replication_executor = concurrent.futures.ThreadPoolExecutor(max_workers=__max_num_replicator_threads__) 
+    pending_replications_queue = queue.Queue()
+    exceptions_queue = queue.Queue()
+    replication_completion_condition = threading.Condition()
+    set_of_completed_replications = set()
+   
+    # -----------------------------------------------------------------
+    @classmethod
+    def get_max_num_replicator_threads(cls):
+        return cls.__max_num_replicator_threads__
+
+    # -----------------------------------------------------------------
+
+    @classmethod
+    def replication_worker(cls):
+        """ worker function for a replication task"""
+
+        while True:
+            # get the task from the job queue
+            task = cls.pending_replications_queue.get()
+
+            #check for termination signal
+            if task.get('exit_now'):
+                logger.info("Exiting Replication worker thread")
+                break
+
+            #perform the task
+            try:
+                task['response_object'].replicate_change_set()
+            except Exception as e:
+                cls.exceptions_queue.put(str(e))
+                logger.exception("Replication task failed %s : Exiting Replication worker thread", str(e))
+                break
+
+            #report replication completion in order to add the task to the transaction submission queue
+            task['response_object'].report_replication_completion()
+    
+    # -----------------------------------------------------------------
+
+    @classmethod
+    def __update_set_of_unreliable_storage_services__(cls):
+        """ Update the set of unreliable storage services based on prior replication attempts. Any service that returned an exception of any kind in 
+        the past is considered unreliable for the rest of the execution."""
+        
+        temp = True
+
+        while temp:
+            try: 
+                url = cls.__queue_of_SSURLS_raising_exceptions__.get_nowait()
+                if url not in cls.__urls_of_storage_services_to_ignore__:
+                    cls.__urls_of_storage_services_to_ignore__.append(url)
+                    logger.info("Adding Storage Service at %s to the list of unreliable storage services to be ignored for replication", str(url))
+            except: 
+                temp = False
+    
+    # -----------------------------------------------------------------
+
+    def __init__(self, replication_params, storage_clients, \
+                contract_id, blocks_to_replicate, enclave_service, data_dir=None):
+        """ Create an instance of the Replicator class: used for replicating the current change set"""
+        
+        self.storage_clients_to_replicate = []
+
+        if len(storage_clients) == 0:
+            return
+        
+        self.sservice_url_for_contract = enclave_service.storage_service_url
+        self.num_provable_replicas = replication_params['num_provable_replicas']
+        self.availability_duration = replication_params['availability_duration']
+        self.contract_id = contract_id
+        self.blocks_to_replicate = blocks_to_replicate
+        self.data_dir = data_dir
+
+        # identify reliable storage services to be used with this instance of Replicator
+        Replicator.__update_set_of_unreliable_storage_services__()
+        for client in  storage_clients:
+            use_client = True
+            if are_the_urls_same(client.ServiceURL, self.sservice_url_for_contract):
+                use_client = False
+            else:
+                for url in Replicator.__urls_of_storage_services_to_ignore__:
+                    if are_the_urls_same(client.ServiceURL, url):
+                        use_client = False
+                        break
+            if use_client:
+                self.storage_clients_to_replicate.append(client)
+         
+        # make sure that the number of reliable storage services is sufficient for replication 
+        if len(self.storage_clients_to_replicate) < replication_params['num_provable_replicas']-1: # -1 since we do not explicitly replicate to 
+                    # the sservice associated with the eservice
+            logger.exception('Cannot create Replicator instance: Insufficient number of reliable storage services available for replication')
+            raise ReplicationException('Cannot create Replicator instance: Insufficient number of reliable storage services available for replication')
+    
+    # -----------------------------------------------------------------
+
+    def push_blocks_to_storage_service(self, client, block_data_list, expiration):
+        """Wrapper around client.store_blocks to handle Exceptions during store_blocks. 
+        This is the task function used by a worker-thread that attempts replication to a specific storage service"""
+        
+        try:
+            response = client.store_blocks(block_data_list, expiration)
+            if response is None :
+                Replicator.__queue_of_SSURLS_raising_exceptions__.put(client.ServiceURL) 
+                logger.warn("Adding Storage Service at %s to the set of  bad ones : block_store_list is None", str(client.ServiceURL))
+        except Exception as e:
+            Replicator.__queue_of_SSURLS_raising_exceptions__.put(client.ServiceURL)
+            logger.warn("Adding Storage Service at %s to the set of  bad ones : uknown exception : %s ", str(client.ServiceURL), str(e))
+            response = None
+
+        return response
+    
+    # -----------------------------------------------------------------
+
+    def replicate_change_set(self):
+        """ Replicate change set to the set of reliable storage services."""
+            
+        # identify if replication can be skipped, including the case where there is only one provisioned enclave
+        if len(self.storage_clients_to_replicate) == 0:
+            logger.info('Skipping replication: Only one provisioned enclave, so nothing to replicate')
+            return
+       
+        if len(self.blocks_to_replicate) == 0:
+            logger.info('Skipping replication: No change set, so nothing to replicate')
+            return
+
+        # submit individual replication tasks to various storage services asynchronously. Each replica is handled by a separate thread 
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers = len(self.storage_clients_to_replicate))
+        futures_to_replication_tasks = dict() # to keep track of the tasks
+        expiration = self.availability_duration
+        for index, client in enumerate(self.storage_clients_to_replicate):
+            # get data generator. Optimization: If  this generator can be wrapped to be threadsafe, itertools.tee can be used to create
+            # copies without having to read the cache multiple times. Directly using itertools.tee will not work with multi-threadeding
+            block_data_list = ContractState.block_data_generator(self.contract_id, self.blocks_to_replicate, self.data_dir)
+            future = executor.submit(self.push_blocks_to_storage_service, client, block_data_list, expiration)
+            futures_to_replication_tasks[future] = client.ServiceURL
+       
+        #poll for completed replication tasks, wait until num_provable_replicas number of tasks finish
+        urls_of_successful_storage_services = [self.sservice_url_for_contract] #successful by default
+        num_successful_replicas = 1
+        num_unsuccessful_replicas = 0
+        max_allowable_num_unsucessful_replicas = len(self.storage_clients_to_replicate) - self.num_provable_replicas + 1
+            # Add 1 since storage_clients_to_replicate does not contain the sservice corresponding to the contract enclave
+        
+        if num_successful_replicas == self.num_provable_replicas: #covers the case when we only need one proof
+            pass
+        else:
+            for future in concurrent.futures.as_completed(futures_to_replication_tasks):
+                url = futures_to_replication_tasks[future]
+                try:
+                    response = future.result()
+                except Exception as e:
+                    logger.exception('Unexpected situation: Unable to gather sservice response after what looks like successful replication: %s', str(e))
+                    Replicator.exceptions_queue.put('Unexpected situation: Unable to gather sservice response after what looks like successful replication')
+                    raise ReplicationException('Unexpected situation: Unable to gather sservice response after what looks like successful replication') from e
+            
+                if response is not None: # an indication of success, but we also need to examine response and verify the signature: TBD in next PR
+                    urls_of_successful_storage_services.append(url)
+                    num_successful_replicas+=1
+                    if num_successful_replicas == self.num_provable_replicas:
+                        break
+                else: 
+                    num_unsuccessful_replicas+=1
+                    if num_successful_replicas > max_allowable_num_unsucessful_replicas:
+                        logger.exception('Replication has failed due to too many bad responses from storage services')
+                        Replicator.exceptions_queue.put('Replication has failed due to too many bad responses from storage services')
+                        raise ReplicationException('Replication has failed due to too many bad responses from storage services')
+        
+        #replication is successful. 
+        logger.info("Successfully replicated change set (%d blocks) at storage services : %s", len(self.blocks_to_replicate), str(urls_of_successful_storage_services))
+        
+        #shutdown executor asynchronously. With wait=False, outstanding threads will run to completion in the background (including 
+        #possibile timeouts and exceptions). Resources will get freed after that. 
+        executor.shutdown(wait=False)

--- a/python/pdo/contract/request.py
+++ b/python/pdo/contract/request.py
@@ -49,6 +49,8 @@ class ContractRequest(object) :
         self.creator_id = contract.creator_id
         self.encrypted_state_encryption_key = contract.get_state_encryption_key(enclave_service.enclave_id)
         self.enclave_service = enclave_service
+        self.storage_clients_for_replication = kwargs.get('storageclients', []);
+        self.replication_params = contract.get_proof_of_replication_parameters()
         self.originator_keys = request_originator_keys
         self.channel_keys = keys.TransactionKeys()
         self.session_key = crypto.SKENC_GenerateKey()

--- a/python/pdo/contract/request.py
+++ b/python/pdo/contract/request.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import os
 import json
+import random
 
 import pdo.common.crypto as crypto
 import pdo.common.keys as keys
@@ -21,6 +22,8 @@ from pdo.contract.response import ContractResponse
 from pdo.contract.message import ContractMessage
 from pdo.contract.state import ContractState
 from pdo.submitter.submitter import Submitter
+
+import pdo.service_client.service_data.eservice as eservice_db
 
 import logging
 logger = logging.getLogger(__name__)
@@ -38,27 +41,43 @@ class InvocationException(Exception) :
 class ContractRequest(object) :
     __ops__ = { 'initialize' : True, 'update' : True }
 
+    __request_number__ = 0 # a monotonic counter used locally by the client to identify all its requests. 
+                         # Every (contract_id, statehash) pair maps to a unique request_number. The converse is not true (if the request failed)
+    
     # -------------------------------------------------------
-    def __init__(self, operation, request_originator_keys, enclave_service, contract, **kwargs) :
+    def __init__(self, operation, request_originator_keys, contract, **kwargs) :
         if not self.__ops__[operation] :
             raise ValueError('invalid operation')
 
         self.operation = operation
-
         self.contract_id = contract.contract_id
         self.creator_id = contract.creator_id
-        self.encrypted_state_encryption_key = contract.get_state_encryption_key(enclave_service.enclave_id)
-        self.enclave_service = enclave_service
-        self.storage_clients_for_replication = kwargs.get('storageclients', []);
-        self.replication_params = contract.get_proof_of_replication_parameters()
+                
+        if kwargs.get('enclave_service'):
+            self.enclave_service = kwargs['enclave_service']
+        else:
+            enclave_id = random.choice(list(contract.enclave_map.keys()))
+            try: #use the eservice database to get the client
+                self.enclave_service = eservice_db.get_client_by_id(enclave_id)
+            except Exception as e:
+                raise Exception('unable to assign eservice for the conrtract: Failed to get enclave client using database: %s', str(e))
+        try:
+            logger.info("Contract enclave at %s", str(self.enclave_service.ServiceURL))
+        except:
+            pass #in case the execution runs without an actual enclave
+
+        self.encrypted_state_encryption_key = contract.get_state_encryption_key(self.enclave_service.enclave_id)
         self.originator_keys = request_originator_keys
         self.channel_keys = keys.TransactionKeys()
         self.session_key = crypto.SKENC_GenerateKey()
-
         self.contract_code = contract.contract_code
         self.contract_state = contract.contract_state
         self.message = ContractMessage(self.originator_keys, self.channel_keys, **kwargs)
-
+        self.replication_params = contract.replication_params
+        self.storage_clients_for_replication = contract.storage_clients_for_replication
+        self.request_number = ContractRequest.__request_number__
+        ContractRequest.__request_number__+=1
+        
     # -------------------------------------------------------
     @property
     def enclave_keys(self) :

--- a/python/pdo/contract/response.py
+++ b/python/pdo/contract/response.py
@@ -12,13 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import json
+import sys
+import concurrent.futures
+import queue
+import time
+import threading
 
 import pdo.common.crypto as crypto
 import pdo.common.keys as keys
 
 from pdo.submitter.submitter import Submitter
 from pdo.contract.state import ContractState
+from pdo.contract.replication import ReplicationException
+from pdo.contract.replication import Replicator
 from sawtooth.helpers.pdo_connect import PdoRegistryHelper
 
 import logging
@@ -50,6 +56,10 @@ class Dependencies(object) :
     def __get(self, contractid, statehash) :
         k = self.__key(contractid, statehash)
         return self.__depcache.get(k)
+
+    ##--------------------------------------------------------
+    def FindDependencyLocally(self, contractid, statehash):
+        return self.__get(contractid, statehash)
 
     ## -------------------------------------------------------
     def FindDependency(self, ledger_config, contractid, statehash) :
@@ -90,6 +100,216 @@ class ContractResponse(object) :
     Class for managing the contract operation response from an enclave service
     """
 
+    __start_threads_for_commit__ = True
+    transaction_submission_exceptions_queue = queue.Queue()
+
+    transaction_executor = concurrent.futures.ThreadPoolExecutor(max_workers=1) # executor that submit transactions
+    pending_transactions_queue = queue.Queue()
+
+    txn_completion_condition = threading.Condition()
+    set_of_completed_txns = set()
+    
+    # -------------------------------------------------------
+    @classmethod
+    def get_exceptions_from_past_commits(cls):
+        """ Return any exception rasied by concurrent Replication and transaction submsission tasks"""
+
+        try:
+            e = Replicator.exceptions_queue.get_nowait()
+        except:
+            try:
+                e = cls.transaction_submission_exceptions_queue.get_nowait()
+            except:
+                e = None
+
+        return e
+
+    # -------------------------------------------------------
+
+    @classmethod
+    def wait_for_commit(cls, commit_id, use_ledger=True, shut_down=False):
+        """ Wait for completion of the commit task specified by id. Return transaction id if ledger is used, else return None. If shut_down is True,
+        send exit singals to replication and transaction threads. The implementation relies on threading.Condition objects"""
+        
+        if use_ledger:
+            cls.txn_completion_condition.acquire()
+            while commit_id not in cls.set_of_completed_txns: 
+                cls.txn_completion_condition.wait(timeout=1.0)
+                e = cls.get_exceptions_from_past_commits()
+                if e is not None: 
+                    raise Exception(str(e))
+                cls.txn_completion_condition.acquire()    
+            cls.txn_completion_condition.release()    
+
+            global transaction_dependencies
+            contract_id = commit_id[0]
+            state_hash = commit_id[1]
+            txn_id = transaction_dependencies.FindDependencyLocally(contract_id, crypto.byte_array_to_base64(state_hash))
+        
+        else: #wait until the replication task for commit_id completes
+
+            Replicator.replication_completion_condition.acquire()
+            while commit_id not in Replicator.set_of_completed_replications: 
+                Replicator.replication_completion_condition.wait(timeout = 1.0)
+                e = cls.get_exceptions_from_past_commits()
+                if e is not None:
+                    raise Exception(str(e))
+                Replicator.replication_completion_condition.acquire()    
+            Replicator.replication_completion_condition.release()    
+
+            txn_id = None
+
+        if shut_down:
+            cls.exit_commit_workers()
+        
+        return txn_id
+
+    # -------------------------------------------------------
+
+    @classmethod
+    def exit_commit_workers(cls):
+        """Shutdown replication exectuor. Send "exit now" message to txn submit thead"""
+
+        # send termination signal to executor thread 
+        for i in range(Replicator.get_max_num_replicator_threads()):
+            Replicator.pending_replications_queue.put(dict({'exit_now': True}))
+        
+        #shutdown replication executor
+        Replicator.replication_executor.shutdown(wait=True)
+        
+        # send termination signal to txn_executor thread
+        try:
+            cls.pending_transactions_queue.put(dict({'exit_now': True}))
+        except :
+            pass # to cover the case when we run without ledgers, in which case there is no txn thread to terminate 
+
+        #shutdown tx executor
+        cls.transaction_executor.shutdown(wait=True) 
+
+    # -------------------------------------------------------
+
+    @classmethod
+    def transaction_submission_worker(cls):
+        """This is the worker for submitting transactions"""
+
+        def submit_doable_transactions_for_contract(contract_id):
+            """ helper function to submit pending transactions for a specific contact. 
+            Transactions will be submitted for all pending commits whose commit dependecies are met"""
+           
+            nonlocal rep_completed_but_txn_not_submitted_updates
+            global transaction_dependencies
+            submitted_any = False
+
+            pending_requests_numbers = list(rep_completed_but_txn_not_submitted_updates[contract_id].keys())
+            pending_requests_numbers.sort()
+            for request_number in pending_requests_numbers:
+              
+                task = rep_completed_but_txn_not_submitted_updates[contract_id][request_number]
+                commit_id = task['commit_id']
+                response = task['response_object']
+                txn_dependencies = []
+
+                # Check for implicit commit dependencies , no need to add them to txn_dependencies, this will be taken care of by the submitter
+                txnid = transaction_dependencies.FindDependencyLocally(response.contract_id, crypto.byte_array_to_base64(response.old_state_hash))
+                if txnid is None:
+                    return submitted_any
+              
+                # check for explicit commit dependencies (specfied explicitly by the client during the commit call)
+                commit_dependencies = response.txn_params['dependency_list_commit_ids']
+                fail_explit_commit_dependencies = False
+                for commit_id_temp in commit_dependencies:
+                    txnid = transaction_dependencies.FindDependencyLocally(commit_id_temp[0], crypto.byte_array_to_base64(commit_id_temp[1]))
+                    if txnid :
+                        txn_dependencies.append(txnid)
+                    else:
+                        fail_explit_commit_dependencies = True
+                        break
+            
+                if fail_explit_commit_dependencies:
+                    return submitted_any
+                    
+                # OK, all commit dependencies are met. Add any transaction dependecies explicitly specified by client durind the commit call.
+                # these will be checked by the submitter
+                for txn_id in response.txn_params['dependency_list_txnids']:
+                    txn_dependencies.append(txn_id)                         
+                
+                # get rest of the info needed to submit txn
+                ledger_config = response.txn_params['ledger_config']
+                wait = response.txn_params['wait']
+            
+                # submit txn
+                try:
+                    txn_id =  response.submit_update_transaction(ledger_config, wait=wait, transaction_dependency_list=txn_dependencies)
+                    if txn_id:
+                        logger.info("Submitted transaction for request number %d", request_number)
+                        submitted_any = True
+                        del rep_completed_but_txn_not_submitted_updates[contract_id][request_number] # remove the task from the pending list
+                        # acquire lock to the condition varaiable, add the commit_id to completed list, notify, and release the lock
+                        cls.txn_completion_condition.acquire()
+                        cls.set_of_completed_txns.add(commit_id)
+                        cls.txn_completion_condition.notify()
+                        cls.txn_completion_condition.release()
+                    else:
+                        logger.error("Did not get a transaction id after transaction submission,  request nunmber %d", request_number)
+                        cls.transaction_submission_exceptions_queue.put("Did not get a transaction id after transaction submission")
+                        raise Exception("Did not get a transaction id after transaction submission,  request nunmber %d", request_number)
+                except Exception as e:
+                    logger.error("Transaction submission failed, request nunmber %d %s", request_number, str(e))
+                    cls.transaction_submission_exceptions_queue.put("Transaction submission failed")
+                    raise Exception("Transaction submission failed, request nunmber %d %s", request_number, str(e))
+            
+            return submitted_any
+
+        # -------------------------------------------------------
+
+        rep_completed_but_txn_not_submitted_updates = dict() # key is contract_id, value is dict(k:v). k = request_number from the commit _id
+        # and v is everything else needed to submit transaction
+        
+        poll_next = True
+        
+        while poll_next:
+            task = cls.pending_transactions_queue.get()
+
+            # check if the task corresponds to a termination signal (indicating an exception of any kind)
+            if task.get('exit_now'):
+                logger.info("Exiting transaction submission woker thread")
+                break
+
+            commit_id = task['commit_id']
+            contract_id = commit_id[0]
+            request_number = commit_id[2]
+            
+            if rep_completed_but_txn_not_submitted_updates.get(contract_id):
+                rep_completed_but_txn_not_submitted_updates[contract_id][request_number] =  task
+            else:
+                rep_completed_but_txn_not_submitted_updates[contract_id] = dict({request_number: task})
+            
+            # submit transactions as many as possible for the contract_id just added 
+            try:
+                submitted_any = submit_doable_transactions_for_contract(contract_id)
+            except Exception as e:
+                cls.transaction_submission_exceptions_queue("Failure in submit_doable_transactions_for_contract")
+                logger.error("Failure in submit_doable_transactions_for_contract, %s", str(e))
+                raise Exception("Failure in submit_doable_transactions_for_contract, %s", str(e))
+                                
+            # loop over all contracts_ids. For each check contract_id, submit transactions as many as possible.
+            # Continue looping until no transaction can be submitted for any conrtract_id
+            if submitted_any and len(rep_completed_but_txn_not_submitted_updates.keys()) > 1:
+                while True:
+                    loop_again = False
+                    
+                    for contract_id in list(rep_completed_but_txn_not_submitted_updates.keys()):
+                        try:
+                            submitted_any = submit_doable_transactions_for_contract(contract_id)
+                        except Exception as e:
+                            cls.transaction_submission_exceptions_queue("Failure in submit_doable_transactions_for_contract")
+                            logger.error("Failure in submit_doable_transactions_for_contract, %s", str(e))
+                            raise Exception("Failure in submit_doable_transactions_for_contract, %s", str(e))
+                        loop_again = loop_again or submitted_any
+                    
+                    if loop_again is False:
+                        break    
+
     # -------------------------------------------------------
     def __init__(self, request, response) :
         """
@@ -102,7 +322,12 @@ class ContractResponse(object) :
         self.result = response['Result']
         self.state_changed = response['StateChanged']
         self.new_state_object = request.contract_state
-
+        #if the new state is same as the old state, then change set is empty 
+        self.new_state_object.changed_block_ids=[]
+        self.replication_params = request.replication_params
+        self.storage_clients_for_replication = request.storage_clients_for_replication
+        self.request_number = request.request_number
+        
         if self.status and self.state_changed :
             self.signature = response['Signature']
             state_hash_b64 = response['StateHash']
@@ -123,7 +348,7 @@ class ContractResponse(object) :
             self.code_hash = request.contract_code.compute_hash()
             self.message_hash = request.message.compute_hash()
             self.new_state_hash = crypto.base64_to_byte_array(state_hash_b64)
-
+            
             self.originator_keys = request.originator_keys
             self.enclave_service = request.enclave_service
 
@@ -137,6 +362,86 @@ class ContractResponse(object) :
             self.raw_state = self.enclave_service.get_block(state_hash_b64)
             self.new_state_object = ContractState(self.contract_id, self.raw_state)
             self.new_state_object.pull_state_from_eservice(self.enclave_service)
+            
+            # compute ids of blocks in the change set (used for replication)
+            self.new_state_object.compute_ids_of_newblocks(request.contract_state.component_block_ids)
+            self.replicator = Replicator(self.replication_params, self.storage_clients_for_replication, \
+                self.contract_id, self.new_state_object.changed_block_ids, request.enclave_service)
+
+    # -------------------------------------------------------
+    
+    @property
+    def commit_id(self):
+        if self.status and self.state_changed:
+            return (self.contract_id, self.new_state_hash, self.request_number)
+        else:
+            return None
+        
+    # -------------------------------------------------------
+    def replicate_change_set(self):
+        """replicate change set for the current contract state to all provisioned enclaves"""
+            
+        try:
+            self.replicator.replicate_change_set()
+        except ReplicationException as e:
+            logger.exception("Failed to replicate change set %s", str(e))
+            raise Exception("Failed to replicate change set %s", str(e))
+
+    # -------------------------------------------------------    
+    def commit_asynchronously(self, ledger_config, wait, dependency_list_txnids=[], dependency_list_commit_ids=[], use_ledger=True):
+        """Commit includes two steps: First, replicate the change set to all provisioned encalves. Second, 
+        commit the transaction to the ledger. In this method, we add a job to the replication queue to enable the first step. The job will 
+        be picked by a replicator thead which after replication will add a sumit txn job to the pending transactions queue for the 
+        second step """
+
+        #sanity check: ensure that commit_id is not None
+        if self.commit_id is None:
+            logger.error('Commiting a response that should not be committed. Perhaps the state did not change? Or a failed update?')
+            raise Exception('Commiting a response that should not be committed. Perhaps the state did not change? Or a failed update?')
+
+        #start threads for commiting response if not done before
+        if ContractResponse.__start_threads_for_commit__:
+            # start replicator threads
+            for i in range(Replicator.get_max_num_replicator_threads()):
+                Replicator.replication_executor.submit(Replicator.replication_worker)
+                
+            # start txn submisstion thread
+            if use_ledger:
+                ContractResponse.transaction_executor.submit(ContractResponse.transaction_submission_worker)
+                
+            ContractResponse.__start_threads_for_commit__ = False
+        
+        txn_params = dict()
+        txn_params['use_ledger'] = use_ledger
+        txn_params['ledger_config'] = ledger_config
+        txn_params['wait'] = wait
+        txn_params['dependency_list_txnids'] = dependency_list_txnids
+        txn_params['dependency_list_commit_ids']=dependency_list_commit_ids
+        self.txn_params = txn_params
+                
+        Replicator.pending_replications_queue.put(dict({'response_object': self}))
+        
+        return self.commit_id
+           
+    # -------------------------------------------------------
+
+    def report_replication_completion(self):
+        """this is the call back function after replication. This function's job is to add the replication completion status to a queue, 
+        which will be processed by a "submit transaction" thread whose job is to submit transactions corresponding to completed replication tasks.
+        Such a separate thread to centralize transaction submissions helps easily ensure that a txn is submitted only after 
+        txns for all past updates are submitted """
+        
+        if self.txn_params['use_ledger']: # add the task to the transaction proceesing queue only if ledger is in use
+            params = dict()
+            params['commit_id'] = self.commit_id
+            params['response_object'] = self
+            ContractResponse.pending_transactions_queue.put(params)
+        else:
+            # in this case simply log the commit_id for the completed replication task. this is usual to check the status of completed tasks
+            Replicator.replication_completion_condition.acquire()
+            Replicator.set_of_completed_replications.add(self.commit_id)
+            Replicator.replication_completion_condition.notify()
+            Replicator.replication_completion_condition.release()
 
     # -------------------------------------------------------
     def __verify_enclave_signature(self, enclave_keys) :

--- a/python/pdo/contract/state.py
+++ b/python/pdo/contract/state.py
@@ -56,6 +56,16 @@ class ContractState(object) :
         return encoded[:16]
 
     # --------------------------------------------------
+    @staticmethod
+    def block_data_generator(contract_id, block_ids, data_dir) :
+        for block_id in block_ids :
+            raw_data = ContractState.__read_data_block_from_cache__(contract_id, block_id, data_dir)
+            if raw_data is None :
+                raise Exception('unable to locate required block; {}'.format(block_id))
+            yield raw_data
+
+    
+    
     @classmethod
     def __cache_filename__(cls, contract_id, state_hash, data_dir) :
         """
@@ -150,15 +160,8 @@ class ContractState(object) :
             return 0
 
         logger.debug('push blocks to service: %s', blocks_to_push)
-
-        def block_data_generator(contract_id, block_ids, data_dir) :
-            for block_id in block_ids :
-                raw_data = ContractState.__read_data_block_from_cache__(contract_id, block_id, data_dir)
-                if raw_data is None :
-                    raise Exception('unable to locate required block; {}'.format(block_id))
-                yield raw_data
-
-        block_data_list = block_data_generator(contract_id, blocks_to_push, data_dir)
+        
+        block_data_list = ContractState.block_data_generator(contract_id, blocks_to_push, data_dir)
         block_store_list = eservice.store_blocks(block_data_list, expiration=60)
         if block_store_list is None :
             raise Exception('failed to push blocks to eservice')
@@ -186,6 +189,7 @@ class ContractState(object) :
         block_count = len(blocks_to_pull)
         if block_count == 0 :
             logger.debug('no blocks to pull')
+            logger.info("Pulled 0 new blocks after contract update")
             return 0
 
         # it is not in the cache so grab it from the eservice
@@ -205,6 +209,8 @@ class ContractState(object) :
         if len(blocks_to_pull) != 0 :
             raise Exception('failed to pull blocks from storage service; %s', list(blocks_to_pull))
 
+        logger.info("Pulled %d new blocks after contract update", block_count + 1) # + 1 to add the root block
+       
         return len(blocks_to_pull)
 
     # --------------------------------------------------
@@ -302,6 +308,24 @@ class ContractState(object) :
             self.component_block_ids = json_main_state_block['BlockIds']
 
     # --------------------------------------------------
+
+    def compute_ids_of_newblocks(self, old_block_ids):
+        """ Compute the blocks in the change set : Used for replication. The change set includes the root block if there is any change.
+        """
+        self.changed_block_ids = []
+        for block_id in self.component_block_ids:
+            if block_id not in old_block_ids :
+                self.changed_block_ids.append(block_id)
+
+        # add state hash (not sure if this is part of component block_ids, if so we can skip the following)
+        if len(self.changed_block_ids) > 0: # if there is any change, make sure that state hash is part of chaged_block_ids
+            state_hash = self.get_state_hash(encoding='b64')
+            if state_hash not in self.changed_block_ids:
+                self.changed_block_ids.append(state_hash)
+
+
+
+    #------------------------------------------------------              
     def get_state_hash(self, encoding='raw') :
         """
         gets the hash of the contract state if it is non-empty
@@ -339,6 +363,9 @@ class ContractState(object) :
         block_ids.extend(self.component_block_ids)
 
         pushed_blocks = ContractState.__push_blocks_to_eservice__(eservice, self.contract_id, block_ids, data_dir)
+
+        logger.info("Pushed %d new blocks before contract update", pushed_blocks)
+        
         stat_logger.debug('state length is %d, pushed %d new blocks', len(self.component_block_ids), pushed_blocks)
 
     # --------------------------------------------------
@@ -364,3 +391,5 @@ class ContractState(object) :
     # --------------------------------------------------
     def save_to_cache(self, data_dir = None) :
         ContractState.__cache_data_block__(self.contract_id, self.raw_state, data_dir)
+
+    #---------------------------------------------------

--- a/python/pdo/service_client/service_data/eservice.py
+++ b/python/pdo/service_client/service_data/eservice.py
@@ -321,7 +321,7 @@ def get_client_by_id(id):
     try:
         return get_client_by_url(__url_by_name__[__name_by_id__[id]])
     except Exception as e:
-        raise Exception('Cannot generate client for eservice id %s: %s', str(id), str(e))
+        raise Exception('Cannot generate client for eservice id %s , %s', str(id), str(e))
 
 #--------------------------------------------
 #--------------------------------------------

--- a/python/pdo/service_client/storage.py
+++ b/python/pdo/service_client/storage.py
@@ -43,7 +43,7 @@ class StorageServiceClient(GenericServiceClient) :
     """A class to wrap calls to the storage service.
     """
 
-    default_timeout = 1.0
+    default_timeout = 3.1
 
     # -----------------------------------------------------------------
     def __init__(self, url) :

--- a/python/pdo/test/__init__.py
+++ b/python/pdo/test/__init__.py
@@ -18,4 +18,5 @@ __all__ = [
     'request',
     'state',
     'servicedb',
+    'replication'
 ]

--- a/python/pdo/test/contract.py
+++ b/python/pdo/test/contract.py
@@ -32,6 +32,8 @@ import pdo.service_client.provisioning as pservice_helper
 import pdo.service_client.service_data.eservice as db
 
 import pdo.contract as contract_helper
+from pdo.contract.response import ContractResponse
+from pdo.contract.replication import ReplicationException
 import pdo.common.crypto as crypto
 import pdo.common.keys as keys
 import pdo.common.secrets as secrets
@@ -68,36 +70,102 @@ def ErrorShutdown() :
     except Exception as e :
         logger.exception('shutdown failed')
 
+    # Send termination signal to commit tasks
+    ContractResponse.exit_commit_workers()
+
     sys.exit(-1)
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
+def AddReplicationParamsToContract(config, enclave_clients, contract):
+    """ Get parameters for change set replication from config. """
+    
+    replication_config = config['Replication']
+
+    # ---------- get replication parameters from config --------------------------------------------------
+
+    try :
+        num_provable_replicas = replication_config['NumProvableReplicas']
+        availability_duration = replication_config['Duration']
+    except Exception as e :
+        logger.error('Replication is enabled with incomplete configuration.')
+        sys.exit(-1)
+
+    assert num_provable_replicas >= 0 , "Invalid configuration for num_provable_replicas: Must be a postive integer for proof of replication "
+    assert num_provable_replicas <= len(enclave_clients), "Invalid configuration for num_provable_replicas : Can be at most number of provisioned eservices"
+    assert availability_duration > 0 , "Invalid configuration for availability duration: Must be positive."
+
+    contract.set_replication_parameters(num_provable_replicas, availability_duration)
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+def AddEnclaveSecrets(ledger_config, contract_id, client_keys, enclaves, provclients) :
+    secrets = {}
+    encrypted_state_encryption_keys = {}
+    for enclave in enclaves:
+        if use_pservice:
+            psecrets = []
+            for provclient in provclients:
+                # Get a pspk:esecret pair from the provisioning service for each enclave
+                sig_payload = crypto.string_to_byte_array(enclave.enclave_id + contract_id)
+                secretinfo = provclient.get_secret(enclave.enclave_id,
+                                               contract_id,
+                                               client_keys.verifying_key,
+                                               client_keys.sign(sig_payload))
+                logger.debug("pservice secretinfo: %s", secretinfo)
+
+                # Add this pspk:esecret pair to the list
+                psecrets.append(secretinfo)
+        else:
+            psecrets = secret_helper.create_secrets_for_services(provclients, enclave.enclave_keys, contract_id, client_keys.identity)
+
+        # Print all of the secret pairs generated for this particular enclave
+        logger.debug('psecrets for enclave %s : %s', enclave.enclave_id, psecrets)
+
+        # Verify those secrets with the enclave
+        esresponse = enclave.verify_secrets(contract_id, client_keys.verifying_key, psecrets)
+        logger.debug("verify_secrets response: %s", esresponse)
+
+        # Store the ESEK mapping in a dictionary key'd by the enclave's public key (ID)
+        encrypted_state_encryption_keys[enclave.enclave_id] = esresponse['encrypted_state_encryption_key']
+
+        # Add this spefiic enclave to the contract
+        if use_ledger:
+            contract_helper.add_enclave_to_contract(ledger_config,
+                                client_keys,
+                                contract_id,
+                                enclave.enclave_id,
+                                psecrets,
+                                esresponse['encrypted_state_encryption_key'],
+                                esresponse['signature'])
+
+    return encrypted_state_encryption_keys
+
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
 def CreateAndRegisterEnclave(config) :
+    """
+    creates and registers an enclave
+    IMPORTANT: if an eservice is available it will be used,
+               otherwise, the code interfaces directly with the python/swig wrapper in the eservice code
+    """
+    
     global enclave
     global txn_dependencies
 
+    # if we are using the eservice then there is nothing to register since
+    # the eservice has already registered the enclave
     if use_eservice :
+        enclaveclients = []
+        try :
+            for url in config['Service']['EnclaveServiceURLs'] :
+                enclaveclients.append(db.get_client_by_url(url))
+        except Exception as e :
+            logger.error('unable to setup enclave services; %s', str(e))
+            sys.exit(-1)
 
-        # Pick an enclave for the creating the contract
-        if config['Service'].get('EnclaveServiceNames'): #use the database to get the enclave
-            logger.info('Using eservice database to look up service URL for the contract enclave')
-            try:
-                eservice_to_use = random.choice(config['Service']['EnclaveServiceNames'])
-                enclave = db.get_client_by_name(eservice_to_use)
-            except Exception as e:
-                logger.error('Unable to get the eservice client using the eservice database: %s', str(e))
-                sys.exit(-1)
-        else: # do not use the database, use the url and get the client directly
-            try :
-                eservice_urls = config['Service']['EnclaveServiceURLs']
-                eservice_url = random.choice(eservice_urls)
-                enclave = eservice_helper.EnclaveServiceClient(eservice_url)
-            except Exception as e :
-                logger.error('failed to contact enclave service; %s', str(e))
-                sys.exit(-1)
-
-        logger.info('use enclave service at %s', enclave.ServiceURL)
-        return enclave
+        return enclaveclients 
 
     # not using an eservice so build the local enclave
     try :
@@ -105,6 +173,7 @@ def CreateAndRegisterEnclave(config) :
         block_store_file = config['StorageService']['BlockStore']
         block_store = BlockStoreManager(block_store_file, create_block_store=True)
     except Exception as e :
+        block_store.close()
         logger.error('failed to initialize the block store; %s', str(e))
         sys.exit(-1)
 
@@ -131,12 +200,12 @@ def CreateAndRegisterEnclave(config) :
     except Exception as e :
         logger.exception('failed to register the enclave; %s', str(e))
         ErrorShutdown()
-
-    return enclave
+    
+    return [enclave]
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
-def CreateAndRegisterContract(config, enclave, contract_creator_keys) :
+def CreateAndRegisterContract(config, enclaves, contract_creator_keys) :
     global txn_dependencies
 
     data_dir = config['Contract']['DataDirectory']
@@ -182,74 +251,24 @@ def CreateAndRegisterContract(config, enclave, contract_creator_keys) :
     # --------------------------------------------------
     logger.info('create the provisioning secrets')
     # --------------------------------------------------
-    if use_pservice :
-        secret_list = []
-        for pservice in provisioning_services :
-            logger.debug('ask pservice %s to generate a secret for %s', pservice.ServiceURL, contract_id)
-            message = enclave.enclave_id + contract_id
-            signature = contract_creator_keys.sign(message, encoding='hex')
-            secret = pservice.get_secret(enclave.enclave_id, contract_id, contract_creator_keys.verifying_key, signature)
-            if secret is None :
-                logger.error('failed to create secret for %s', pservice.ServiceURL)
-                ErrorShutdown()
-            secret_list.append(secret)
-    else :
-        secret_list = secret_helper.create_secrets_for_services(
-            provisioning_services, enclave.enclave_keys, contract_id, contract_creator_id)
+    encrypted_state_encryption_keys = AddEnclaveSecrets(
+        ledger_config, contract.contract_id, contract_creator_keys, enclaves, provisioning_services)
 
-    logger.debug('secrets: %s', secret_list)
+    for enclave_id in encrypted_state_encryption_keys :
+        encrypted_key = encrypted_state_encryption_keys[enclave_id]
+        contract.set_state_encryption_key(enclave_id, encrypted_key)
+    
+    #add replication information to contract
+    AddReplicationParamsToContract(config, enclaves, contract)
 
-    try :
-        secretinfo = enclave.verify_secrets(contract_id, contract_creator_id, secret_list)
-        assert secretinfo
+    # Decide if the contract use a fixed enclave or a randomized one for each update. If fixed, we chose here. If random, nothing to be done here, 
+    # will be (atuomatically) selected at random during request creation 
+    if (use_eservice is False) or (config['Service']['Randomize_Eservice'] is False):
+        enclave_to_use = enclaves[0]
+    else:
+        enclave_to_use = None
 
-        encrypted_state_encryption_key = secretinfo['encrypted_state_encryption_key']
-        signature = secretinfo['signature']
-
-    except Exception as e :
-        logger.error('failed to create the state encryption key; %s', str(e))
-        ErrorShutdown()
-
-    try :
-        if not secrets.verify_state_encryption_key_signature(
-                encrypted_state_encryption_key,
-                secret_list,
-                contract_id,
-                contract_creator_id,
-                signature,
-                enclave.enclave_keys) :
-            raise RuntimeError('signature verification failed')
-    except Exception as e :
-        logger.error('failed to verify the state encryption key; %s', str(e))
-        ErrorShutdown()
-
-    logger.info('encrypted state encryption key: %s', encrypted_state_encryption_key)
-
-    # --------------------------------------------------
-    logger.info('add the provisioned enclave to the contract')
-    # --------------------------------------------------
-    try :
-        if use_ledger :
-            txnid = contract_helper.add_enclave_to_contract(
-                ledger_config,
-                contract_creator_keys,
-                contract_id,
-                enclave.enclave_id,
-                secret_list,
-                encrypted_state_encryption_key,
-                signature,
-                transaction_dependency_list=txn_dependencies)
-            txn_dependencies = [ txnid ]
-
-            logger.info('contract state encryption key added to contract')
-        else :
-            logger.debug('no ledger config; skipping state encryption key registration')
-    except Exception as e :
-        logger.error('failed to add state encryption key; %s', str(e))
-        ErrorShutdown()
-
-    contract.set_state_encryption_key(enclave.enclave_id, encrypted_state_encryption_key)
-
+    # save the contract info as a pdo file
     contract_save_file = '_' + contract.short_id + '.pdo'
     contract.save_to_file(contract_save_file, data_dir=data_dir)
 
@@ -257,7 +276,7 @@ def CreateAndRegisterContract(config, enclave, contract_creator_keys) :
     logger.info('create the initial contract state')
     # --------------------------------------------------
     try :
-        initialize_request = contract.create_initialize_request(contract_creator_keys, enclave)
+        initialize_request = contract.create_initialize_request(contract_creator_keys, enclave_to_use)
         initialize_response = initialize_request.evaluate()
         if initialize_response.status is False :
             logger.error('contract initialization failed: %s', initialize_response.result)
@@ -269,7 +288,15 @@ def CreateAndRegisterContract(config, enclave, contract_creator_keys) :
         logger.error('failed to create the initial state; %s', str(e))
         ErrorShutdown()
 
-    logger.info('enclave created initial state')
+    logger.info('Created initial state')
+
+    #replicate initial state to all provisioned enclaves
+    try:
+        logger.info("Replicate initial state to all provisioned enclaves")
+        initialize_response.replicate_change_set()
+    except ReplicationException as e:
+        logger.error('Failed to replicate initial state, %s', str(e))
+        ErrorShutdown()
 
     # --------------------------------------------------
     logger.info('save the initial state in the ledger')
@@ -285,7 +312,6 @@ def CreateAndRegisterContract(config, enclave, contract_creator_keys) :
                 ledger_config,
                 wait=30,
                 transaction_dependency_list=txn_dependencies)
-            txn_dependencies = [txnid]
         else:
             logger.debug('no ledger config; skipping iniatialize state save')
     except Exception as e :
@@ -298,11 +324,18 @@ def CreateAndRegisterContract(config, enclave, contract_creator_keys) :
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
-def UpdateTheContract(config, enclave, contract, contract_invoker_keys) :
-    txn_dependencies = []
+def UpdateTheContract(config, contract, enclaves, contract_invoker_keys) :
+    commit_dependenices = []
 
     ledger_config = config.get('Sawtooth')
     contract_invoker_id = contract_invoker_keys.identity
+
+    # Decide if the contract use a fixed enclave or a randomized one for each update. If fixed, we chose here. If random, nothing to be done here, 
+    # will be (atuomatically) selected at random during request creation 
+    if (use_eservice is False) or (config['Service']['Randomize_Eservice'] is False):
+        enclave_to_use = enclaves[0]
+    else:
+        enclave_to_use = None
 
     start_time = time.time()
     total_tests = 0
@@ -312,13 +345,21 @@ def UpdateTheContract(config, enclave, contract, contract_invoker_keys) :
         fieldnames = ['expression', 'expected', 'invert']
         reader = csv.DictReader(filter(lambda row: row[0] != '#', efile),
                                 fieldnames, quoting=csv.QUOTE_NONE, escapechar='\\', skipinitialspace=True)
+                                                
+        commit_dependencies = []
 
         for test in reader :
             expression = test["expression"]
 
+            #check if any past commits (carried out asynchronously) failed, if so abort the rest of the execution
+            e = ContractResponse.get_exceptions_from_past_commits()
+            if e is not None:
+                logger.exception("Error in past response commit. Aborting rest of the updates: %s", str(e))
+                ErrorShutdown()
+
             try :
                 total_tests += 1
-                update_request = contract.create_update_request(contract_invoker_keys, enclave, expression)
+                update_request = contract.create_update_request(contract_invoker_keys, expression, enclave_to_use)
                 update_response = update_request.evaluate()
                 result = update_response.result[:15] + (len(update_response.result) >= 15 and "..." or "")
 
@@ -339,38 +380,39 @@ def UpdateTheContract(config, enclave, contract, contract_invoker_keys) :
                 logger.error('enclave failed to evaluation expression; %s', str(e))
                 ErrorShutdown()
 
-            # if this operation did not change state then there is nothing
-            # to send to the ledger or to save
-            if not update_response.state_changed :
-                continue
+            # if this operation did not change state then there is nothing to commit
+            if update_response.state_changed :
+                # asynchronously submit the commit task: (a commit task replicates change-set and submits the corresponding transaction)
+                try:
+                    logger.info("asynchronously replicate change set and submit transaction in the background")
+                    commit_id = update_response.commit_asynchronously(ledger_config,
+                        wait=30, dependency_list_txnids=[], dependency_list_commit_ids=commit_dependencies, use_ledger=use_ledger)
+                    commit_dependencies = [commit_id] 
+                except ReplicationException as e:
+                    logger.exception('failed to asynchronously start replication and transaction submission:' + str(e))
+                    ErrorShutdown()
 
-            try :
-                if ledger_config is not None :
-                    logger.debug("sending to ledger")
-                    # note that we will wait for commit of the transaction before
-                    # continuing; this is not necessary in general (if there is
-                    # confidence the transaction will succeed) but is useful for
-                    # testing
-                    txnid = update_response.submit_update_transaction(
-                        ledger_config,
-                        wait=30,
-                        transaction_dependency_list = txn_dependencies)
-                    txn_dependencies = [ txnid ]
-                else :
-                    logger.debug('no ledger config; skipping state save')
-            except Exception as e :
-                logger.error('failed to save the new state; %s', str(e))
-                ErrorShutdown()
+                logger.debug('update state')
+                contract.set_state(update_response.raw_state)
 
-            logger.debug('update state')
-            contract.set_state(update_response.raw_state)
-
+    # wait for the last commit to finish. Also shutdown commit workers
+    if len(commit_dependencies) > 0:
+        try:
+            txn_id = ContractResponse.wait_for_commit(commit_dependencies[0], use_ledger, shut_down=True)
+            if use_ledger and txn_id is None:
+                logger.error("Did not receive txn id for the final commit")
+                ErrorShutdown()    
+        except Exception as e:
+            logger.error(str(e))
+            ErrorShutdown()
+    
     logger.info('completed in %s', time.time() - start_time)
     logger.info('passed %d of %d tests', total_tests - total_failed, total_tests)
-    if total_failed > 0 :
+    
+    if total_failed > 0: 
         logger.warn('failed %d of %d tests', total_failed, total_tests)
         ErrorShutdown()
-
+    
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
 def LocalMain(config) :
@@ -389,15 +431,22 @@ def LocalMain(config) :
             logger.error('Error loading eservice database %s', str(e))
             sys.exit(-1)
 
+        #convert any eservice names to urls using the database
+        if config['Service'].get('EnclaveServiceNames'):
+            config['Service']['EnclaveServiceURLs'] = []
+            for name in  config['Service']['EnclaveServiceNames']:
+                info = db.get_info_by_name(name)
+                config['Service']['EnclaveServiceURLs'].append(info['url'])
+
     # --------------------------------------------------
-    logger.info('create and register the enclave')
+    logger.info('create and register the enclaves')
     # --------------------------------------------------
-    enclave = CreateAndRegisterEnclave(config)
+    enclaves =  CreateAndRegisterEnclave(config) 
 
     # --------------------------------------------------
     logger.info('create the contract and register it')
     # --------------------------------------------------
-    contract = CreateAndRegisterContract(config, enclave, contract_creator_keys)
+    contract = CreateAndRegisterContract(config, enclaves, contract_creator_keys)
 
     # --------------------------------------------------
     logger.info('invoke a few methods on the contract, load from file')
@@ -414,7 +463,7 @@ def LocalMain(config) :
         ErrorShutdown()
 
     try :
-        UpdateTheContract(config, enclave, contract, contract_creator_keys)
+        UpdateTheContract(config, contract, enclaves, contract_creator_keys)
     except Exception as e :
         logger.error('contract execution failed; %s', str(e))
         ErrorShutdown()
@@ -483,6 +532,8 @@ def Main() :
     parser.add_argument('--eservice-db', help='json file for eservice database', type=str)
     parser.add_argument('--eservice-name', help='List of enclave services to use. Give names as in database', nargs='+')
     parser.add_argument('--eservice-url', help='List of enclave service URLs to use', nargs='+')
+    parser.add_argument('--randomize-eservice', help="Say True if eservice must be randomized for each update. \
+        Else, the same eservice (the first one in the list of input eservices) will be used for all udpates.", type=bool, default=False)
     parser.add_argument('--pservice-url', help='List of provisioning service URLs to use', nargs='+')
 
     parser.add_argument('--block-store', help='Name of the file where blocks are stored', type=str)
@@ -490,6 +541,9 @@ def Main() :
     parser.add_argument('--secret-count', help='Number of secrets to generate', type=int, default=3)
     parser.add_argument('--contract', help='Name of the contract to use', default='integer-key')
     parser.add_argument('--expressions', help='Name of a file to read for expressions', default=None)
+
+    parser.add_argument('--num-provable-replicas', help='Number of sservice signatures needed for proof of replication', type=int, default=1)
+    parser.add_argument('--availability-duration', help='duration (in seconds) for which the replicas are stored at storage service', type=int, default=60)
 
     options = parser.parse_args()
 
@@ -559,6 +613,7 @@ def Main() :
             'EnclaveServiceDatabaseFile' : None
         }
 
+    config['Service']['Randomize_Eservice'] = options.randomize_eservice
     if options.eservice_name:
         use_eservice = True
         config['Service']['EnclaveServiceNames'] = options.eservice_name
@@ -572,6 +627,12 @@ def Main() :
     if options.pservice_url :
         use_pservice = True
         config['Service']['ProvisioningServiceURLs'] = options.pservice_url
+
+    # replication parameters
+    if options.num_provable_replicas :
+        config['Replication']['NumProvableReplicas'] = options.num_provable_replicas
+    if options.availability_duration :
+        config['Replication']['Duration'] = options.availability_duration
 
     # set up the data paths
     if config.get('Contract') is None :

--- a/python/pdo/test/request.py
+++ b/python/pdo/test/request.py
@@ -18,7 +18,7 @@ import os
 import sys
 import time
 import argparse
-import random
+
 from string import Template
 
 import pdo.test.helpers.secrets as secret_helper
@@ -32,6 +32,8 @@ import pdo.service_client.provisioning as pservice_helper
 import pdo.service_client.service_data.eservice as db
 
 import pdo.contract as contract_helper
+from pdo.contract.response import ContractResponse
+from pdo.contract.replication import ReplicationException
 import pdo.common.crypto as crypto
 import pdo.common.keys as keys
 import pdo.common.secrets as secrets
@@ -68,7 +70,77 @@ def ErrorShutdown() :
     except Exception as e :
         logger.exception('shutdown failed')
 
+    # Send termination signal to commit tasks
+    ContractResponse.exit_commit_workers()
+
     sys.exit(-1)
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+def AddReplicationParamsToContract(config, enclave_clients, contract):
+    """ Get parameters for change set replication from config. """
+    
+    replication_config = config['Replication']
+
+    # ---------- get replication parameters from config --------------------------------------------------
+
+    try :
+        num_provable_replicas = replication_config['NumProvableReplicas']
+        availability_duration = replication_config['Duration']
+    except Exception as e :
+        logger.error('Replication is enabled with incomplete configuration.')
+        sys.exit(-1)
+
+    assert num_provable_replicas >= 0 , "Invalid configuration for num_provable_replicas: Must be a postive integer for proof of replication "
+    assert num_provable_replicas <= len(enclave_clients), "Invalid configuration for num_provable_replicas : Can be at most number of provisioned eservices"
+    assert availability_duration > 0 , "Invalid configuration for availability duration: Must be positive."
+
+    contract.set_replication_parameters(num_provable_replicas, availability_duration)
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+def AddEnclaveSecrets(ledger_config, contract_id, client_keys, enclaves, provclients) :
+    secrets = {}
+    encrypted_state_encryption_keys = {}
+    for enclave in enclaves:
+        
+        if use_pservice:
+            psecrets = []
+            for provclient in provclients:
+                # Get a pspk:esecret pair from the provisioning service for each enclave
+                sig_payload = crypto.string_to_byte_array(enclave.enclave_id + contract_id)
+                secretinfo = provclient.get_secret(enclave.enclave_id,
+                                               contract_id,
+                                               client_keys.verifying_key,
+                                               client_keys.sign(sig_payload))
+                logger.debug("pservice secretinfo: %s", secretinfo)
+
+                # Add this pspk:esecret pair to the list
+                psecrets.append(secretinfo)
+        else:
+            psecrets = secret_helper.create_secrets_for_services(provclients, enclave.enclave_keys, contract_id, client_keys.identity)
+
+        # Print all of the secret pairs generated for this particular enclave
+        logger.debug('psecrets for enclave %s : %s', enclave.enclave_id, psecrets)
+
+        # Verify those secrets with the enclave
+        esresponse = enclave.verify_secrets(contract_id, client_keys.verifying_key, psecrets)
+        logger.debug("verify_secrets response: %s", esresponse)
+
+        # Store the ESEK mapping in a dictionary key'd by the enclave's public key (ID)
+        encrypted_state_encryption_keys[enclave.enclave_id] = esresponse['encrypted_state_encryption_key']
+
+        # Add this spefiic enclave to the contract
+        if use_ledger :
+            contract_helper.add_enclave_to_contract(ledger_config,
+                                client_keys,
+                                contract_id,
+                                enclave.enclave_id,
+                                psecrets,
+                                esresponse['encrypted_state_encryption_key'],
+                                esresponse['signature'])
+
+    return encrypted_state_encryption_keys
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
@@ -78,34 +150,22 @@ def CreateAndRegisterEnclave(config) :
     IMPORTANT: if an eservice is available it will be used,
                otherwise, the code interfaces directly with the python/swig wrapper in the eservice code
     """
+
     global enclave
     global txn_dependencies
 
     # if we are using the eservice then there is nothing to register since
     # the eservice has already registered the enclave
     if use_eservice :
-
-        # Pick an enclave for the creating the contract
-        if config['Service'].get('EnclaveServiceNames'): #use the database to get the enclave
-            logger.info('Using eservice database to look up service URL for the contract enclave')
-            try:
-                eservice_to_use = random.choice(config['Service']['EnclaveServiceNames'])
-                enclave = db.get_client_by_name(eservice_to_use)
-            except Exception as e:
-                logger.error('Unable to get the eservice client using the eservice database: %s',  str(e))
-                sys.exit(-1)
-        else: # do not use the database, use the url and get the client directly
-            try :
-                eservice_urls = config['Service']['EnclaveServiceURLs']
-                eservice_url = random.choice(eservice_urls)
-                enclave = eservice_helper.EnclaveServiceClient(eservice_url)
-            except Exception as e :
-                logger.error('failed to contact enclave service; %s', str(e))
-                sys.exit(-1)
-
-        logger.info('use enclave service at %s', enclave.ServiceURL)
-        return enclave
-
+        enclaveclients = []
+        try :
+            for url in config['Service']['EnclaveServiceURLs'] :
+                enclaveclients.append(db.get_client_by_url(url))
+        except Exception as e :
+            logger.error('unable to setup enclave services; %s', str(e))
+            sys.exit(-1)
+        return enclaveclients  
+    
     # not using an eservice so build the local enclave
     try :
         global block_store
@@ -128,7 +188,7 @@ def CreateAndRegisterEnclave(config) :
         ledger_config = config.get('Sawtooth')
         if use_ledger :
             txnid = enclave.register_enclave(ledger_config)
-            txn_dependencies.append(txnid)
+            txn_dependencies = [ txnid ]
 
             logger.info('enclave registration successful')
 
@@ -137,14 +197,14 @@ def CreateAndRegisterEnclave(config) :
         else :
             logger.debug('no ledger config; skipping enclave registration')
     except Exception as e :
-        logger.error('failed to register the enclave; %s', str(e))
+        logger.exception('failed to register the enclave; %s', str(e))
         ErrorShutdown()
 
-    return enclave
+    return [enclave]
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
-def CreateAndRegisterContract(config, enclave, contract_creator_keys) :
+def CreateAndRegisterContract(config, enclaves, contract_creator_keys) :
     global txn_dependencies
 
     data_dir = config['Contract']['DataDirectory']
@@ -160,7 +220,7 @@ def CreateAndRegisterContract(config, enclave, contract_creator_keys) :
     except Exception as e :
         raise Exception('unable to load contract source; {0}'.format(str(e)))
 
-    # create the provisioning servers
+    # create the provisioning service clients
     if use_pservice :
         try :
             pservice_urls = config['Service']['ProvisioningServiceURLs']
@@ -172,6 +232,7 @@ def CreateAndRegisterContract(config, enclave, contract_creator_keys) :
         provisioning_services = secret_helper.create_provisioning_services(config['secrets'])
     provisioning_service_keys = list(map(lambda svc : svc.identity, provisioning_services))
 
+    # register the contract, get contract_id
     try :
         if use_ledger :
             contract_id = contract_helper.register_contract(
@@ -190,82 +251,32 @@ def CreateAndRegisterContract(config, enclave, contract_creator_keys) :
     # --------------------------------------------------
     logger.info('create the provisioning secrets')
     # --------------------------------------------------
-    if use_pservice :
-        secret_list = []
-        for pservice in provisioning_services :
-            logger.debug('ask pservice %s to generate a secret for %s', pservice.ServiceURL, contract_id)
-            message = enclave.enclave_id + contract_id
-            signature = contract_creator_keys.sign(message, encoding='hex')
-            secret = pservice.get_secret(enclave.enclave_id, contract_id, contract_creator_keys.verifying_key, signature)
-            if secret is None :
-                logger.error('failed to create secret for %s', pservice.ServiceURL)
-                ErrorShutdown()
-            secret_list.append(secret)
-    else :
-        secret_list = secret_helper.create_secrets_for_services(
-            provisioning_services, enclave.enclave_keys, contract_id, contract_creator_id)
+    encrypted_state_encryption_keys = AddEnclaveSecrets(
+        ledger_config, contract.contract_id, contract_creator_keys, enclaves, provisioning_services)
 
-    logger.debug('secrets: %s', secret_list)
+    for enclave_id in encrypted_state_encryption_keys :
+        encrypted_key = encrypted_state_encryption_keys[enclave_id]
+        contract.set_state_encryption_key(enclave_id, encrypted_key)
+    
+    # add replication information to contract
+    AddReplicationParamsToContract(config, enclaves, contract)
 
-    try :
-        secretinfo = enclave.verify_secrets(contract_id, contract_creator_id, secret_list)
-        assert secretinfo
+    # Decide if the contract use a fixed enclave or a randomized one for each update. If fixed, we chose here. If random, nothing to be done here, 
+    # will be (atuomatically) selected at random during request creation 
+    if (use_eservice is False) or (config['Service']['Randomize_Eservice'] is False):
+        enclave_to_use = enclaves[0]
+    else:
+        enclave_to_use = None
 
-        encrypted_state_encryption_key = secretinfo['encrypted_state_encryption_key']
-        signature = secretinfo['signature']
-
-    except Exception as e :
-        logger.error('failed to create the state encryption key; %s', str(e))
-        ErrorShutdown()
-
-    try :
-        if not secrets.verify_state_encryption_key_signature(
-                encrypted_state_encryption_key,
-                secret_list,
-                contract_id,
-                contract_creator_id,
-                signature,
-                enclave.enclave_keys) :
-            raise RuntimeError('signature verification failed')
-    except Exception as e :
-        logger.error('failed to verify the state encryption key; %s', str(e))
-        ErrorShutdown()
-
-    logger.debug('encrypted state encryption key: %s', encrypted_state_encryption_key)
-
-    # --------------------------------------------------
-    logger.info('add the provisioned enclave to the contract')
-    # --------------------------------------------------
-    try :
-        if use_ledger :
-            txnid = contract_helper.add_enclave_to_contract(
-                ledger_config,
-                contract_creator_keys,
-                contract_id,
-                enclave.enclave_id,
-                secret_list,
-                encrypted_state_encryption_key,
-                signature)
-            #transaction_dependency_list=txn_dependencies)
-            txn_dependencies.append(txnid)
-
-            logger.info('contract state encryption key added to contract')
-        else :
-            logger.debug('no ledger config; skipping state encryption key registration')
-    except Exception as e :
-        logger.error('failed to add state encryption key; %s', str(e))
-        ErrorShutdown()
-
-    contract.set_state_encryption_key(enclave.enclave_id, encrypted_state_encryption_key)
-
+    # save the contract info as a pdo file
     contract_save_file = '_' + contract.short_id + '.pdo'
     contract.save_to_file(contract_save_file, data_dir=data_dir)
-
+    
     # --------------------------------------------------
     logger.info('create the initial contract state')
     # --------------------------------------------------
     try :
-        initialize_request = contract.create_initialize_request(contract_creator_keys, enclave)
+        initialize_request = contract.create_initialize_request(contract_creator_keys, enclave_to_use)
         initialize_response = initialize_request.evaluate()
         if initialize_response.status is False :
             logger.error('contract initialization failed: %s', initialize_response.result)
@@ -279,6 +290,14 @@ def CreateAndRegisterContract(config, enclave, contract_creator_keys) :
 
     logger.info('enclave created initial state')
 
+    #replicate initial state to all provisioned enclaves
+    try:
+        logger.info("Replicate initial state to all provisioned enclaves")
+        initialize_response.replicate_change_set()
+    except ReplicationException as e:
+        logger.error('Failed to replicate initial state, %s', str(e))
+        ErrorShutdown()
+    
     # --------------------------------------------------
     logger.info('save the initial state in the ledger')
     # --------------------------------------------------
@@ -293,7 +312,6 @@ def CreateAndRegisterContract(config, enclave, contract_creator_keys) :
                 ledger_config,
                 wait=30,
                 transaction_dependency_list=txn_dependencies)
-            txn_dependencies = [txnid]
         else:
             logger.debug('no ledger config; skipping iniatialize state save')
     except Exception as e :
@@ -306,11 +324,18 @@ def CreateAndRegisterContract(config, enclave, contract_creator_keys) :
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
-def UpdateTheContract(config, enclave, contract, contract_invoker_keys) :
-    global txn_dependencies
+def UpdateTheContract(config, contract, enclaves, contract_invoker_keys) :
 
     ledger_config = config.get('Sawtooth')
     contract_invoker_id = contract_invoker_keys.identity
+    commit_dependencies = []
+
+    # Decide if the contract use a fixed enclave or a randomized one for each update. If fixed, we chose here. If random, nothing to be done here, 
+    # will be (atuomatically) selected at random during request creation 
+    if (use_eservice is False) or (config['Service']['Randomize_Eservice'] is False):
+        enclave_to_use = enclaves[0]
+    else:
+        enclave_to_use = None
 
     start_time = time.time()
     for x in range(config['iterations']) :
@@ -320,9 +345,15 @@ def UpdateTheContract(config, enclave, contract, contract_invoker_keys) :
             temp_saved_state_hash = contract.contract_state.get_state_hash(encoding='b64')
             test_state.TamperWithStateBlockOrder(contract.contract_state)
 
+        #check if any past commits (carried out asynchronously) failed, if so abort the rest of the execution
+        e = ContractResponse.get_exceptions_from_past_commits()
+        if e is not None:
+            logger.exception("Error in past response commit. Aborting rest of the updates: %s", str(e))
+            ErrorShutdown()
+
         try :
             expression = "'(inc-value)"
-            update_request = contract.create_update_request(contract_invoker_keys, enclave, expression)
+            update_request = contract.create_update_request(contract_invoker_keys, expression, enclave_to_use)
             update_response = update_request.evaluate()
 
             if update_response.status is False :
@@ -335,33 +366,36 @@ def UpdateTheContract(config, enclave, contract, contract_invoker_keys) :
             logger.error('enclave failed to evaluation expression; %s', str(e))
             ErrorShutdown()
 
-        # if this operation did not change state then there is nothing
-        # to send to the ledger or to save
-        if not update_response.state_changed :
-            continue
+        # if this operation did not change state then there is nothing to commit
+        if update_response.state_changed :
+            # asynchronously submit the commit task: (a commit task replicates change-set and submits the corresponding transaction)
+            try:
+                commit_id = update_response.commit_asynchronously(ledger_config,
+                    wait=30, dependency_list_txnids=[], dependency_list_commit_ids=commit_dependencies, use_ledger=use_ledger) 
+                    # Here we explicitly specify dependency_list_commit_ids solely for purposes of clarity. The call works with 
+                    # dependency_list_commit_ids = [] as well, as long as the dependencies arise just from past commits from the same contract. 
+                    # In the latter case, the dependencies are automatically identified during commit
+                commit_dependencies = [commit_id]
+            except ReplicationException as e:
+                logger.exception('failed to asynchronously start replication and transaction submission:' + str(e))
+                ErrorShutdown()
 
-        try :
-            if use_ledger :
-                logger.debug("sending to ledger")
-                # note that we will wait for commit of the transaction before
-                # continuing; this is not necessary in general (if there is
-                # confidence the transaction will succeed) but is useful for
-                # testing
-                txnid = update_response.submit_update_transaction(
-                    ledger_config,
-                    wait=30,
-                    transaction_dependency_list=txn_dependencies)
-                txn_dependencies = [txnid]
-            else :
-                logger.debug('no ledger config; skipping state save')
-        except Exception as e :
-            logger.error('failed to save the new state; %s', str(e))
-            ErrorShutdown()
+            logger.debug('update state')
+            contract.set_state(update_response.raw_state)
 
-        logger.debug('update state')
-        contract.set_state(update_response.raw_state)
-
+    # wait for the last commit to finish. Also shutdown commit workers
+    try:
+        txn_id = ContractResponse.wait_for_commit(commit_dependencies[0], use_ledger, shut_down=True)
+        if use_ledger and txn_id is None:
+            logger.error("Did not receive txn id for the final commit")
+            ErrorShutdown()    
+    except Exception as e:
+        logger.error(str(e))
+        ErrorShutdown()
+    
+    logger.info("All commits completed")
     logger.info('completed in %s', time.time() - start_time)
+    
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
@@ -381,15 +415,22 @@ def LocalMain(config) :
             logger.error('Error loading eservice database %s', str(e))
             sys.exit(-1)
 
+        #convert any eservice names to urls using the database
+        if config['Service'].get('EnclaveServiceNames'):
+            config['Service']['EnclaveServiceURLs'] = []
+            for name in  config['Service']['EnclaveServiceNames']:
+                info = db.get_info_by_name(name)
+                config['Service']['EnclaveServiceURLs'].append(info['url'])
+
     # --------------------------------------------------
-    logger.info('create and register the enclave')
+    logger.info('create and register the enclaves')
     # --------------------------------------------------
-    enclave = CreateAndRegisterEnclave(config)
+    enclaves  = CreateAndRegisterEnclave(config)
 
     # --------------------------------------------------
     logger.info('create the contract and register it')
     # --------------------------------------------------
-    contract = CreateAndRegisterContract(config, enclave, contract_creator_keys)
+    contract = CreateAndRegisterContract(config, enclaves, contract_creator_keys)
 
     # --------------------------------------------------
     logger.info('invoke a few methods on the contract, load from file')
@@ -406,7 +447,7 @@ def LocalMain(config) :
         ErrorShutdown()
 
     try :
-        UpdateTheContract(config, enclave, contract, contract_creator_keys)
+        UpdateTheContract(config, contract, enclaves, contract_creator_keys)
     except Exception as e :
         logger.exception('contract execution failed; %s', str(e))
         ErrorShutdown()
@@ -476,12 +517,17 @@ def Main() :
     parser.add_argument('--eservice-db', help='json file for eservice database', type=str)
     parser.add_argument('--eservice-name', help='List of enclave services to use. Give names as in database', nargs='+')
     parser.add_argument('--eservice-url', help='List of enclave service URLs to use', nargs='+')
+    parser.add_argument('--randomize-eservice', help="Say True if eservice must be randomized for each update. \
+        Else, the same eservice (the first one in the list of input eservices) will be used for all udpates.", type=bool, default=False)
     parser.add_argument('--pservice-url', help='List of provisioning service URLs to use', nargs='+')
 
     parser.add_argument('--block-store', help='Name of the file where blocks are stored', type=str)
 
     parser.add_argument('--secret-count', help='Number of secrets to generate', type=int, default=3)
     parser.add_argument('--iterations', help='Number of operations to perform', type=int, default=10)
+
+    parser.add_argument('--num-provable-replicas', help='Number of sservice signatures needed for proof of replication', type=int, default=1)
+    parser.add_argument('--availability-duration', help='duration (in seconds) for which the replicas are stored at storage service', type=int, default=60)
 
     parser.add_argument('--tamper-block-order', help='Flag for tampering with the order of the state blocks', action='store_true')
 
@@ -553,6 +599,7 @@ def Main() :
             'EnclaveServiceDatabaseFile' : None
         }
 
+    config['Service']['Randomize_Eservice'] = options.randomize_eservice
     if options.eservice_name:
         use_eservice = True
         config['Service']['EnclaveServiceNames'] = options.eservice_name
@@ -567,6 +614,11 @@ def Main() :
         use_pservice = True
         config['Service']['ProvisioningServiceURLs'] = options.pservice_url
 
+    # replication parameters
+    if options.num_provable_replicas :
+        config['Replication']['NumProvableReplicas'] = options.num_provable_replicas
+    if options.availability_duration :
+        config['Replication']['Duration'] = options.availability_duration
 
     # set up the data paths
     if config.get('Contract') is None :

--- a/python/setup.py
+++ b/python/setup.py
@@ -104,6 +104,7 @@ setup(name='pdo_common_library',
               'pdo-test-contract = pdo.test.contract:Main',
               'pdo-test-request = pdo.test.request:Main',
               'pdo-test-storage = pdo.test.storage:Main',
+              'pdo-test-replication = pdo.test.replication:Main'
           ]
       }
 )


### PR DESCRIPTION
This PR implements two features:

1. Facility to replicate change-set (new blocks in the state after update) to the storage services associated with all provisioned enclaves for the contract
2. Facility to submit transactions asynchronously.

Replication and transaction submission are together referred to a commit operation.  To use the two facilities, the client can simply invoke the commit operation to carry out both replication and transaction submission asynchronously. A commit id is returned, and the client can proceed with the next update operation. The client can use the commit id any time in the future to check the status of the commit operation. The commit operation permits the client to specify past commit ids as dependencies, in case the transaction corresponding to the commit operation must only be submitted after the submission of transactions corresponding to commit operations whose ids are specified as dependencies