### PR TITLE
New Replcation and transaction Modules

### DIFF
--- a/build/__tools__/run-tests.sh
+++ b/build/__tools__/run-tests.sh
@@ -343,14 +343,14 @@ try pdo-test-request --ledger ${PDO_LEDGER_URL} \
     --pservice http://localhost:7001/ http://localhost:7002 http://localhost:7003 \
     --eservice-url http://localhost:7101/ http://localhost:7102/ http://localhost:7103/ \
     --logfile __screen__ --loglevel warn --iterations 10 \
-    --num-provable-replicas 2 --availability-duration 100 --randomize-eservice True
+    --num-provable-replicas 2 --availability-duration 100 --randomize-eservice
 
 say start memory test test with replication 3 eservices 2 replicas needed before txn
 try pdo-test-contract --ledger ${PDO_LEDGER_URL} --contract memory-test \
     --pservice http://localhost:7001/ http://localhost:7002 http://localhost:7003 \
     --eservice-url http://localhost:7101/ http://localhost:7102/ http://localhost:7103/ \
     --logfile __screen__ --loglevel warn \
-    --num-provable-replicas 2 --availability-duration 100 --randomize-eservice True
+    --num-provable-replicas 2 --availability-duration 100 --randomize-eservice
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------

--- a/build/opt/pdo/etc/template/pcontract.toml
+++ b/build/opt/pdo/etc/template/pcontract.toml
@@ -52,6 +52,13 @@ ProvisioningServiceURLs = [
     "http://127.0.0.1:7003"
 ]
 
+#--------------------------------------------------
+#Replication -- to maintain state availability
+#-------------------------------------------------
+[Replication]
+NumProvableReplicas=2
+Duration=120 #seconds
+
 # --------------------------------------------------
 # Contract -- Contract configuration
 # --------------------------------------------------

