### PR TITLE
Change service shutdown to use signals #165

### DIFF
--- a/eservice/Makefile
+++ b/eservice/Makefile
@@ -45,6 +45,7 @@ SWIG_TARGET = pdo/eservice/enclave/pdo_enclave_internal.py
 PYTHON_FILES = $(shell cat MANIFEST)
 
 SCRIPTS = \
+	bin/common.sh \
 	bin/es-start.sh \
 	bin/es-stop.sh \
 	bin/es-status.sh \

--- a/eservice/bin/es-start.sh
+++ b/eservice/bin/es-start.sh
@@ -61,16 +61,7 @@ if [ $? == 0 ] ; then
     exit 1
 fi
 
-# (2) prepare output
-if [ "$F_OUTPUTDIR" != "" ] ; then
-    mkdir -p $F_OUTPUTDIR
-    rm -f $F_OUTPUTDIR/*
-else
-    EFILE=/dev/null
-    OFILE=/dev/null
-fi
-
-# (3) start services asynchronously
+# (2) start services asynchronously
 for index in `seq 1 $F_COUNT` ; do
     IDENTITY="${F_BASENAME}$index"
     echo start enclave service $IDENTITY
@@ -79,20 +70,23 @@ for index in `seq 1 $F_COUNT` ; do
         rm -f "${F_SERVICEHOME}/data/${IDENTITY}.enc"
     fi
 
-    rm -f $F_LOGDIR/$IDENTITY.log
+    rm -f $F_LOGDIR/$IDENTITY.log $F_LOGDIR/$IDENTITY.pid
 
     if [ "$F_OUTPUTDIR" != "" ]  ; then
         EFILE="$F_OUTPUTDIR/$IDENTITY.err"
         OFILE="$F_OUTPUTDIR/$IDENTITY.out"
         rm -f $EFILE $OFILE
+    else
+        EFILE=/dev/null
+        OFILE=/dev/null
     fi
 
     eservice --identity ${IDENTITY} --config ${IDENTITY}.toml enclave.toml --config-dir ${F_CONFDIR} ${F_LEDGERURL} \
              --loglevel ${F_LOGLEVEL} --logfile ${F_LOGDIR}/${IDENTITY}.log 2> $EFILE > $OFILE &
-
+    echo $! > ${F_LOGDIR}/${IDENTITY}.pid
 done
 
-# (4) wait for successfull start of the services
+# (3) wait for successfull start of the services
 for index in `seq 1 $F_COUNT` ; do
     IDENTITY="${F_BASENAME}$index"
     echo waiting for startup completion of enclave service $IDENTITY

--- a/eservice/bin/es-stop.sh
+++ b/eservice/bin/es-stop.sh
@@ -45,11 +45,12 @@ for index in `seq 1 $F_COUNT` ; do
     IDENTITY="${F_BASENAME}$index"
     echo stopping enclave service $IDENTITY
 
-    url="$(get_url_base $IDENTITY)/shutdown" || { echo "no url found for enclave service"; exit 1; }
-    resp=$(curl -sL -w "%{http_code}\\n" ${url} -o /dev/null)
-    if [ $? != 0 ]; then # shutdown results in 500 error, so do not test also || [ $resp != "200" ]
-	echo "enclave service $IDENTITY not running or not properly shut down"
-	rc=1
+    if [ -f ${F_LOGDIR}/${IDENTITY}.pid ]; then
+        kill -SIGTERM $(cat ${F_LOGDIR}/${IDENTITY}.pid)
+        rm -f ${F_LOGDIR}/${IDENTITY}.pid
+    else
+        echo "enclave service ${IDENTITY} not running or not properly shut down"
+        rc=1
     fi
 done
 exit $rc

--- a/eservice/bin/ss-start.sh
+++ b/eservice/bin/ss-start.sh
@@ -57,34 +57,28 @@ if [ $? == 0 ] ; then
     exit 1
 fi
 
-# (2) prepare output
-if [ "$F_OUTPUTDIR" != "" ] ; then
-    mkdir -p $F_OUTPUTDIR
-    rm -f $F_OUTPUTDIR/*
-else
-    EFILE=/dev/null
-    OFILE=/dev/null
-fi
-
-# (3) start services asynchronously
+# (2) start services asynchronously
 for index in `seq 1 $F_COUNT` ; do
     IDENTITY="${F_BASENAME}$index"
     echo start storage service $IDENTITY
 
-    rm -f $F_LOGDIR/$IDENTITY.log
+    rm -f $F_LOGDIR/$IDENTITY.log $F_LOGDIR/$IDENTITY.pid
 
     if [ "$F_OUTPUTDIR" != "" ]  ; then
         EFILE="$F_OUTPUTDIR/$IDENTITY.err"
         OFILE="$F_OUTPUTDIR/$IDENTITY.out"
         rm -f $EFILE $OFILE
+    else
+        EFILE=/dev/null
+        OFILE=/dev/null
     fi
 
     sservice --identity ${IDENTITY} --config ${IDENTITY}.toml --config-dir ${F_CONFDIR} \
              --loglevel ${F_LOGLEVEL} --logfile ${F_LOGDIR}/${IDENTITY}.log 2> $EFILE > $OFILE &
-
+    echo $! > ${F_LOGDIR}/${IDENTITY}.pid
 done
 
-# (4) wait for successfull start of the services
+# (3) wait for successfull start of the services
 for index in `seq 1 $F_COUNT` ; do
     IDENTITY="${F_BASENAME}$index"
     echo waiting for startup completion of storage service $IDENTITY

--- a/eservice/bin/ss-stop.sh
+++ b/eservice/bin/ss-stop.sh
@@ -45,9 +45,10 @@ for index in `seq 1 $F_COUNT` ; do
     IDENTITY="${F_BASENAME}$index"
     echo stopping storage service $IDENTITY
 
-    url="$(get_url_base $IDENTITY)/shutdown" || { echo "no url found for storage service"; exit 1; }
-    resp=$(curl -sL -w "%{http_code}\\n" ${url} -o /dev/null)
-    if [ $? != 0 ]; then # shutdown results in 500 error, so do not test also || [ $resp != "200" ]
+    if [ -f ${F_LOGDIR}/${IDENTITY}.pid ]; then
+        kill -SIGTERM $(cat ${F_LOGDIR}/${IDENTITY}.pid)
+        rm -f ${F_LOGDIR}/${IDENTITY}.pid
+    else
 	echo "storage service $IDENTITY not running or not properly shut down"
 	rc=1
     fi

--- a/pservice/Makefile
+++ b/pservice/Makefile
@@ -31,6 +31,11 @@ SWIG_SOURCES = \
 SWIG_FILES = $(addprefix pdo/pservice/enclave/,$(SWIG_SOURCES))
 SWIG_TARGET = pdo/pservice/enclave/pdo_enclave_internal.py
 
+SCRIPTS = \
+	bin/ps-start.sh \
+	bin/ps-stop.sh \
+	bin/ps-status.sh
+
 PYTHON_FILES = \
 	pdo/pservice/enclave/__init__.py \
 	pdo/pservice/pdo_helper.py \
@@ -49,7 +54,7 @@ ENCLAVE_FILES = $(CONTRACT_ENCLAVE_MRENCLAVE_C_FILE) $(wildcard lib/libpdo_encla
 
 all : $(ENCLAVE_LIB) $(EGG_FILE)
 
-$(EGG_FILE) : $(ENCLAVE_LIB) $(SWIG_TARGET) $(PYTHON_FILES)
+$(EGG_FILE) : $(ENCLAVE_LIB) $(SWIG_TARGET) $(PYTHON_FILES) $(SCRIPTS)
 	@echo Build Distribution
 	python setup.py bdist_egg
 

--- a/pservice/bin/ps-stop.sh
+++ b/pservice/bin/ps-stop.sh
@@ -45,9 +45,10 @@ for index in `seq 1 $F_COUNT` ; do
     IDENTITY="${F_BASENAME}$index"
     echo stopping provisioning service $IDENTITY
 
-    url="$(get_url_base $IDENTITY)/shutdown" || { echo "no url found for enclave service"; exit 1; }
-    resp=$(curl -sL -w "%{http_code}\\n" ${url} -o /dev/null)
-    if [ $? != 0 ]; then # shutdown results in 500 error, so do not test also || [ $resp != "200" ]
+    if [ -f ${F_LOGDIR}/${IDENTITY}.pid ]; then
+        kill -SIGTERM $(cat ${F_LOGDIR}/${IDENTITY}.pid)
+        rm -f ${F_LOGDIR}/${IDENTITY}.pid
+    else
 	echo "provisioning service $IDENTITY not running or not properly shut down"
 	rc=1
     fi


### PR DESCRIPTION
Replace the code that shutdown the service through an
HTTP request with a signal handler for SIGTERM. This
should ensure clean shutdown with greater security.

Addresses issued #165

Signed-off-by: Mic Bowman <mic.bowman@intel.com>