### PR TITLE
simplifying API for the commit module 

### DIFF
--- a/client/pdo/client/controller/commands/create.py
+++ b/client/pdo/client/controller/commands/create.py
@@ -92,7 +92,7 @@ def __create_contract(ledger_config, client_keys, preferred_eservice_client, ese
 
     # submit the commit task: (a commit task replicates change-set and submits the corresponding transaction)
     try:
-        initialize_response.commit_asynchronously(ledger_config, wait_parameter_for_ledger=30, use_ledger=True)
+        initialize_response.commit_asynchronously(ledger_config)
     except Exception as e:
         raise Exception('failed to submit commit: %s', str(e))
 

--- a/client/pdo/client/controller/commands/send.py
+++ b/client/pdo/client/controller/commands/send.py
@@ -101,7 +101,7 @@ def send_to_contract(state, save_file, message, eservice_url=None, quiet=False, 
 
         # asynchronously submit the commit task: (a commit task replicates change-set and submits the corresponding transaction)
         try:
-            update_response.commit_asynchronously(ledger_config, wait_parameter_for_ledger=30, use_ledger=True)
+            update_response.commit_asynchronously(ledger_config)
         except Exception as e:
             raise Exception('failed to submit commit: %s', str(e))
 

--- a/client/pdo/client/scripts/CreateCLI.py
+++ b/client/pdo/client/scripts/CreateCLI.py
@@ -92,7 +92,7 @@ def CreateContract(ledger_config, client_keys, enclaveclients, contract) :
 
     # submit the commit task: (a commit task replicates change-set and submits the corresponding transaction)
     try:
-        initialize_response.commit_asynchronously(ledger_config, wait_parameter_for_ledger=30, use_ledger=True)
+        initialize_response.commit_asynchronously(ledger_config)
     except Exception as e:
         logger.error('failed to submit commit: %s', str(e))
         ContractResponse.exit_commit_workers()

--- a/client/pdo/client/scripts/UpdateCLI.py
+++ b/client/pdo/client/scripts/UpdateCLI.py
@@ -176,7 +176,7 @@ def LocalMain(config, message) :
 
         # asynchronously submit the commit task: (a commit task replicates change-set and submits the corresponding transaction)
         try:
-            update_response.commit_asynchronously(ledger_config, wait_parameter_for_ledger=30, use_ledger=True)
+            update_response.commit_asynchronously(ledger_config)
             last_response_committed = update_response
         except Exception as e:
             logger.error('failed to submit commit: %s', str(e))

--- a/python/pdo/service_client/storage.py
+++ b/python/pdo/service_client/storage.py
@@ -43,7 +43,7 @@ class StorageServiceClient(GenericServiceClient) :
     """A class to wrap calls to the storage service.
     """
 
-    default_timeout = 1.0
+    default_timeout = 10.0
 
     # -----------------------------------------------------------------
     def __init__(self, url) :

--- a/python/pdo/test/contract.py
+++ b/python/pdo/test/contract.py
@@ -285,7 +285,7 @@ def CreateAndRegisterContract(config, enclaves, contract_creator_keys) :
 
     # submit the commit task: (a commit task replicates change-set and submits the corresponding transaction)
     try:
-        initialize_response.commit_asynchronously(ledger_config, wait_parameter_for_ledger=30, use_ledger=use_ledger)
+        initialize_response.commit_asynchronously(ledger_config)
     except Exception as e:
         logger.exception('failed to asynchronously start replication and transaction submission:' + str(e))
         ErrorShutdown()
@@ -359,7 +359,7 @@ def UpdateTheContract(config, enclaves, contract, contract_invoker_keys) :
                 # asynchronously submit the commit task: (a commit task replicates change-set and submits the corresponding transaction)
                 try:
                     logger.info("asynchronously replicate change set and submit transaction in the background")
-                    update_response.commit_asynchronously(ledger_config, wait_parameter_for_ledger=30, use_ledger=use_ledger)
+                    update_response.commit_asynchronously(ledger_config)
                     last_response_committed = update_response
                 except Exception as e:
                     logger.error('failed to submit commit: %s', str(e))
@@ -570,6 +570,9 @@ def Main() :
         }
     if options.ledger :
         config['Sawtooth']['LedgerURL'] = options.ledger
+    if options.no_ledger  or not config['Sawtooth']['LedgerURL'] :
+        use_ledger = False
+        config.pop('Sawtooth', None)
 
     # set up the key search paths
     if config.get('Key') is None :
@@ -634,11 +637,6 @@ def Main() :
         }
     if options.block_store :
         config['StorageService']['BlockStore'] = options.block_store
-
-    # set up the ledger configuration
-    if options.no_ledger  or not config['Sawtooth']['LedgerURL'] :
-        use_ledger = False
-        config.pop('Sawtooth', None)
 
     config['secrets'] = options.secret_count
 

--- a/python/pdo/test/request.py
+++ b/python/pdo/test/request.py
@@ -284,7 +284,7 @@ def CreateAndRegisterContract(config, enclaves, contract_creator_keys) :
 
     # submit the commit task: (a commit task replicates change-set and submits the corresponding transaction)
     try:
-        initialize_response.commit_asynchronously(ledger_config, wait_parameter_for_ledger=30, use_ledger=use_ledger)
+        initialize_response.commit_asynchronously(ledger_config)
     except Exception as e:
         logger.exception('failed to asynchronously start replication and transaction submission:' + str(e))
         ErrorShutdown()
@@ -345,7 +345,7 @@ def UpdateTheContract(config, contract, enclaves, contract_invoker_keys) :
         if update_response.state_changed :
             # asynchronously submit the commit task: (a commit task replicates change-set and submits the corresponding transaction)
             try:
-                update_response.commit_asynchronously(ledger_config, wait_parameter_for_ledger=30, use_ledger=use_ledger)
+                update_response.commit_asynchronously(ledger_config)
                 last_response_committed = update_response
             except Exception as e:
                 logger.error('failed to submit commit: %s', str(e))
@@ -555,6 +555,9 @@ def Main() :
         }
     if options.ledger :
         config['Sawtooth']['LedgerURL'] = options.ledger
+    if options.no_ledger  or not config['Sawtooth']['LedgerURL'] :
+        use_ledger = False
+        config.pop('Sawtooth', None)
 
     # set up the key search paths
     if config.get('Key') is None :
@@ -619,11 +622,6 @@ def Main() :
         }
     if options.block_store :
         config['StorageService']['BlockStore'] = options.block_store
-
-    # set up the ledger configuration
-    if options.no_ledger  or not config['Sawtooth']['LedgerURL'] :
-        use_ledger = False
-        config.pop('Sawtooth', None)
 
     config['secrets'] = options.secret_count
     config['iterations'] = options.iterations


### PR DESCRIPTION
the commit_async API is simplified. Previously, there was a need to specify commit_dependencies explicitly via the API under special circumstances such as 1) when the contract state was loaded from a file, 2) when running multiple contracts with inter-contract dependencies. After the cleanup, all commit dependencies are automatically identified. In fact, commit_dependenciy specification is no longer part of the API, since everything is automatically identified.

Signed-off-by: prakashngit <prakash.narayana.moorthy@intel.com>