--- a/client/pdo/client/controller/commands/create.py
+++ b/client/pdo/client/controller/commands/create.py
@@ -92,7 +92,7 @@ def __create_contract(ledger_config, client_keys, preferred_eservice_client, ese
 
     # submit the commit task: (a commit task replicates change-set and submits the corresponding transaction)
     try:
-        initialize_response.commit_asynchronously(ledger_config, wait=30, use_ledger=True)
+        initialize_response.commit_asynchronously(ledger_config, wait_parameter_for_ledger=30, use_ledger=True)
     except Exception as e:
         raise Exception('failed to submit commit: %s', str(e))
 

--- a/client/pdo/client/controller/commands/send.py
+++ b/client/pdo/client/controller/commands/send.py
@@ -101,7 +101,7 @@ def send_to_contract(state, save_file, message, eservice_url=None, quiet=False, 
 
         # asynchronously submit the commit task: (a commit task replicates change-set and submits the corresponding transaction)
         try:
-            update_response.commit_asynchronously(ledger_config, wait=30, use_ledger=True)
+            update_response.commit_asynchronously(ledger_config, wait_parameter_for_ledger=30, use_ledger=True)
         except Exception as e:
             raise Exception('failed to submit commit: %s', str(e))
 

--- a/client/pdo/client/controller/contract_controller.py
+++ b/client/pdo/client/controller/contract_controller.py
@@ -32,6 +32,7 @@ __all__ = ['ContractController']
 
 from pdo.client.controller.commands import *
 from pdo.common.utility import find_file_in_path
+from pdo.contract.response import ContractResponse
 
 # XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 # XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -598,6 +599,7 @@ class ContractController(cmd.Cmd) :
         """
         if self.deferred > 0 : return False
 
+        ContractResponse.exit_commit_workers()
         try :
             pargs = self.__arg_parse__(args)
             parser = argparse.ArgumentParser(prog='exit')
@@ -614,12 +616,11 @@ class ContractController(cmd.Cmd) :
             self.exit_code = 1
             return True
 
-        return True
-
     # -----------------------------------------------------------------
     def do_EOF(self, args) :
         """
         exit -- shutdown the simulator and exit the command loop
         """
+        ContractResponse.exit_commit_workers()
         self.exit_code = 0
         return True

--- a/client/pdo/client/controller/contract_controller.py
+++ b/client/pdo/client/controller/contract_controller.py
@@ -32,7 +32,6 @@ __all__ = ['ContractController']
 
 from pdo.client.controller.commands import *
 from pdo.common.utility import find_file_in_path
-from pdo.contract.response import ContractResponse
 
 # XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 # XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -599,7 +598,6 @@ class ContractController(cmd.Cmd) :
         """
         if self.deferred > 0 : return False
 
-        ContractResponse.exit_commit_workers()
         try :
             pargs = self.__arg_parse__(args)
             parser = argparse.ArgumentParser(prog='exit')
@@ -616,11 +614,12 @@ class ContractController(cmd.Cmd) :
             self.exit_code = 1
             return True
 
+        return True
+
     # -----------------------------------------------------------------
     def do_EOF(self, args) :
         """
         exit -- shutdown the simulator and exit the command loop
         """
-        ContractResponse.exit_commit_workers()
         self.exit_code = 0
         return True

--- a/client/pdo/client/scripts/AuctionTestCLI.py
+++ b/client/pdo/client/scripts/AuctionTestCLI.py
@@ -76,7 +76,7 @@ def SendMessageAsIdentity(config, contract, invoker_keys, message, fmt = 'python
         enclave_id = random.choice(contract.provisioned_enclaves)
         enclave_service = enclave_services[enclave_id]
 
-        request = contract.create_update_request(invoker_keys, enclave_service, message)
+        request = contract.create_update_request(invoker_keys, message, enclave_service)
         response = request.evaluate()
         logger.info('result: %s, ', response.result)
     except Exception as e :

--- a/client/pdo/client/scripts/CreateCLI.py
+++ b/client/pdo/client/scripts/CreateCLI.py
@@ -33,6 +33,7 @@ from pdo.contract import add_enclave_to_contract
 from pdo.service_client.enclave import EnclaveServiceClient
 from pdo.service_client.provisioning import ProvisioningServiceClient
 import pdo.service_client.service_data.eservice as db
+from pdo.contract.response import ContractResponse
 
 logger = logging.getLogger(__name__)
 
@@ -87,10 +88,30 @@ def CreateContract(ledger_config, client_keys, enclaveclients, contract) :
 
     logger.info('Contract state created successfully')
 
-    logger.info('Saving the initial contract state in the ledger...')
+    logger.info('Commiting the initial state')
 
-    cclinit_result = initialize_response.submit_initialize_transaction(ledger_config)
+    # submit the commit task: (a commit task replicates change-set and submits the corresponding transaction)
+    try:
+        initialize_response.commit_asynchronously(ledger_config, wait=30, use_ledger=True)
+    except Exception as e:
+        logger.error('failed to submit commit: %s', str(e))
+        ContractResponse.exit_commit_workers()
+        sys.exit(-1)
 
+    # wait for the commit to finish
+    try:
+        txn_id = initialize_response.wait_for_commit()
+        if txn_id is None:
+            logger.error("Did not receive txn id for the initial commit")
+            ContractResponse.exit_commit_workers()
+            sys.exit(-1)
+    except Exception as e:
+        logger.error("Error while waiting for initial commit: %s", str(e))
+        ContractResponse.exit_commit_workers()
+        sys.exit(-1)
+
+    # exit the commit workers
+    ContractResponse.exit_commit_workers()
 ## -----------------------------------------------------------------
 ## -----------------------------------------------------------------
 def LocalMain(commands, config) :

--- a/client/pdo/client/scripts/CreateCLI.py
+++ b/client/pdo/client/scripts/CreateCLI.py
@@ -92,7 +92,7 @@ def CreateContract(ledger_config, client_keys, enclaveclients, contract) :
 
     # submit the commit task: (a commit task replicates change-set and submits the corresponding transaction)
     try:
-        initialize_response.commit_asynchronously(ledger_config, wait=30, use_ledger=True)
+        initialize_response.commit_asynchronously(ledger_config, wait_parameter_for_ledger=30, use_ledger=True)
     except Exception as e:
         logger.error('failed to submit commit: %s', str(e))
         ContractResponse.exit_commit_workers()

--- a/client/pdo/client/scripts/ShellCLI.py
+++ b/client/pdo/client/scripts/ShellCLI.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 from pdo.client.controller.contract_controller import ContractController
 import pdo.common.utility as putils
+from pdo.contract.response import ContractResponse
 
 ## -----------------------------------------------------------------
 ## -----------------------------------------------------------------
@@ -33,12 +34,15 @@ def LocalMain(config) :
     script_file = config.get("ScriptFile")
     if script_file :
         if not ContractController.ProcessScript(shell, script_file) :
+            ContractResponse.exit_commit_workers()
             sys.exit(shell.exit_code)
 
     shell.cmdloop()
     print("")
 
+    ContractResponse.exit_commit_workers()
     sys.exit(shell.exit_code)
+
 
 ## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/client/pdo/client/scripts/ShellCLI.py
+++ b/client/pdo/client/scripts/ShellCLI.py
@@ -33,6 +33,7 @@ def LocalMain(config) :
     # shell will start unless there is an explicit exit in the script
     script_file = config.get("ScriptFile")
     if script_file :
+        logger.info("Processing script file %s", str(script_file))
         if not ContractController.ProcessScript(shell, script_file) :
             ContractResponse.exit_commit_workers()
             sys.exit(shell.exit_code)
@@ -42,7 +43,6 @@ def LocalMain(config) :
 
     ContractResponse.exit_commit_workers()
     sys.exit(shell.exit_code)
-
 
 ## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/client/pdo/client/scripts/UpdateCLI.py
+++ b/client/pdo/client/scripts/UpdateCLI.py
@@ -26,6 +26,7 @@ from pdo.contract import Contract
 from pdo.common.keys import ServiceKeys
 from pdo.service_client.enclave import EnclaveServiceClient
 import pdo.service_client.service_data.eservice as db
+from pdo.contract.response import ContractResponse
 
 ## -----------------------------------------------------------------
 ## -----------------------------------------------------------------
@@ -70,6 +71,15 @@ def LocalMain(config, message) :
         logger.error('missing configuration section %s', str(ke))
         sys.exit(-1)
 
+    # ---------- load the eservice database ----------
+    if os.path.exists(service_config['EnclaveServiceDatabaseFile']):
+        logger.info('loading eservice database')
+        try:
+            db.load_database(service_config['EnclaveServiceDatabaseFile'])
+        except Exception as e:
+            logger.error('Error loading eservice database %s', str(e))
+            sys.exit(-1)
+
     # ---------- load the contract information file ----------
     try:
         save_file = contract_config['SaveFile']
@@ -101,20 +111,13 @@ def LocalMain(config, message) :
         logger.info('Using eservice database to look up service URL for the contract enclave')
         try:
             eservice_to_use = random.choice(service_config['EnclaveServiceNames'])
-            # load the eservice database
-            if os.path.exists(service_config['EnclaveServiceDatabaseFile']):
-                try:
-                    db.load_database(service_config['EnclaveServiceDatabaseFile'])
-                except Exception as e:
-                    logger.error('Error loading eservice database %s', str(e))
-                    sys.exit(-1)
             enclave_client = db.get_client_by_name(eservice_to_use)
         except Exception as e:
-            logger.error('Unable to get the eservice client using the eservice database: %s', str(e)) 
-            sys.exit(-1)   
+            logger.error('Unable to get the eservice client using the eservice database: %s', str(e))
+            sys.exit(-1)
     else:
         try:
-            enclave_url = service_config['PreferredEnclaveService'] 
+            enclave_url = service_config['PreferredEnclaveService']
         except Exception as e:
             logger.error('missing configuration parameter %s', str(ke))
             sys.exit(-1)
@@ -123,7 +126,7 @@ def LocalMain(config, message) :
         except Exception as e :
             logger.error('unable to connect to enclave service; %s', str(e))
             sys.exit(-1)
-        
+
     logger.info('contact enclave service at %s', enclave_client.ServiceURL)
 
     try :
@@ -140,6 +143,7 @@ def LocalMain(config, message) :
     else :
         mlist = InputIterator(config.get('Identity', '') + "> ")
 
+    last_response_committed = None
     for msg in mlist :
         if not msg :
             continue
@@ -147,7 +151,7 @@ def LocalMain(config, message) :
         logger.info('send message <%s> to contract', msg)
 
         try :
-            update_request = contract.create_update_request(contract_invoker_keys, enclave_client, msg)
+            update_request = contract.create_update_request(contract_invoker_keys, msg, enclave_client)
             update_response = update_request.evaluate()
             if update_response.status :
                 print(update_response.result)
@@ -168,16 +172,33 @@ def LocalMain(config, message) :
         if not update_response.state_changed :
             continue
 
-        try :
-            logger.debug("sending to ledger")
-            txnid = update_response.submit_update_transaction(ledger_config)
-        except Exception as e :
-            logger.error('failed to save the new state; %s', str(e))
+        contract.set_state(update_response.raw_state)
+
+        # asynchronously submit the commit task: (a commit task replicates change-set and submits the corresponding transaction)
+        try:
+            update_response.commit_asynchronously(ledger_config, wait=30, use_ledger=True)
+            last_response_committed = update_response
+        except Exception as e:
+            logger.error('failed to submit commit: %s', str(e))
+            ContractResponse.exit_commit_workers()
             sys.exit(-1)
 
-        contract.set_state(update_response.raw_state)
         contract.contract_state.save_to_cache(data_dir = data_directory)
 
+    if last_response_committed is not None:
+        # wait for the last commit to finish
+        try:
+            txn_id = last_response_committed.wait_for_commit()
+            if txn_id is None:
+                logger.error("Did not receive txn id for the final commit")
+                ContractResponse.exit_commit_workers()
+                sys.exit(-1)
+        except Exception as e:
+            logger.error("Error while waiting for final commit: %s", str(e))
+            ContractResponse.exit_commit_workers()
+            sys.exit(-1)
+
+    ContractResponse.exit_commit_workers()
     sys.exit(0)
 
 
@@ -292,18 +313,18 @@ def Main() :
             'ProvisioningServiceURLs' : [],
             'EnclaveServiceDatabaseFile' : None
         }
-    
+
     if options.eservice_name:
         config['Service']['EnclaveServiceNames'] = options.eservice_name
     if options.eservice_db:
-        config['Service']['EnclaveServiceDatabaseFile'] = options.eservice_db    
+        config['Service']['EnclaveServiceDatabaseFile'] = options.eservice_db
     if options.enclave :
         if options.enclave == 'random' :
             options.enclave = random.choice(config['Service'].get('EnclaveServiceURLs',['http://localhost:7001']))
         config['Service']['PreferredEnclaveService'] = options.enclave
         # we will not use database
         config['Service']['EnclaveServiceNames'] = []
-    
+
     # set up the key search paths
     if config.get('Key') is None :
         config['Key'] = {

--- a/client/pdo/client/scripts/UpdateCLI.py
+++ b/client/pdo/client/scripts/UpdateCLI.py
@@ -176,7 +176,7 @@ def LocalMain(config, message) :
 
         # asynchronously submit the commit task: (a commit task replicates change-set and submits the corresponding transaction)
         try:
-            update_response.commit_asynchronously(ledger_config, wait=30, use_ledger=True)
+            update_response.commit_asynchronously(ledger_config, wait_parameter_for_ledger=30, use_ledger=True)
             last_response_committed = update_response
         except Exception as e:
             logger.error('failed to submit commit: %s', str(e))

--- a/python/pdo/contract/__init__.py
+++ b/python/pdo/contract/__init__.py
@@ -20,7 +20,15 @@ __all__ = [
     "ContractResponse",
     "ContractRequest",
     "register_contract",
-    "add_enclave_to_contract"
+    "add_enclave_to_contract",
+    "ReplicationRequest",
+    "start_replication_service",
+    "stop_replication_service",
+    "add_replication_task",
+    "TransactionRequest",
+    "start_transaction_processing_service",
+    "stop_transacion_processing_service",
+    "add_transaction_task"
 ]
 
 from pdo.contract.code import ContractCode
@@ -29,3 +37,5 @@ from pdo.contract.message import ContractMessage
 from pdo.contract.request import ContractRequest
 from pdo.contract.response import ContractResponse
 from pdo.contract.state import ContractState
+from pdo.contract.replication import ReplicationRequest, start_replication_service, stop_replication_service, add_replication_task
+from pdo.contract.transaction import TransactionRequest, start_transaction_processing_service, stop_transacion_processing_service, add_transaction_task

--- a/python/pdo/contract/contract.py
+++ b/python/pdo/contract/contract.py
@@ -116,17 +116,14 @@ class Contract(object) :
         assert self.contract_id
         return hex(abs(hash(self.contract_id)))[2:]
 
-
     # -------------------------------------------------------
     def set_replication_parameters(self, num_provable_replicas=1, availability_duration=120):
 
-        replication_params = dict()
-        replication_params['max_num_replicas'] = len(self.enclave_map.keys())
-        replication_params['num_provable_replicas'] = num_provable_replicas
-        replication_params['availability_duration'] = availability_duration #seconds
-        replication_params['service_ids'] = self.enclave_map.keys() #we replicate to storage services associated with all provisioned encalves
-
-        self.replication_params = replication_params
+        self.replication_params = dict()
+        self.replication_params['max_num_replicas'] = len(self.enclave_map.keys())
+        self.replication_params['num_provable_replicas'] = num_provable_replicas
+        self.replication_params['availability_duration'] = availability_duration #seconds
+        self.replication_params['service_ids'] = self.enclave_map.keys() #we replicate to storage services associated with all provisioned encalves
 
     # -------------------------------------------------------
     @property

--- a/python/pdo/contract/contract.py
+++ b/python/pdo/contract/contract.py
@@ -86,6 +86,8 @@ class Contract(object) :
                 enclave['contract_enclave_id'],
                 enclave['encrypted_contract_state_encryption_key'])
 
+        obj.set_replication_parameters(contract_info['num_provable_replicas'], contract_info['availability_duration'])
+
         return obj
 
     # -------------------------------------------------------
@@ -97,8 +99,8 @@ class Contract(object) :
         self.contract_id = contract_id
         self.creator_id = creator_id
         self.extra_data = kwargs.get('extra_data', {})
-
         self.enclave_map = kwargs.get('enclave_map',{})
+        self.set_replication_parameters()
 
     # -------------------------------------------------------
     def set_state_encryption_key(self, enclave_id, encrypted_state_encryption_key) :
@@ -106,13 +108,25 @@ class Contract(object) :
 
     # -------------------------------------------------------
     def get_state_encryption_key(self, enclave_id) :
-        return self.enclave_map[enclave_id];
+        return self.enclave_map[enclave_id]
 
     # -------------------------------------------------------
     @property
     def short_id(self) :
         assert self.contract_id
         return hex(abs(hash(self.contract_id)))[2:]
+
+
+    # -------------------------------------------------------
+    def set_replication_parameters(self, num_provable_replicas=1, availability_duration=120):
+
+        replication_params = dict()
+        replication_params['max_num_replicas'] = len(self.enclave_map.keys())
+        replication_params['num_provable_replicas'] = num_provable_replicas
+        replication_params['availability_duration'] = availability_duration #seconds
+        replication_params['service_ids'] = self.enclave_map.keys() #we replicate to storage services associated with all provisioned encalves
+
+        self.replication_params = replication_params
 
     # -------------------------------------------------------
     @property
@@ -125,7 +139,7 @@ class Contract(object) :
         self.contract_state.update_state(state)
 
     # -------------------------------------------------------
-    def create_initialize_request(self, request_originator_keys, enclave_service) :
+    def create_initialize_request(self, request_originator_keys, enclave_service='random') :
         """create a request to initialize the state of the contract
 
         :param request_originator_keys: object of type ServiceKeys
@@ -134,11 +148,11 @@ class Contract(object) :
         return ContractRequest(
             'initialize',
             request_originator_keys,
-            enclave_service,
-            self)
+            self,
+            enclave_service=enclave_service)
 
     # -------------------------------------------------------
-    def create_update_request(self, request_originator_keys, enclave_service, expression) :
+    def create_update_request(self, request_originator_keys, expression, enclave_service='random') :
         """create a request to update the state of the contract
 
         :param request_originator_keys: object of type ServiceKeys
@@ -148,8 +162,8 @@ class Contract(object) :
         return ContractRequest(
             'update',
             request_originator_keys,
-            enclave_service,
             self,
+            enclave_service=enclave_service,
             expression = expression)
 
     # -------------------------------------------------------
@@ -170,6 +184,10 @@ class Contract(object) :
             enclaves_info.append(enclave_info)
 
         serialized['enclaves_info'] = enclaves_info
+
+        # add replication params
+        serialized['num_provable_replicas'] = self.replication_params['num_provable_replicas']
+        serialized['availability_duration'] = self.replication_params['availability_duration']
 
         filename = putils.build_file_name(basename, data_dir, self.__path__, self.__extension__)
 

--- a/python/pdo/contract/replication.py
+++ b/python/pdo/contract/replication.py
@@ -1,0 +1,277 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import concurrent.futures
+import queue
+import threading
+
+from pdo.contract.state import ContractState
+import pdo.service_client.service_data.eservice as service_db
+
+import logging
+logger = logging.getLogger(__name__)
+
+# -----------------------------------------------------------------
+__replication_manager_executor__ = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+__pending_replication_tasks_manager_queue__ = queue.Queue()
+
+__replication_workers_executor__ = dict() #key is service id, value is a ThreadPoolExecutor object that manages the worker threads for this storage service
+num_threads_per_storage_service = 2 # we many want to parametrize this later
+__pending_replication_tasks_workers_queues__ = dict() #key is service id, value is a queue of pending replication tasks for this storage service
+
+__condition_variable_for_completed_tasks__ = threading.Condition() # used to notify the parent thread about a new task that got completed (if the parent is waiting)
+
+__services_to_ignore__ = set()
+
+__stop_service__ = False
+
+# -----------------------------------------------------------------
+def start_replication_service():
+
+    # start the manager
+    __replication_manager_executor__.submit(__replication_manager__)
+
+# -----------------------------------------------------------------
+def stop_replication_service():
+
+    global __stop_service__
+    __stop_service__ = True
+
+    #shutdown replication executor
+    __replication_manager_executor__.shutdown(wait=True)
+
+# -----------------------------------------------------------------
+def add_replication_task(task):
+
+    __pending_replication_tasks_manager_queue__.put(task)
+
+# -----------------------------------------------------------------
+def __set_up_worker__(service_id):
+
+    __replication_workers_executor__[service_id] = concurrent.futures.ThreadPoolExecutor(max_workers=num_threads_per_storage_service)
+    __pending_replication_tasks_workers_queues__[service_id] = queue.Queue()
+    condition_variable_for_setup = threading.Condition()
+    for i in range(num_threads_per_storage_service):
+        __replication_workers_executor__[service_id].submit(__replication_worker__, service_id, __pending_replication_tasks_workers_queues__[service_id], \
+            condition_variable_for_setup)
+        #wait for the thread to initialize
+        condition_variable_for_setup.acquire()
+        condition_variable_for_setup.wait()
+        condition_variable_for_setup.release()
+
+# -----------------------------------------------------------------
+def __shutdown_workers__():
+    """Shutdown all worker threads"""
+
+    #shutdown the worker executors
+    for service_id in __replication_workers_executor__.keys():
+        __replication_workers_executor__[service_id].shutdown(wait=True)
+
+# -----------------------------------------------------------------
+def __replication_manager__():
+    """ Manager thread for a replication task"""
+
+    try:
+        while True:
+
+            # wait for a new task, task is the response object
+            try:
+                response = __pending_replication_tasks_manager_queue__.get(timeout=1.0)
+            except:
+                # check for termination signal
+                if __stop_service__:
+                    __shutdown_workers__()
+                    logger.info("Exiting Replication manager thread")
+                    break
+                else:
+                    continue
+
+            replication_request = response.replication_request
+            request_id = response.commit_id[2]
+
+            # identify if replication can be skipped, including the case where there is only one provisioned enclave
+            if len(replication_request.service_ids) == 1:
+                logger.info('Skipping replication for request id %d : Only one provisioned enclave, so nothing to replicate', request_id)
+                replication_request.mark_as_completed(response.call_back_after_replication)
+                continue
+
+            if len(replication_request.blocks_to_replicate) == 0:
+                logger.info('Skipping replication for request id %d: No change set, so nothing to replicate', request_id)
+                replication_request.mark_as_completed(response.call_back_after_replication)
+                continue
+
+            #ensure that the worker threads and queues are in place for services associated with this replication request
+            for service_id in replication_request.service_ids:
+                if __replication_workers_executor__.get(service_id) is None:
+                    __set_up_worker__(service_id)
+
+            # get the set of services to use with this task
+            ids_of_services_to_use = replication_request.service_ids - __services_to_ignore__
+
+            #check that there are enough services for replication, else add to the set of failed tasks and go to the next task
+            if len(ids_of_services_to_use) < replication_request.num_provable_replicas:
+                logger.error("Replication failed for request number %d. Not enough reliable storage services.", request_id)
+                replication_request.mark_as_failed()
+                continue
+
+            # add the task to the workers queues
+            for service_id in ids_of_services_to_use:
+                __pending_replication_tasks_workers_queues__[service_id].put(response)
+
+    except Exception as e:
+        logger.info("Replication Manager exception %s", str(e))
+
+# -----------------------------------------------------------------
+def __replication_worker__(service_id, pending_taks_queue, condition_variable_for_setup):
+    """ Worker thread that replicates to a specific storage service"""
+    # set up the service client
+    try:
+        service_client = service_db.get_client_by_id(service_id)
+        init_sucess = True
+    except:
+        logger.info("Failed to set up service client for service id %s", str(service_id))
+        # mark the service as unusable
+        __services_to_ignore__.add(service_id)
+        #exit the thread
+        init_sucess = False
+
+    # notify the manager that init was attempted
+    condition_variable_for_setup.acquire()
+    condition_variable_for_setup.notify()
+    condition_variable_for_setup.release()
+
+    # exit the thread if init failed
+    if not init_sucess:
+        return
+
+    try:
+        while True:
+
+            # wait for a new task, task is the response object
+            try:
+                response = pending_taks_queue.get(timeout=1.0)
+            except:
+                # check for termination signal
+                if __stop_service__:
+                    logger.info("Exiting Replication worker thread for service at %s", str(service_client.ServiceURL))
+                    break
+                else:
+                    continue
+
+            #check if the task is already complete. If so go to the next one
+            replication_request = response.replication_request
+            if replication_request.is_completed:
+                continue
+
+            # replicate now!
+            block_data_list = ContractState.block_data_generator(replication_request.contract_id, \
+                replication_request.blocks_to_replicate, replication_request.data_dir)
+            expiration = replication_request.availability_duration
+            request_id = response.commit_id[2]
+            try:
+                fail_task = False
+                response_from_replication = service_client.store_blocks(block_data_list, expiration)
+                if response_from_replication is None :
+                    fail_task =  True
+                    logger.info("No response from storage service %s for replication request %d", str(service_client.ServiceURL), request_id)
+            except Exception as e:
+                fail_task =  True
+                logger.info("Replication request %d got an exception from %s: %s", request_id, str(service_client.ServiceURL), str(e))
+
+            # update the set of services where replication is completed
+            replication_request.update_set_of_services_where_replicated(service_id, fail_task)
+
+            # check if the overall task can be marked as successful or failed:
+            if len(replication_request.successful_services) >= replication_request.num_provable_replicas:
+                replication_request.mark_as_completed(response.call_back_after_replication)
+            elif len(replication_request.unsuccessful_services) > len(replication_request.service_ids) - replication_request.num_provable_replicas:
+                replication_request.mark_as_failed()
+
+            # Finally, if the task failed, mark the service as unreliable
+            # (this may be a bit harsh, we will refine this later based on the nature of the failure)
+            if fail_task:
+                __services_to_ignore__.add(service_id)
+                logger.info("Ignoring service at %s for rest of replication attempts", str(service_client.ServiceURL))
+                #exit the thread
+                break
+
+    except Exception as e:
+        logger.info("Replication Worker exception %s", str(e))
+
+# -----------------------------------------------------------------
+class ReplicationRequest(object):
+    """ implements the replicator class functionality : used for change-set replication after
+    contract update, before commiting transaction."""
+
+    # -----------------------------------------------------------------
+    def __init__(self, replication_params, \
+                contract_id, blocks_to_replicate, commit_id, data_dir=None):
+        """ Create an instance of the ReplicationRequest class: used for replicating the current change set.
+        eservice_ids can be replaced with sservice_ids after we create an sservice database that can be used to look up the sservice url using the id."""
+
+        self.service_ids = replication_params['service_ids']
+        self.num_provable_replicas = replication_params['num_provable_replicas']
+        self.availability_duration = replication_params['availability_duration']
+        self.contract_id = contract_id
+        self.blocks_to_replicate = blocks_to_replicate
+        self.commit_id = commit_id
+        self.data_dir = data_dir
+
+        self.is_completed = False
+        self.is_failed = False
+        self.successful_services = set()
+        self.unsuccessful_services = set()
+
+    # -----------------------------------------------------------------
+    def mark_as_completed(self, call_back_after_replication=None):
+        """ Mark as completed. Notify waiting threads. If successful, invoke the call back method. Multiple notifications and call backs are prevented"""
+
+        if not self.is_completed: # check reduces contention for lock
+            __condition_variable_for_completed_tasks__.acquire()
+            if not self.is_completed: # yes we check this again, the outside check is only for performance optimization, this check is algorithmic
+                self.is_completed = True
+                logger.info("Replication for request number %d successfully completed", self.commit_id[2])
+                __condition_variable_for_completed_tasks__.notify()
+                if not self.is_failed:
+                    call_back_after_replication()
+            __condition_variable_for_completed_tasks__.release()
+
+    # -----------------------------------------------------------------
+    def mark_as_failed(self):
+        self.is_failed = True
+        self.mark_as_completed()
+
+    # -----------------------------------------------------------------
+    def wait_for_completion(self):
+        """ Returns after successful completion of the replication request. Raises exception if the request failed"""
+
+        release_lock = False
+        while self.is_completed is False:
+            __condition_variable_for_completed_tasks__.acquire()
+            __condition_variable_for_completed_tasks__.wait(timeout=1.0)
+            release_lock = True
+
+        if release_lock:
+            __condition_variable_for_completed_tasks__.release()
+
+        if self.is_failed:
+            raise Exception("Replication task failed for request number %s", str(self.commit_id[2]))
+
+    # -----------------------------------------------------------------
+    def update_set_of_services_where_replicated(self, service_id, fail_task):
+
+        if fail_task:
+            self.unsuccessful_services.add(service_id)
+        else:
+            self.successful_services.add(service_id)

--- a/python/pdo/contract/replication.py
+++ b/python/pdo/contract/replication.py
@@ -256,14 +256,11 @@ class ReplicationRequest(object):
     def wait_for_completion(self):
         """ Returns after successful completion of the replication request. Raises exception if the request failed."""
 
-        release_lock = False
+        __condition_variable_for_completed_tasks__.acquire()
         while self.is_completed is False:
-            __condition_variable_for_completed_tasks__.acquire()
             __condition_variable_for_completed_tasks__.wait()
-            release_lock = True
 
-        if release_lock:
-            __condition_variable_for_completed_tasks__.release()
+        __condition_variable_for_completed_tasks__.release()
 
         if self.is_failed:
             raise Exception("Replication task failed for request number %s", str(self.commit_id[2]))

--- a/python/pdo/contract/request.py
+++ b/python/pdo/contract/request.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import os
 import json
+import random
 
 import pdo.common.crypto as crypto
 import pdo.common.keys as keys
@@ -21,6 +22,8 @@ from pdo.contract.response import ContractResponse
 from pdo.contract.message import ContractMessage
 from pdo.contract.state import ContractState
 from pdo.submitter.submitter import Submitter
+
+import pdo.service_client.service_data.eservice as eservice_db
 
 import logging
 logger = logging.getLogger(__name__)
@@ -38,24 +41,35 @@ class InvocationException(Exception) :
 class ContractRequest(object) :
     __ops__ = { 'initialize' : True, 'update' : True }
 
+    __request_number__ = 0 # a monotonic counter used locally by the client to identify all its requests.
+                         # Every (contract_id, statehash) pair maps to a unique request_number. The converse is not true (if the request failed)
+
     # -------------------------------------------------------
-    def __init__(self, operation, request_originator_keys, enclave_service, contract, **kwargs) :
+    def __init__(self, operation, request_originator_keys, contract, **kwargs) :
         if not self.__ops__[operation] :
             raise ValueError('invalid operation')
 
         self.operation = operation
-
         self.contract_id = contract.contract_id
         self.creator_id = contract.creator_id
-        self.encrypted_state_encryption_key = contract.get_state_encryption_key(enclave_service.enclave_id)
-        self.enclave_service = enclave_service
+        self.enclave_service = kwargs.get('enclave_service')
+        if self.enclave_service == 'random':
+            enclave_id = random.choice(list(contract.enclave_map.keys()))
+            try: #use the eservice database to get the client
+                self.enclave_service = eservice_db.get_client_by_id(enclave_id)
+            except Exception as e:
+                raise Exception('unable to assign eservice for the conrtract: Failed to get enclave client using database: %s', str(e))
+
+        self.encrypted_state_encryption_key = contract.get_state_encryption_key(self.enclave_service.enclave_id)
         self.originator_keys = request_originator_keys
         self.channel_keys = keys.TransactionKeys()
         self.session_key = crypto.SKENC_GenerateKey()
-
         self.contract_code = contract.contract_code
         self.contract_state = contract.contract_state
         self.message = ContractMessage(self.originator_keys, self.channel_keys, **kwargs)
+        self.replication_params = contract.replication_params
+        self.request_number = ContractRequest.__request_number__
+        ContractRequest.__request_number__+=1
 
     # -------------------------------------------------------
     @property

--- a/python/pdo/contract/response.py
+++ b/python/pdo/contract/response.py
@@ -111,7 +111,7 @@ class ContractResponse(object) :
             return None
 
     # -------------------------------------------------------
-    def commit_asynchronously(self, ledger_config, wait, external_dependencies_txn_ids=[],
+    def commit_asynchronously(self, ledger_config, wait_parameter_for_ledger, external_dependencies_txn_ids=[],
             commit_dependencies=[], use_ledger=True, check_implicit_commit=True):
         """Commit includes two steps: First, replicate the change set to all provisioned encalves. Second,
         commit the transaction to the ledger. In this method, we add a job to the replication queue to enable the first step. The job will
@@ -128,7 +128,7 @@ class ContractResponse(object) :
         if self.enable_transaction_submission:
             if self.request_number==0 or self.operation == 'initialize' :
                 check_implicit_commit = False
-            self.transaction_request = TransactionRequest(ledger_config, self.commit_id, wait, \
+            self.transaction_request = TransactionRequest(ledger_config, self.commit_id, wait_parameter_for_ledger, \
                 external_dependencies_txn_ids, commit_dependencies, check_implicit_commit)
 
         add_replication_task(self)

--- a/python/pdo/contract/response.py
+++ b/python/pdo/contract/response.py
@@ -12,76 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-import json
+import sys
+import concurrent.futures
+import queue
+import time
+import threading
 
 import pdo.common.crypto as crypto
 import pdo.common.keys as keys
 
-from pdo.submitter.submitter import Submitter
 from pdo.contract.state import ContractState
-from sawtooth.helpers.pdo_connect import PdoRegistryHelper
+from pdo.contract.replication import ReplicationRequest, start_replication_service, stop_replication_service, add_replication_task
+from pdo.contract.transaction import TransactionRequest, start_transaction_processing_service, stop_transacion_processing_service, add_transaction_task
 
 import logging
 logger = logging.getLogger(__name__)
-
-# -----------------------------------------------------------------
-# -----------------------------------------------------------------
-class Dependencies(object) :
-
-    """
-    Class for mapping contract state commits to the corresponding
-    ledger transaction. This class facilitates efficient assignment
-    of dependencies in PDO transactions.
-    """
-
-    ## -------------------------------------------------------
-    def __init__(self) :
-        self.__depcache = {}
-
-    ## -------------------------------------------------------
-    def __key(self, contractid, statehash) :
-        return str(contractid) + '$' + str(statehash)
-
-    ## -------------------------------------------------------
-    def __set(self, contractid, statehash, txnid) :
-        self.__depcache[self.__key(contractid, statehash)] = txnid
-
-    ## -------------------------------------------------------
-    def __get(self, contractid, statehash) :
-        k = self.__key(contractid, statehash)
-        return self.__depcache.get(k)
-
-    ## -------------------------------------------------------
-    def FindDependency(self, ledger_config, contractid, statehash) :
-        logger.debug('find dependency for %s, %s', contractid, statehash)
-
-        txnid = self.__get(contractid, statehash)
-        if txnid :
-            return txnid
-
-        # no information about this update locally, so go to the
-        # ledger to retrieve it
-        client = PdoRegistryHelper(ledger_config['LedgerURL'])
-
-        try :
-            # this is not very efficient since it pulls all of the state
-            # down with the txnid
-            contract_state_info = client.get_ccl_state_dict(contractid, statehash)
-            txnid = contract_state_info['transaction_id']
-            self.__set(contractid, statehash, txnid)
-            return txnid
-        except Exception as e :
-            logger.info('failed to retrieve the transaction: %s', str(e))
-
-        logger.info('unable to find dependency for %s:%s', contractid, statehash)
-        return None
-
-    ## -------------------------------------------------------
-    def SaveDependency(self, contractid, statehash, txnid) :
-        self.__set(contractid, statehash, txnid)
-
-
-transaction_dependencies = Dependencies()
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
@@ -89,6 +34,16 @@ class ContractResponse(object) :
     """
     Class for managing the contract operation response from an enclave service
     """
+
+    __start_commit_service__ = True
+
+    # -------------------------------------------------------
+    @staticmethod
+    def exit_commit_workers():
+        """Set the global variable stop_commit_service to True. This will be picked by the workers"""
+
+        stop_replication_service()
+        stop_transacion_processing_service()
 
     # -------------------------------------------------------
     def __init__(self, request, response) :
@@ -102,6 +57,10 @@ class ContractResponse(object) :
         self.result = response['Result']
         self.state_changed = response['StateChanged']
         self.new_state_object = request.contract_state
+        #if the new state is same as the old state, then change set is empty
+        self.new_state_object.changed_block_ids=[]
+        self.request_number = request.request_number
+        self.operation = request.operation
 
         if self.status and self.state_changed :
             self.signature = response['Signature']
@@ -138,6 +97,71 @@ class ContractResponse(object) :
             self.new_state_object = ContractState(self.contract_id, self.raw_state)
             self.new_state_object.pull_state_from_eservice(self.enclave_service)
 
+            # compute ids of blocks in the change set (used for replication)
+            self.new_state_object.compute_ids_of_newblocks(request.contract_state.component_block_ids)
+            self.replication_request = ReplicationRequest(request.replication_params, \
+                self.contract_id, self.new_state_object.changed_block_ids, self.commit_id)
+
+    # -------------------------------------------------------
+    @property
+    def commit_id(self):
+        if self.status and self.state_changed:
+            return (self.contract_id, self.new_state_hash, self.request_number)
+        else:
+            return None
+
+    # -------------------------------------------------------
+    def commit_asynchronously(self, ledger_config, wait, external_dependencies_txn_ids=[],
+            commit_dependencies=[], use_ledger=True, check_implicit_commit=True):
+        """Commit includes two steps: First, replicate the change set to all provisioned encalves. Second,
+        commit the transaction to the ledger. In this method, we add a job to the replication queue to enable the first step. The job will
+        be picked by a replication worker thead. A call_back_after_replication function (see below) is automatically invoked to add a task for the second step """
+
+        #start threads for commiting response if not done before
+        if ContractResponse.__start_commit_service__:
+            # start replication service
+            start_replication_service()
+            start_transaction_processing_service()
+            ContractResponse.__start_commit_service__ = False
+
+        self.enable_transaction_submission = use_ledger
+        if self.enable_transaction_submission:
+            if self.request_number==0 or self.operation == 'initialize' :
+                check_implicit_commit = False
+            self.transaction_request = TransactionRequest(ledger_config, self.commit_id, wait, \
+                external_dependencies_txn_ids, commit_dependencies, check_implicit_commit)
+
+        add_replication_task(self)
+
+    # -------------------------------------------------------
+    def call_back_after_replication(self):
+        """this is the call back function after replication. Currently, the call-back's role is to add a new task to the pending transactions queue,
+        which will be processed by a "submit transaction" thread whose job is to submit transactions corresponding to completed replication tasks
+        """
+        if self.enable_transaction_submission:
+            add_transaction_task(self)
+
+    # -------------------------------------------------------
+    def wait_for_commit(self):
+        """ Wait for completion of the commit task corresponding to the response. Return transaction id if ledger is used, else return None"""
+
+        # wait for the completion of the replication task
+        try:
+            self.replication_request.wait_for_completion()
+        except Exception as e:
+            raise Exception(str(e))
+
+        # wait for the completion of the transaction processing if ledger is in use
+        if self.enable_transaction_submission:
+            try:
+                txn_id = self.transaction_request.wait_for_completion()
+            except Exception as e:
+                raise Exception(str(e))
+        else:
+            txn_id = None
+
+        return txn_id
+
     # -------------------------------------------------------
     def __verify_enclave_signature(self, enclave_keys) :
         """verify the signature of the response
@@ -163,119 +187,3 @@ class ContractResponse(object) :
             message += crypto.string_to_byte_array(dependency['state_hash'])
 
         return message
-
-    # -------------------------------------------------------
-    def submit_initialize_transaction(self, ledger_config, **extra_params) :
-        """submit the initialize transaction to the ledger
-        """
-
-        if self.status is False :
-            raise Exception('attempt to submit failed initialization transactions')
-
-        global transaction_dependencies
-
-        # an initialize operation has no previous state
-        assert not self.old_state_hash
-
-        initialize_submitter = Submitter(
-            ledger_config['LedgerURL'],
-            key_str = self.channel_keys.txn_private)
-
-        b64_message_hash = crypto.byte_array_to_base64(self.message_hash)
-        b64_new_state_hash = crypto.byte_array_to_base64(self.new_state_hash)
-        b64_code_hash = crypto.byte_array_to_base64(self.code_hash)
-
-        raw_state = self.raw_state
-        try :
-            raw_state = raw_state.decode()
-        except AttributeError :
-            pass
-
-        txnid = initialize_submitter.submit_ccl_initialize_from_data(
-            self.originator_keys.signing_key,
-            self.originator_keys.verifying_key,
-            self.channel_keys.txn_public,
-            self.enclave_service.enclave_id,
-            self.signature,
-            self.contract_id,
-            b64_message_hash,
-            b64_new_state_hash,
-            raw_state,
-            b64_code_hash,
-            **extra_params)
-
-        if txnid :
-            transaction_dependencies.SaveDependency(self.contract_id, b64_new_state_hash, txnid)
-
-        return txnid
-
-    # -------------------------------------------------------
-    def submit_update_transaction(self, ledger_config, **extra_params):
-        """submit the update transaction to the ledger
-        """
-
-        if self.status is False :
-            raise Exception('attempt to submit failed update transaction')
-
-        global transaction_dependencies
-
-        # there must be a previous state hash if this is
-        # an update
-        assert self.old_state_hash
-
-        update_submitter = Submitter(
-            ledger_config['LedgerURL'],
-            key_str = self.channel_keys.txn_private)
-
-        b64_message_hash = crypto.byte_array_to_base64(self.message_hash)
-        b64_new_state_hash = crypto.byte_array_to_base64(self.new_state_hash)
-        b64_old_state_hash = crypto.byte_array_to_base64(self.old_state_hash)
-
-        # convert contract dependencies into transaction dependencies
-        # to ensure that the sawtooth validator does not attempt to
-        # re-order the transactions since it is unaware of the semantics
-        # of the contract dependencies
-        txn_dependencies = set()
-        if extra_params.get('transaction_dependency_list') :
-            txn_dependencies.update(extra_params['transaction_dependency_list'])
-
-        txnid = transaction_dependencies.FindDependency(ledger_config, self.contract_id, b64_old_state_hash)
-        if txnid :
-            txn_dependencies.add(txnid)
-
-        for dependency in self.dependencies :
-            contract_id = dependency['contract_id']
-            state_hash = dependency['state_hash']
-            txnid = transaction_dependencies.FindDependency(ledger_config, contract_id, state_hash)
-            if txnid :
-                txn_dependencies.add(txnid)
-            else :
-                raise Exception('failed to find dependency; {0}:{1}'.format(contract_id, state_hash))
-
-        if txn_dependencies :
-            extra_params['transaction_dependency_list'] = list(txn_dependencies)
-
-        raw_state = self.raw_state
-        try :
-            raw_state = raw_state.decode()
-        except AttributeError :
-            pass
-
-        # now send off the transaction to the ledger
-        txnid = update_submitter.submit_ccl_update_from_data(
-            self.originator_keys.verifying_key,
-            self.channel_keys.txn_public,
-            self.enclave_service.enclave_id,
-            self.signature,
-            self.contract_id,
-            b64_message_hash,
-            b64_new_state_hash,
-            b64_old_state_hash,
-            raw_state,
-            self.dependencies,
-            **extra_params)
-
-        if txnid :
-            transaction_dependencies.SaveDependency(self.contract_id, b64_new_state_hash, txnid)
-
-        return txnid

--- a/python/pdo/contract/state.py
+++ b/python/pdo/contract/state.py
@@ -188,7 +188,6 @@ class ContractState(object) :
         block_count = len(blocks_to_pull)
         if block_count == 0 :
             logger.debug('no blocks to pull')
-            logger.info("Pulled 0 new blocks after contract update")
             return 0
 
         # it is not in the cache so grab it from the eservice

--- a/python/pdo/contract/transaction.py
+++ b/python/pdo/contract/transaction.py
@@ -386,14 +386,11 @@ class TransactionRequest(object):
     def wait_for_completion(self):
         """ wait until completion of transaction. If success, return txn_id, else raise Exception"""
 
-        release_lock = False
+        __condition_variable_for_completed_transactions__.acquire()
         while self.is_completed is False:
-            __condition_variable_for_completed_transactions__.acquire()
             __condition_variable_for_completed_transactions__.wait()
-            release_lock = True
 
-        if release_lock:
-            __condition_variable_for_completed_transactions__.release()
+        __condition_variable_for_completed_transactions__.release()
 
         if self.is_failed:
             raise Exception("Transaction submission failed for request number %d", self.commit_id[2])

--- a/python/pdo/contract/transaction.py
+++ b/python/pdo/contract/transaction.py
@@ -1,0 +1,404 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import concurrent.futures
+import queue
+import threading
+
+import pdo.common.crypto as crypto
+from sawtooth.helpers.pdo_connect import PdoRegistryHelper
+from pdo.submitter.submitter import Submitter
+
+import logging
+logger = logging.getLogger(__name__)
+
+# -----------------------------------------------------------------
+__transaction_executor__ = concurrent.futures.ThreadPoolExecutor(max_workers=1) # executor that submit transactions
+__pending_transactions_queue__ = queue.Queue()
+__condition_variable_for_completed_transactions__ = threading.Condition() # used to notify the parent thread about a new task
+                                                                          # that got completed (if the parent is waiting)
+__stop_service__ = False
+__set_of_failed_transactions__ = set()
+
+# -----------------------------------------------------------------
+class Dependencies(object) :
+    """
+    Class for mapping contract state commits to the corresponding
+    ledger transaction. This class facilitates efficient assignment
+    of dependencies in PDO transactions.
+    """
+
+    ## -------------------------------------------------------
+    def __init__(self) :
+        self.__depcache = {}
+
+    ## -------------------------------------------------------
+    def __key(self, contractid, statehash) :
+        return str(contractid) + '$' + str(statehash)
+
+    ## -------------------------------------------------------
+    def __set(self, contractid, statehash, txnid) :
+        self.__depcache[self.__key(contractid, statehash)] = txnid
+
+    ## -------------------------------------------------------
+    def __get(self, contractid, statehash) :
+        k = self.__key(contractid, statehash)
+        return self.__depcache.get(k)
+
+    ##--------------------------------------------------------
+    def FindDependencyLocally(self, contractid, statehash):
+        return self.__get(contractid, statehash)
+
+    ## -------------------------------------------------------
+    def FindDependency(self, ledger_config, contractid, statehash) :
+        logger.debug('find dependency for %s, %s', contractid, statehash)
+
+        txnid = self.__get(contractid, statehash)
+        if txnid :
+            return txnid
+
+        # no information about this update locally, so go to the
+        # ledger to retrieve it
+        client = PdoRegistryHelper(ledger_config['LedgerURL'])
+
+        try :
+            # this is not very efficient since it pulls all of the state
+            # down with the txnid
+            contract_state_info = client.get_ccl_state_dict(contractid, statehash)
+            txnid = contract_state_info['transaction_id']
+            self.__set(contractid, statehash, txnid)
+            return txnid
+        except Exception as e :
+            logger.info('failed to retrieve the transaction: %s', str(e))
+
+        logger.info('unable to find dependency for %s:%s', contractid, statehash)
+        return None
+
+    ## -------------------------------------------------------
+    def SaveDependency(self, contractid, statehash, txnid) :
+        self.__set(contractid, statehash, txnid)
+
+# -----------------------------------------------------------------
+__external_dependencies_txn_ids__ = Dependencies()
+
+# -----------------------------------------------------------------
+def start_transaction_processing_service():
+
+    __transaction_executor__.submit(__transaction_worker__)
+
+# -----------------------------------------------------------------
+def stop_transacion_processing_service():
+
+    global __stop_service__
+    __stop_service__ = True
+
+    #shutdown executor
+    __transaction_executor__.shutdown(wait=True)
+
+# -----------------------------------------------------------------
+def add_transaction_task(task):
+
+    __pending_transactions_queue__.put(task)
+
+# -----------------------------------------------------------------
+def __transaction_worker__():
+    """This is the worker for submitting transactions"""
+
+    def submit_doable_transactions_for_contract(contract_id):
+        """ helper function to submit pending transactions for a specific contact.
+        Transactions will be submitted for all pending commits whose commit dependecies are met"""
+
+        nonlocal rep_completed_but_txn_not_submitted_updates
+
+        submitted_any = False
+
+        pending_requests_numbers = list(rep_completed_but_txn_not_submitted_updates[contract_id].keys())
+        pending_requests_numbers.sort()
+        for request_number in pending_requests_numbers:
+
+            response = rep_completed_but_txn_not_submitted_updates[contract_id][request_number]
+            transaction_request = response.transaction_request
+            txn_dependencies = []
+
+            # Check for implicit dependency: (check to ensure that the transaction corresponding to the old_state_hash
+            # was submitted (if committed by the same client)). Don't have to add them to txn_dependencies, this will be added by submitter
+            if transaction_request.check_implicit_commit:
+
+                # first check that the implicit dependency did not fail, if so mark the current transaction as failed
+                if (contract_id, response.old_state_hash) in __set_of_failed_transactions__:
+                    logger.info("Aborting transaction for request %d since old state commit failed", request_number)
+                    __set_of_failed_transactions__.add((contract_id, response.new_state_hash))
+                    transaction_request.mark_as_failed()
+                    del rep_completed_but_txn_not_submitted_updates[contract_id][request_number] # remove the task from the pending list
+                    break
+
+                # Ok the implicit did not fail, but did it complete yet? if not, no more transactions can be submitted for this conract_id
+                txnid = __external_dependencies_txn_ids__.FindDependencyLocally(contract_id, crypto.byte_array_to_base64(response.old_state_hash))
+                if txnid is None:
+                    break
+
+            # check for explicit dependencies: (specfied by the client during the commit call)
+            fail_explit_commit_dependencies = False
+            for commit_id_temp in transaction_request.commit_dependencies:
+
+                # check if the transaction for commit_id_temp failed, if so mark the current transaction as failed
+                if (commit_id_temp[0], commit_id_temp[1]) in __set_of_failed_transactions__:
+                    logger.info("Aborting transaction for request %d since one or more dependencies have failed", request_number)
+                    __set_of_failed_transactions__.add((contract_id, response.new_state_hash))
+                    transaction_request.mark_as_failed()
+                    del rep_completed_but_txn_not_submitted_updates[contract_id][request_number] # remove the task from the pending list
+                    fail_explit_commit_dependencies = True
+                    break
+
+                # Ok the explicit did not fail, but did it complete yet? if not, no more transactions can be submitted for this conract_id
+                txnid = __external_dependencies_txn_ids__.FindDependencyLocally(commit_id_temp[0], crypto.byte_array_to_base64(commit_id_temp[1]))
+                if txnid :
+                    txn_dependencies.append(txnid)
+                else:
+                    fail_explit_commit_dependencies = True
+                    break
+
+            if fail_explit_commit_dependencies:
+                break
+
+            # OK, all commit dependencies are met. Add any transaction dependecies explicitly specified by client durind the commit call.
+            # (transactions can come from other clients). These will be checked by the submitter
+            for txn_id in transaction_request.external_dependencies_txn_ids:
+                txn_dependencies.append(txn_id)
+
+            # submit txn
+            try:
+                if response.operation != 'initialize' :
+                    txn_id =  __submit_update_transaction__(response, transaction_request.ledger_config, wait=transaction_request.wait, \
+                        transaction_dependency_list=txn_dependencies)
+                else:
+                    txn_id = __submit_initialize_transaction__(response, transaction_request.ledger_config, wait=transaction_request.wait)
+
+                del rep_completed_but_txn_not_submitted_updates[contract_id][request_number] # remove the task from the pending list
+
+                if txn_id:
+                    logger.info("Submitted transaction for request number %d", request_number)
+                    submitted_any = True
+                    # add the commit_id to completed list, notify any waiting thread
+                    transaction_request.mark_as_completed()
+                    __condition_variable_for_completed_transactions__.acquire()
+                    __condition_variable_for_completed_transactions__.notify()
+                    __condition_variable_for_completed_transactions__.release()
+                else:
+                    logger.error("Did not get a transaction id after transaction submission,  request nunmber %d", request_number)
+                    __set_of_failed_transactions__.add((contract_id, response.new_state_hash))
+                    transaction_request.mark_as_failed()
+                    break
+            except Exception as e:
+                logger.error("Transaction submission failed for request number %d: %s", request_number, str(e))
+                __set_of_failed_transactions__.add((contract_id, response.new_state_hash))
+                transaction_request.mark_as_failed()
+                break
+
+        return submitted_any
+
+    # -------------------------------------------------------
+    rep_completed_but_txn_not_submitted_updates = dict() # key is contract_id, value is dict(k:v). k = request_number from the commit _id
+    # and v is everything else needed to submit transaction
+
+    while True:
+
+        # wait for a new task. Task is the reponse object for the update
+        try:
+            response = __pending_transactions_queue__.get(timeout=1.0)
+        except:
+            # check for termination signal
+            if __stop_service__:
+                logger.info("Exiting transaction submission thread")
+                break
+            else:
+                continue
+
+        contract_id = response.commit_id[0]
+        request_number = response.commit_id[2]
+
+        if rep_completed_but_txn_not_submitted_updates.get(contract_id):
+            rep_completed_but_txn_not_submitted_updates[contract_id][request_number] =  response
+        else:
+            rep_completed_but_txn_not_submitted_updates[contract_id] = dict({request_number: response})
+
+        # submit as many transactions as possible for the contract_id just added
+        submitted_any = submit_doable_transactions_for_contract(contract_id)
+
+        # loop over all contracts_ids. For each check contract_id, submit as many transactions as possible.
+        # Continue looping until no transaction can be submitted for any conrtract_id
+        if submitted_any and len(rep_completed_but_txn_not_submitted_updates.keys()) > 1:
+            loop_again = True
+            while loop_again:
+                loop_again = False
+                for contract_id in rep_completed_but_txn_not_submitted_updates.keys():
+                    loop_again = loop_again or submit_doable_transactions_for_contract(contract_id)
+
+# -------------------------------------------------------
+def __submit_initialize_transaction__(response, ledger_config, **extra_params):
+    """submit the initialize transaction to the ledger
+    """
+
+    if response.status is False :
+        raise Exception('attempt to submit failed initialization transactions')
+
+    # an initialize operation has no previous state
+    assert not response.old_state_hash
+
+    initialize_submitter = Submitter(
+        ledger_config['LedgerURL'],
+        key_str = response.channel_keys.txn_private)
+
+    b64_message_hash = crypto.byte_array_to_base64(response.message_hash)
+    b64_new_state_hash = crypto.byte_array_to_base64(response.new_state_hash)
+    b64_code_hash = crypto.byte_array_to_base64(response.code_hash)
+
+    raw_state = response.raw_state
+    try :
+        raw_state = raw_state.decode()
+    except AttributeError :
+        pass
+
+    txnid = initialize_submitter.submit_ccl_initialize_from_data(
+        response.originator_keys.signing_key,
+        response.originator_keys.verifying_key,
+        response.channel_keys.txn_public,
+        response.enclave_service.enclave_id,
+        response.signature,
+        response.contract_id,
+        b64_message_hash,
+        b64_new_state_hash,
+        raw_state,
+        b64_code_hash,
+        **extra_params)
+
+    if txnid :
+        __external_dependencies_txn_ids__.SaveDependency(response.contract_id, b64_new_state_hash, txnid)
+
+    return txnid
+
+# -------------------------------------------------------
+def __submit_update_transaction__(response, ledger_config, **extra_params):
+    """submit the update transaction to the ledger
+    """
+
+    if response.status is False :
+        raise Exception('attempt to submit failed update transaction')
+
+    # there must be a previous state hash if this is
+    # an update
+    assert response.old_state_hash
+
+    update_submitter = Submitter(
+        ledger_config['LedgerURL'],
+        key_str = response.channel_keys.txn_private)
+
+    b64_message_hash = crypto.byte_array_to_base64(response.message_hash)
+    b64_new_state_hash = crypto.byte_array_to_base64(response.new_state_hash)
+    b64_old_state_hash = crypto.byte_array_to_base64(response.old_state_hash)
+
+    # convert contract dependencies into transaction dependencies
+    # to ensure that the sawtooth validator does not attempt to
+    # re-order the transactions since it is unaware of the semantics
+    # of the contract dependencies
+    txn_dependencies = set()
+    if extra_params.get('transaction_dependency_list') :
+        txn_dependencies.update(extra_params['transaction_dependency_list'])
+
+    txnid = __external_dependencies_txn_ids__.FindDependency(ledger_config, response.contract_id, b64_old_state_hash)
+    if txnid :
+        txn_dependencies.add(txnid)
+
+    for dependency in response.dependencies :
+        contract_id = dependency['contract_id']
+        state_hash = dependency['state_hash']
+        txnid = __external_dependencies_txn_ids__.FindDependency(ledger_config, contract_id, state_hash)
+        if txnid :
+            txn_dependencies.add(txnid)
+        else :
+            raise Exception('failed to find dependency; {0}:{1}'.format(contract_id, state_hash))
+
+    if txn_dependencies :
+        extra_params['transaction_dependency_list'] = list(txn_dependencies)
+
+    raw_state = response.raw_state
+    try :
+        raw_state = raw_state.decode()
+    except AttributeError :
+        pass
+
+    # now send off the transaction to the ledger
+    txnid = update_submitter.submit_ccl_update_from_data(
+        response.originator_keys.verifying_key,
+        response.channel_keys.txn_public,
+        response.enclave_service.enclave_id,
+        response.signature,
+        response.contract_id,
+        b64_message_hash,
+        b64_new_state_hash,
+        b64_old_state_hash,
+        raw_state,
+        response.dependencies,
+        **extra_params)
+
+    if txnid :
+        __external_dependencies_txn_ids__.SaveDependency(response.contract_id, b64_new_state_hash, txnid)
+
+    return txnid
+
+# -----------------------------------------------------------------
+class TransactionRequest(object):
+
+    def __init__(self, ledger_config, commit_id, wait = 30,
+        external_dependencies_txn_ids=[], commit_dependencies=[], check_implicit_commit=True):
+
+        self.ledger_config = ledger_config
+        self.commit_id = commit_id
+        self.wait = wait
+        self.external_dependencies_txn_ids = external_dependencies_txn_ids
+        self.commit_dependencies = commit_dependencies
+        self.check_implicit_commit = check_implicit_commit
+        self.is_completed = False
+        self.is_failed = False
+
+    # -----------------------------------------------------------------
+    def mark_as_completed(self):
+        self.is_completed = True
+
+    # -----------------------------------------------------------------
+    def mark_as_failed(self):
+        self.is_failed = True
+        self.mark_as_completed()
+
+    # -----------------------------------------------------------------
+    def wait_for_completion(self):
+        """ wait until completion of transaction. If success, return txn_id, else raise Exception"""
+
+        release_lock = False
+        while self.is_completed is False:
+            __condition_variable_for_completed_transactions__.acquire()
+            __condition_variable_for_completed_transactions__.wait(timeout=1.0)
+            release_lock = True
+
+        if release_lock:
+            __condition_variable_for_completed_transactions__.release()
+
+        if self.is_failed:
+            raise Exception("Transaction submission failed for request number %d", self.commit_id[2])
+
+        contract_id = self.commit_id[0]
+        state_hash = self.commit_id[1]
+        txn_id = __external_dependencies_txn_ids__.FindDependencyLocally(contract_id, crypto.byte_array_to_base64(state_hash))
+
+        return txn_id

--- a/python/pdo/service_client/__init__.py
+++ b/python/pdo/service_client/__init__.py
@@ -17,5 +17,4 @@ all = [
     'generic',
     'provisioning',
     'storage',
-    'servicedatabase'
 ]

--- a/python/pdo/service_client/storage.py
+++ b/python/pdo/service_client/storage.py
@@ -172,7 +172,6 @@ class StorageServiceClient(GenericServiceClient) :
         try :
             request_data = dict()
             request_data['operation'] = (None, json.dumps({'expiration' : expiration}), 'application/json')
-
             count = 0                     # just needed to uniquify the keys
             for block_data in block_data_list :
                 request_data['block{0}'.format(count)] = (None, block_data, 'application/octet-stream')
@@ -183,7 +182,6 @@ class StorageServiceClient(GenericServiceClient) :
         except Exception as e :
             logger.warn('unknown exception (store_blocks); %s', str(e))
             raise StorageException(str(e)) from e
-
         try :
             response = self.session.post(url, data=mp_encoder.to_string(), headers=request_headers, timeout=self.default_timeout)
         except Exception as e :

--- a/python/pdo/test/contract.py
+++ b/python/pdo/test/contract.py
@@ -255,12 +255,11 @@ def CreateAndRegisterContract(config, enclaves, contract_creator_keys) :
     #add replication information to contract
     AddReplicationParamsToContract(config, enclaves, contract)
 
-    # Decide if the contract use a fixed enclave or a randomized one for each update. If fixed, we chose here. If random, nothing to be done here,
-    # will be (atuomatically) selected at random during request creation
-    if (use_eservice is False) or (config['Service']['Randomize_Eservice'] is False):
-        enclave_to_use = enclaves[0]
-    else:
+    # Decide if the contract use a fixed enclave or a randomized one for each update. 
+    if use_eservice and config['Service']['Randomize_Eservice']:
         enclave_to_use = 'random'
+    else:
+        enclave_to_use = enclaves[0]
 
     # save the contract info as a pdo file
     contract_save_file = '_' + contract.short_id + '.pdo'
@@ -314,12 +313,11 @@ def UpdateTheContract(config, enclaves, contract, contract_invoker_keys) :
     ledger_config = config.get('Sawtooth')
     contract_invoker_id = contract_invoker_keys.identity
 
-    # Decide if the contract use a fixed enclave or a randomized one for each update. If fixed, we chose here. If random, nothing to be done here,
-    # will be (atuomatically) selected at random during request creation
-    if (use_eservice is False) or (config['Service']['Randomize_Eservice'] is False):
-        enclave_to_use = enclaves[0]
-    else:
+    # Decide if the contract use a fixed enclave or a randomized one for each update. 
+    if use_eservice and config['Service']['Randomize_Eservice']:
         enclave_to_use = 'random'
+    else:
+        enclave_to_use = enclaves[0]
 
     start_time = time.time()
     total_tests = 0
@@ -510,8 +508,8 @@ def Main() :
     parser.add_argument('--eservice-db', help='json file for eservice database', type=str)
     parser.add_argument('--eservice-name', help='List of enclave services to use. Give names as in database', nargs='+')
     parser.add_argument('--eservice-url', help='List of enclave service URLs to use', nargs='+')
-    parser.add_argument('--randomize-eservice', help="Say True if eservice must be randomized for each update. \
-        Else, the same eservice (the first one in the list of input eservices) will be used for all udpates.", type=bool, default=False)
+    parser.add_argument('--randomize-eservice', help="Eservice will be randomized for each update. \
+        Else, the same eservice (the first one in the list of input eservices) will be used for all udpates.", action="store_true")
     parser.add_argument('--pservice-url', help='List of provisioning service URLs to use', nargs='+')
 
     parser.add_argument('--block-store', help='Name of the file where blocks are stored', type=str)
@@ -591,7 +589,10 @@ def Main() :
             'EnclaveServiceDatabaseFile' : None
         }
 
-    config['Service']['Randomize_Eservice'] = options.randomize_eservice
+    if options.randomize_eservice:
+        config['Service']['Randomize_Eservice'] = True
+    else:
+        config['Service']['Randomize_Eservice'] = False
     if options.eservice_name:
         use_eservice = True
         config['Service']['EnclaveServiceNames'] = options.eservice_name

--- a/python/pdo/test/contract.py
+++ b/python/pdo/test/contract.py
@@ -285,7 +285,7 @@ def CreateAndRegisterContract(config, enclaves, contract_creator_keys) :
 
     # submit the commit task: (a commit task replicates change-set and submits the corresponding transaction)
     try:
-        initialize_response.commit_asynchronously(ledger_config, wait=30, use_ledger=use_ledger)
+        initialize_response.commit_asynchronously(ledger_config, wait_parameter_for_ledger=30, use_ledger=use_ledger)
     except Exception as e:
         logger.exception('failed to asynchronously start replication and transaction submission:' + str(e))
         ErrorShutdown()
@@ -359,7 +359,7 @@ def UpdateTheContract(config, enclaves, contract, contract_invoker_keys) :
                 # asynchronously submit the commit task: (a commit task replicates change-set and submits the corresponding transaction)
                 try:
                     logger.info("asynchronously replicate change set and submit transaction in the background")
-                    update_response.commit_asynchronously(ledger_config, wait=30, use_ledger=use_ledger)
+                    update_response.commit_asynchronously(ledger_config, wait_parameter_for_ledger=30, use_ledger=use_ledger)
                     last_response_committed = update_response
                 except Exception as e:
                     logger.error('failed to submit commit: %s', str(e))

--- a/python/pdo/test/request.py
+++ b/python/pdo/test/request.py
@@ -284,7 +284,7 @@ def CreateAndRegisterContract(config, enclaves, contract_creator_keys) :
 
     # submit the commit task: (a commit task replicates change-set and submits the corresponding transaction)
     try:
-        initialize_response.commit_asynchronously(ledger_config, wait=30, use_ledger=use_ledger)
+        initialize_response.commit_asynchronously(ledger_config, wait_parameter_for_ledger=30, use_ledger=use_ledger)
     except Exception as e:
         logger.exception('failed to asynchronously start replication and transaction submission:' + str(e))
         ErrorShutdown()
@@ -345,7 +345,7 @@ def UpdateTheContract(config, contract, enclaves, contract_invoker_keys) :
         if update_response.state_changed :
             # asynchronously submit the commit task: (a commit task replicates change-set and submits the corresponding transaction)
             try:
-                update_response.commit_asynchronously(ledger_config, wait=30, use_ledger=use_ledger)
+                update_response.commit_asynchronously(ledger_config, wait_parameter_for_ledger=30, use_ledger=use_ledger)
                 last_response_committed = update_response
             except Exception as e:
                 logger.error('failed to submit commit: %s', str(e))

--- a/python/pdo/test/request.py
+++ b/python/pdo/test/request.py
@@ -18,7 +18,7 @@ import os
 import sys
 import time
 import argparse
-import random
+
 from string import Template
 
 import pdo.test.helpers.secrets as secret_helper
@@ -32,6 +32,7 @@ import pdo.service_client.provisioning as pservice_helper
 import pdo.service_client.service_data.eservice as db
 
 import pdo.contract as contract_helper
+from pdo.contract.response import ContractResponse
 import pdo.common.crypto as crypto
 import pdo.common.keys as keys
 import pdo.common.secrets as secrets
@@ -39,9 +40,6 @@ import pdo.common.utility as putils
 
 import logging
 logger = logging.getLogger(__name__)
-
-# this will be used to test transaction dependencies
-txn_dependencies = []
 
 # representation of the enclave
 enclave = None
@@ -68,7 +66,77 @@ def ErrorShutdown() :
     except Exception as e :
         logger.exception('shutdown failed')
 
+    # Send termination signal to commit tasks
+    ContractResponse.exit_commit_workers()
+
     sys.exit(-1)
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+def AddReplicationParamsToContract(config, enclave_clients, contract):
+    """ Get parameters for change set replication from config. """
+
+    replication_config = config['Replication']
+
+    # ---------- get replication parameters from config --------------------------------------------------
+
+    try :
+        num_provable_replicas = replication_config['NumProvableReplicas']
+        availability_duration = replication_config['Duration']
+    except Exception as e :
+        logger.error('Replication is enabled with incomplete configuration.')
+        sys.exit(-1)
+
+    assert num_provable_replicas >= 0 , "Invalid configuration for num_provable_replicas: Must be a postive integer for proof of replication "
+    assert num_provable_replicas <= len(enclave_clients), "Invalid configuration for num_provable_replicas : Can be at most number of provisioned eservices"
+    assert availability_duration > 0 , "Invalid configuration for availability duration: Must be positive."
+
+    contract.set_replication_parameters(num_provable_replicas, availability_duration)
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+def AddEnclaveSecrets(ledger_config, contract_id, client_keys, enclaves, provclients) :
+    secrets = {}
+    encrypted_state_encryption_keys = {}
+    for enclave in enclaves:
+
+        if use_pservice:
+            psecrets = []
+            for provclient in provclients:
+                # Get a pspk:esecret pair from the provisioning service for each enclave
+                sig_payload = crypto.string_to_byte_array(enclave.enclave_id + contract_id)
+                secretinfo = provclient.get_secret(enclave.enclave_id,
+                                               contract_id,
+                                               client_keys.verifying_key,
+                                               client_keys.sign(sig_payload))
+                logger.debug("pservice secretinfo: %s", secretinfo)
+
+                # Add this pspk:esecret pair to the list
+                psecrets.append(secretinfo)
+        else:
+            psecrets = secret_helper.create_secrets_for_services(provclients, enclave.enclave_keys, contract_id, client_keys.identity)
+
+        # Print all of the secret pairs generated for this particular enclave
+        logger.debug('psecrets for enclave %s : %s', enclave.enclave_id, psecrets)
+
+        # Verify those secrets with the enclave
+        esresponse = enclave.verify_secrets(contract_id, client_keys.verifying_key, psecrets)
+        logger.debug("verify_secrets response: %s", esresponse)
+
+        # Store the ESEK mapping in a dictionary key'd by the enclave's public key (ID)
+        encrypted_state_encryption_keys[enclave.enclave_id] = esresponse['encrypted_state_encryption_key']
+
+        # Add this spefiic enclave to the contract
+        if use_ledger :
+            contract_helper.add_enclave_to_contract(ledger_config,
+                                client_keys,
+                                contract_id,
+                                enclave.enclave_id,
+                                psecrets,
+                                esresponse['encrypted_state_encryption_key'],
+                                esresponse['signature'])
+
+    return encrypted_state_encryption_keys
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
@@ -78,33 +146,20 @@ def CreateAndRegisterEnclave(config) :
     IMPORTANT: if an eservice is available it will be used,
                otherwise, the code interfaces directly with the python/swig wrapper in the eservice code
     """
+
     global enclave
-    global txn_dependencies
 
     # if we are using the eservice then there is nothing to register since
     # the eservice has already registered the enclave
     if use_eservice :
-
-        # Pick an enclave for the creating the contract
-        if config['Service'].get('EnclaveServiceNames'): #use the database to get the enclave
-            logger.info('Using eservice database to look up service URL for the contract enclave')
-            try:
-                eservice_to_use = random.choice(config['Service']['EnclaveServiceNames'])
-                enclave = db.get_client_by_name(eservice_to_use)
-            except Exception as e:
-                logger.error('Unable to get the eservice client using the eservice database: %s',  str(e))
-                sys.exit(-1)
-        else: # do not use the database, use the url and get the client directly
-            try :
-                eservice_urls = config['Service']['EnclaveServiceURLs']
-                eservice_url = random.choice(eservice_urls)
-                enclave = eservice_helper.EnclaveServiceClient(eservice_url)
-            except Exception as e :
-                logger.error('failed to contact enclave service; %s', str(e))
-                sys.exit(-1)
-
-        logger.info('use enclave service at %s', enclave.ServiceURL)
-        return enclave
+        enclaveclients = []
+        try :
+            for url in config['Service']['EnclaveServiceURLs'] :
+                enclaveclients.append(db.get_client_by_url(url))
+        except Exception as e :
+            logger.error('unable to setup enclave services; %s', str(e))
+            sys.exit(-1)
+        return enclaveclients
 
     # not using an eservice so build the local enclave
     try :
@@ -128,8 +183,6 @@ def CreateAndRegisterEnclave(config) :
         ledger_config = config.get('Sawtooth')
         if use_ledger :
             txnid = enclave.register_enclave(ledger_config)
-            txn_dependencies.append(txnid)
-
             logger.info('enclave registration successful')
 
             enclave.verify_registration(ledger_config)
@@ -137,15 +190,14 @@ def CreateAndRegisterEnclave(config) :
         else :
             logger.debug('no ledger config; skipping enclave registration')
     except Exception as e :
-        logger.error('failed to register the enclave; %s', str(e))
+        logger.exception('failed to register the enclave; %s', str(e))
         ErrorShutdown()
 
-    return enclave
+    return [enclave]
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
-def CreateAndRegisterContract(config, enclave, contract_creator_keys) :
-    global txn_dependencies
+def CreateAndRegisterContract(config, enclaves, contract_creator_keys) :
 
     data_dir = config['Contract']['DataDirectory']
 
@@ -160,7 +212,7 @@ def CreateAndRegisterContract(config, enclave, contract_creator_keys) :
     except Exception as e :
         raise Exception('unable to load contract source; {0}'.format(str(e)))
 
-    # create the provisioning servers
+    # create the provisioning service clients
     if use_pservice :
         try :
             pservice_urls = config['Service']['ProvisioningServiceURLs']
@@ -172,6 +224,7 @@ def CreateAndRegisterContract(config, enclave, contract_creator_keys) :
         provisioning_services = secret_helper.create_provisioning_services(config['secrets'])
     provisioning_service_keys = list(map(lambda svc : svc.identity, provisioning_services))
 
+    # register the contract, get contract_id
     try :
         if use_ledger :
             contract_id = contract_helper.register_contract(
@@ -190,74 +243,24 @@ def CreateAndRegisterContract(config, enclave, contract_creator_keys) :
     # --------------------------------------------------
     logger.info('create the provisioning secrets')
     # --------------------------------------------------
-    if use_pservice :
-        secret_list = []
-        for pservice in provisioning_services :
-            logger.debug('ask pservice %s to generate a secret for %s', pservice.ServiceURL, contract_id)
-            message = enclave.enclave_id + contract_id
-            signature = contract_creator_keys.sign(message, encoding='hex')
-            secret = pservice.get_secret(enclave.enclave_id, contract_id, contract_creator_keys.verifying_key, signature)
-            if secret is None :
-                logger.error('failed to create secret for %s', pservice.ServiceURL)
-                ErrorShutdown()
-            secret_list.append(secret)
-    else :
-        secret_list = secret_helper.create_secrets_for_services(
-            provisioning_services, enclave.enclave_keys, contract_id, contract_creator_id)
+    encrypted_state_encryption_keys = AddEnclaveSecrets(
+        ledger_config, contract.contract_id, contract_creator_keys, enclaves, provisioning_services)
 
-    logger.debug('secrets: %s', secret_list)
+    for enclave_id in encrypted_state_encryption_keys :
+        encrypted_key = encrypted_state_encryption_keys[enclave_id]
+        contract.set_state_encryption_key(enclave_id, encrypted_key)
 
-    try :
-        secretinfo = enclave.verify_secrets(contract_id, contract_creator_id, secret_list)
-        assert secretinfo
+    # add replication information to contract
+    AddReplicationParamsToContract(config, enclaves, contract)
 
-        encrypted_state_encryption_key = secretinfo['encrypted_state_encryption_key']
-        signature = secretinfo['signature']
+    # Decide if the contract uses a fixed enclave or a randomized one for each update. If fixed, we chose here. If random, 
+    # will be selected at random during request creation
+    if (use_eservice is False) or (config['Service']['Randomize_Eservice'] is False):
+        enclave_to_use = enclaves[0]
+    else:
+        enclave_to_use = 'random'
 
-    except Exception as e :
-        logger.error('failed to create the state encryption key; %s', str(e))
-        ErrorShutdown()
-
-    try :
-        if not secrets.verify_state_encryption_key_signature(
-                encrypted_state_encryption_key,
-                secret_list,
-                contract_id,
-                contract_creator_id,
-                signature,
-                enclave.enclave_keys) :
-            raise RuntimeError('signature verification failed')
-    except Exception as e :
-        logger.error('failed to verify the state encryption key; %s', str(e))
-        ErrorShutdown()
-
-    logger.debug('encrypted state encryption key: %s', encrypted_state_encryption_key)
-
-    # --------------------------------------------------
-    logger.info('add the provisioned enclave to the contract')
-    # --------------------------------------------------
-    try :
-        if use_ledger :
-            txnid = contract_helper.add_enclave_to_contract(
-                ledger_config,
-                contract_creator_keys,
-                contract_id,
-                enclave.enclave_id,
-                secret_list,
-                encrypted_state_encryption_key,
-                signature)
-            #transaction_dependency_list=txn_dependencies)
-            txn_dependencies.append(txnid)
-
-            logger.info('contract state encryption key added to contract')
-        else :
-            logger.debug('no ledger config; skipping state encryption key registration')
-    except Exception as e :
-        logger.error('failed to add state encryption key; %s', str(e))
-        ErrorShutdown()
-
-    contract.set_state_encryption_key(enclave.enclave_id, encrypted_state_encryption_key)
-
+    # save the contract info as a pdo file
     contract_save_file = '_' + contract.short_id + '.pdo'
     contract.save_to_file(contract_save_file, data_dir=data_dir)
 
@@ -265,7 +268,7 @@ def CreateAndRegisterContract(config, enclave, contract_creator_keys) :
     logger.info('create the initial contract state')
     # --------------------------------------------------
     try :
-        initialize_request = contract.create_initialize_request(contract_creator_keys, enclave)
+        initialize_request = contract.create_initialize_request(contract_creator_keys, enclave_to_use)
         initialize_response = initialize_request.evaluate()
         if initialize_response.status is False :
             logger.error('contract initialization failed: %s', initialize_response.result)
@@ -279,38 +282,41 @@ def CreateAndRegisterContract(config, enclave, contract_creator_keys) :
 
     logger.info('enclave created initial state')
 
-    # --------------------------------------------------
-    logger.info('save the initial state in the ledger')
-    # --------------------------------------------------
-    try :
-        if use_ledger :
-            logger.debug("sending to ledger")
-            # note that we will wait for commit of the transaction before
-            # continuing; this is not necessary in general (if there is
-            # confidence the transaction will succeed) but is useful for
-            # testing
-            txnid = initialize_response.submit_initialize_transaction(
-                ledger_config,
-                wait=30,
-                transaction_dependency_list=txn_dependencies)
-            txn_dependencies = [txnid]
-        else:
-            logger.debug('no ledger config; skipping iniatialize state save')
-    except Exception as e :
-        logger.exception('failed to save the initial state; %s', str(e))
+    # submit the commit task: (a commit task replicates change-set and submits the corresponding transaction)
+    try:
+        initialize_response.commit_asynchronously(ledger_config, wait=30, use_ledger=use_ledger)
+    except Exception as e:
+        logger.exception('failed to asynchronously start replication and transaction submission:' + str(e))
         ErrorShutdown()
 
+    # wait for the commit to finish.
+    try:
+        txn_id = initialize_response.wait_for_commit()
+        if use_ledger and txn_id is None:
+            logger.error("Did not receive txn id for the initial commit")
+            ErrorShutdown()
+    except Exception as e:
+        logger.error("Error while waiting for initial commit: %s", str(e))
+        ErrorShutdown()
+
+    logger.debug('update state')
     contract.contract_state.save_to_cache(data_dir=data_dir)
 
     return contract
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
-def UpdateTheContract(config, enclave, contract, contract_invoker_keys) :
-    global txn_dependencies
+def UpdateTheContract(config, contract, enclaves, contract_invoker_keys) :
 
     ledger_config = config.get('Sawtooth')
     contract_invoker_id = contract_invoker_keys.identity
+    last_response_committed = None
+
+    # Decide if the contract use a fixed enclave or a randomized one for each update. 
+    if (use_eservice is False) or (config['Service']['Randomize_Eservice'] is False):
+        enclave_to_use = enclaves[0]
+    else:
+        enclave_to_use = 'random'
 
     start_time = time.time()
     for x in range(config['iterations']) :
@@ -322,7 +328,7 @@ def UpdateTheContract(config, enclave, contract, contract_invoker_keys) :
 
         try :
             expression = "'(inc-value)"
-            update_request = contract.create_update_request(contract_invoker_keys, enclave, expression)
+            update_request = contract.create_update_request(contract_invoker_keys, expression, enclave_to_use)
             update_response = update_request.evaluate()
 
             if update_response.status is False :
@@ -335,33 +341,35 @@ def UpdateTheContract(config, enclave, contract, contract_invoker_keys) :
             logger.error('enclave failed to evaluation expression; %s', str(e))
             ErrorShutdown()
 
-        # if this operation did not change state then there is nothing
-        # to send to the ledger or to save
-        if not update_response.state_changed :
-            continue
+        # if this operation did not change state then there is nothing to commit
+        if update_response.state_changed :
+            # asynchronously submit the commit task: (a commit task replicates change-set and submits the corresponding transaction)
+            try:
+                update_response.commit_asynchronously(ledger_config, wait=30, use_ledger=use_ledger)
+                last_response_committed = update_response
+            except Exception as e:
+                logger.error('failed to submit commit: %s', str(e))
+                ErrorShutdown()
 
-        try :
-            if use_ledger :
-                logger.debug("sending to ledger")
-                # note that we will wait for commit of the transaction before
-                # continuing; this is not necessary in general (if there is
-                # confidence the transaction will succeed) but is useful for
-                # testing
-                txnid = update_response.submit_update_transaction(
-                    ledger_config,
-                    wait=30,
-                    transaction_dependency_list=txn_dependencies)
-                txn_dependencies = [txnid]
-            else :
-                logger.debug('no ledger config; skipping state save')
-        except Exception as e :
-            logger.error('failed to save the new state; %s', str(e))
+            logger.debug('update state')
+            contract.set_state(update_response.raw_state)
+
+    # wait for the last commit to finish.
+    if last_response_committed is not None:
+        try:
+            txn_id = last_response_committed.wait_for_commit()
+            if use_ledger and txn_id is None:
+                logger.error("Did not receive txn id for the last response committed")
+                ErrorShutdown()
+        except Exception as e:
+            logger.error("Error while waiting for the last response committed: %s", str(e))
             ErrorShutdown()
 
-        logger.debug('update state')
-        contract.set_state(update_response.raw_state)
-
+    logger.info("All commits completed")
     logger.info('completed in %s', time.time() - start_time)
+
+    # shutdown commit workers
+    ContractResponse.exit_commit_workers()
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
@@ -381,15 +389,22 @@ def LocalMain(config) :
             logger.error('Error loading eservice database %s', str(e))
             sys.exit(-1)
 
+        #convert any eservice names to urls using the database
+        if config['Service'].get('EnclaveServiceNames'):
+            config['Service']['EnclaveServiceURLs'] = []
+            for name in  config['Service']['EnclaveServiceNames']:
+                info = db.get_info_by_name(name)
+                config['Service']['EnclaveServiceURLs'].append(info['url'])
+
     # --------------------------------------------------
-    logger.info('create and register the enclave')
+    logger.info('create and register the enclaves')
     # --------------------------------------------------
-    enclave = CreateAndRegisterEnclave(config)
+    enclaves  = CreateAndRegisterEnclave(config)
 
     # --------------------------------------------------
     logger.info('create the contract and register it')
     # --------------------------------------------------
-    contract = CreateAndRegisterContract(config, enclave, contract_creator_keys)
+    contract = CreateAndRegisterContract(config, enclaves, contract_creator_keys)
 
     # --------------------------------------------------
     logger.info('invoke a few methods on the contract, load from file')
@@ -401,12 +416,13 @@ def LocalMain(config) :
             logger.info('reload the contract from local file')
             contract_save_file = '_' + contract.short_id + '.pdo'
             contract = contract_helper.Contract.read_from_file(ledger_config, contract_save_file, data_dir=data_dir)
+            logger.info("read the contract")
     except Exception as e :
         logger.error('failed to load the contract from a file; %s', str(e))
         ErrorShutdown()
 
     try :
-        UpdateTheContract(config, enclave, contract, contract_creator_keys)
+        UpdateTheContract(config, contract, enclaves, contract_creator_keys)
     except Exception as e :
         logger.exception('contract execution failed; %s', str(e))
         ErrorShutdown()
@@ -476,12 +492,17 @@ def Main() :
     parser.add_argument('--eservice-db', help='json file for eservice database', type=str)
     parser.add_argument('--eservice-name', help='List of enclave services to use. Give names as in database', nargs='+')
     parser.add_argument('--eservice-url', help='List of enclave service URLs to use', nargs='+')
+    parser.add_argument('--randomize-eservice', help="Say True if eservice must be randomized for each update. \
+        Else, the same eservice (the first one in the list of input eservices) will be used for all udpates.", type=bool, default=False)
     parser.add_argument('--pservice-url', help='List of provisioning service URLs to use', nargs='+')
 
     parser.add_argument('--block-store', help='Name of the file where blocks are stored', type=str)
 
     parser.add_argument('--secret-count', help='Number of secrets to generate', type=int, default=3)
     parser.add_argument('--iterations', help='Number of operations to perform', type=int, default=10)
+
+    parser.add_argument('--num-provable-replicas', help='Number of sservice signatures needed for proof of replication', type=int, default=1)
+    parser.add_argument('--availability-duration', help='duration (in seconds) for which the replicas are stored at storage service', type=int, default=60)
 
     parser.add_argument('--tamper-block-order', help='Flag for tampering with the order of the state blocks', action='store_true')
 
@@ -553,6 +574,7 @@ def Main() :
             'EnclaveServiceDatabaseFile' : None
         }
 
+    config['Service']['Randomize_Eservice'] = options.randomize_eservice
     if options.eservice_name:
         use_eservice = True
         config['Service']['EnclaveServiceNames'] = options.eservice_name
@@ -567,6 +589,11 @@ def Main() :
         use_pservice = True
         config['Service']['ProvisioningServiceURLs'] = options.pservice_url
 
+    # replication parameters
+    if options.num_provable_replicas :
+        config['Replication']['NumProvableReplicas'] = options.num_provable_replicas
+    if options.availability_duration :
+        config['Replication']['Duration'] = options.availability_duration
 
     # set up the data paths
     if config.get('Contract') is None :

--- a/python/pdo/test/request.py
+++ b/python/pdo/test/request.py
@@ -255,10 +255,10 @@ def CreateAndRegisterContract(config, enclaves, contract_creator_keys) :
 
     # Decide if the contract uses a fixed enclave or a randomized one for each update. If fixed, we chose here. If random, 
     # will be selected at random during request creation
-    if (use_eservice is False) or (config['Service']['Randomize_Eservice'] is False):
-        enclave_to_use = enclaves[0]
-    else:
+    if use_eservice and config['Service']['Randomize_Eservice']:
         enclave_to_use = 'random'
+    else:
+        enclave_to_use = enclaves[0]
 
     # save the contract info as a pdo file
     contract_save_file = '_' + contract.short_id + '.pdo'
@@ -313,10 +313,10 @@ def UpdateTheContract(config, contract, enclaves, contract_invoker_keys) :
     last_response_committed = None
 
     # Decide if the contract use a fixed enclave or a randomized one for each update. 
-    if (use_eservice is False) or (config['Service']['Randomize_Eservice'] is False):
-        enclave_to_use = enclaves[0]
-    else:
+    if use_eservice and config['Service']['Randomize_Eservice']:
         enclave_to_use = 'random'
+    else:
+        enclave_to_use = enclaves[0]
 
     start_time = time.time()
     for x in range(config['iterations']) :
@@ -492,8 +492,8 @@ def Main() :
     parser.add_argument('--eservice-db', help='json file for eservice database', type=str)
     parser.add_argument('--eservice-name', help='List of enclave services to use. Give names as in database', nargs='+')
     parser.add_argument('--eservice-url', help='List of enclave service URLs to use', nargs='+')
-    parser.add_argument('--randomize-eservice', help="Say True if eservice must be randomized for each update. \
-        Else, the same eservice (the first one in the list of input eservices) will be used for all udpates.", type=bool, default=False)
+    parser.add_argument('--randomize-eservice', help="Eservice will be randomized for each update. \
+        Else, the same eservice (the first one in the list of input eservices) will be used for all udpates.", action="store_true")
     parser.add_argument('--pservice-url', help='List of provisioning service URLs to use', nargs='+')
 
     parser.add_argument('--block-store', help='Name of the file where blocks are stored', type=str)
@@ -574,7 +574,10 @@ def Main() :
             'EnclaveServiceDatabaseFile' : None
         }
 
-    config['Service']['Randomize_Eservice'] = options.randomize_eservice
+    if options.randomize_eservice:
+        config['Service']['Randomize_Eservice'] = True
+    else:
+        config['Service']['Randomize_Eservice'] = False
     if options.eservice_name:
         use_eservice = True
         config['Service']['EnclaveServiceNames'] = options.eservice_name


### PR DESCRIPTION
This is a replacement for PR 205 (closed now).  This PR implements two features:

1.  Facility to replicate change-set (new blocks in the state after update) to the storage services associated with all provisioned enclaves for the contract
2. Facility to submit transactions asynchronously.

Both replication and transaction submission are performed after obtaining a response for the update operation being carried out. The two operations are together referred to as a commit operation. The client can simply invoke the commit operation (after obtaining the response to update operation) to carry out both replication and transaction submission asynchronously.  The client can any time in the future to check the status of the commit operation. The commit operation permits the client to specify past commits as dependencies, in case the transaction corresponding to the commit operation must only be submitted after the submission of transactions corresponding to commit operations  specified as dependencies.

Changes with respect to PR 205:

1. Replication thread model has changed: In the new PR, there are a fixed number of threads that handle replication to any given storage service. This helps prevent thread explosion that might have occurred in PR 205.
2. Separate module for transaction: In PR 205, transaction submission functionality was part of the response module. This has now been separated for improved clarity.
3. Changes to address comments on PR205: There were several valuable comments on PR 205, these have been addressed suitably in this PR.

Points to note:

The asynchronous commit is  illustrated via test-request and test-contract. The pdo-update and pdo-shell scripts, while use the new commit modules, carry out "overall commit operation" synchronously. It is expected that pod-sell will be modified in a separate PR to take advantage of asynchronous commits.


Signed-off-by: prakashngit <prakash.narayana.moorthy@intel.com>