### PR TITLE
DCAP infrastructure support

### DIFF
--- a/docker/Dockerfile.pdo-dev
+++ b/docker/Dockerfile.pdo-dev
@@ -19,8 +19,8 @@
 #  Configuration (build) paramaters
 #  - proxy configuration: 	https_proxy http_proxy ftp_proxy, no_proxy  (default: undefined)
 #  - ubuntu base image to use: 	UBUNTU_VERSION (default: bionic)
-#  - sgx sdk version: 		SGX_SDK (default: sgx_2.4)
-#  - openssl version: 		OPENSSL (default: 1.1.0j)
+#  - sgx sdk version: 		SGX_SDK (default: sgx_2.6)
+#  - openssl version: 		OPENSSL (default: 1.1.0k)
 #  - sgxssl version: 		SGXSSL  (default: v2.4.1)
 #  - additional apt packages:	ADD_APT_PKGS (default: )
 
@@ -56,8 +56,8 @@ FROM ubuntu:${UBUNTU_VERSION}
 ARG UBUNTU_VERSION=bionic
 # for bizare docker reason, we have to redefine it here ...
 
-ARG SGX_SDK=sgx_2.4
-ARG OPENSSL=1.1.0j
+ARG SGX_SDK=sgx_2.6
+ARG OPENSSL=1.1.0k
 ARG SGXSSL=v2.4.1
 
 ARG ADD_APT_PKGS=

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -16,6 +16,7 @@
 DOCKER_BUILD_OPTS=
 DOCKER_COMPOSE_COMMAND=docker-compose
 DOCKER_COMPOSE_FILES=
+DOCKER_COMPOSE_OPTS=
 
 # optionally allow local overriding defaults
 -include make.loc
@@ -23,6 +24,8 @@ DOCKER_COMPOSE_FILES=
 DOCKER_COMPOSE_FILES += sawtooth-pdo.yaml sawtooth-pdo.local-code.yaml
 ifeq ($(SGX_MODE),HW)
    DOCKER_COMPOSE_FILES += sawtooth-pdo.sgx.yaml
+   SGX_DEVICE_PATH=$(shell if [ -e "/dev/isgx" ]; then echo "/dev/isgx"; elif [ -e "/dev/sgx" ]; then echo "/dev/sgx"; else echo "ERROR: NO SGX DEVICE FOUND"; fi)
+   DOCKER_COMPOSE_COMMAND := env SGX_DEVICE_PATH=${SGX_DEVICE_PATH} ${DOCKER_COMPOSE_COMMAND}
 endif
 ifdef http_proxy
    DOCKER_BUILD_OPTS += --build-arg http_proxy=${http_proxy}
@@ -46,7 +49,7 @@ endif
 ifdef PDO_DEBUG_BUILD
    DOCKER_COMPOSE_FILES += sawtooth-pdo.debugging.yaml
 endif
-DOCKER_COMPOSE_OPTS=$(foreach cf, $(DOCKER_COMPOSE_FILES), -f $(cf))
+DOCKER_COMPOSE_OPTS += $(foreach cf, $(DOCKER_COMPOSE_FILES), -f $(cf))
 
 all:
 

--- a/docker/sawtooth-pdo.sgx.yaml
+++ b/docker/sawtooth-pdo.sgx.yaml
@@ -47,5 +47,5 @@ services:
       - ${PDO_SGX_KEY_ROOT:-./sgx/}:/project/pdo/build/opt/pdo/etc/keys/sgx/
       - /var/run/aesmd:/var/run/aesmd
     devices:
-      - /dev/isgx:/dev/isgx
+      - ${SGX_DEVICE_PATH:-/dev/isgx}:${SGX_DEVICE_PATH:-/dev/isgx}
 

--- a/docs/docker_install.md
+++ b/docs/docker_install.md
@@ -70,13 +70,19 @@ request as it is easiest way to robustly check your commits. Doing so
 doesn't require any deeper understanding of docker or docker-compose
 and should run out-of the box.
 
-By default it will build and run tests only in SGX simulator mode but
-the makefile does honor
-the `SGX_MODE` environment variable if you want to test in SGX HW
-mode (in which case, though, you will have to put proper sgx attestation info
-files (`sgx_spid.txt`,  `sgx_spid_api_key`, `sgx_ias_key.pem`) into the
-sgx sub-directory or define the `PDO_SGX_KEY_ROOT` environment variable to
-point to a suiteable destination.
+By default it will build and run tests only in SGX simulator mode.
+However, assuming the host is [SGX-enabled](install.md#SGX), you can
+run tests also in HW mode: 
+
+- put proper sgx attestation info files (`sgx_spid.txt`,
+  `sgx_spid_api_key`,  `sgx_ias_key.pem`) into the sgx sub-directory
+  or define the `PDO_SGX_KEY_ROOT` environment variable to point to a
+  suiteable destination.
+
+- The makefile does honor the `SGX_MODE` environment variable, so just
+  make sure `SGX_MODE=HW` is defined before calling corresponding make
+  commands and tests will work in hardware mode.
+
 See `../build/common-config.sh --help` for more information on
 `PDO_SGX_KEY_ROOT` and related settings.
 

--- a/docs/host_install.md
+++ b/docs/host_install.md
@@ -75,8 +75,14 @@ SDK. When asked for the installation directory, we suggest that you install
 the SDK into the directory `/opt/intel`.
 
 ```bash
-wget https://download.01.org/intel-sgx/linux-2.4/ubuntu18.04-server/sgx_linux_x64_sdk_2.4.100.48163.bin -P /tmp
-sudo /bin/bash /tmp/sgx_linux_x64_sdk_2.4.100.48163.bin
+DCAP_VERSION=1.2
+UBUNTU_VERSION=ubuntuServer18.04
+DRIVER_REPO=https://download.01.org/intel-sgx/dcap-${DCAP_VERSION}/linux/dcap_installers/${UBUNTU_VERSION}/
+SDK_FILE=$(cd /tmp; wget --spider -r --no-parent $DRIVER_REPO 2>&1 | perl  -ne 'if (m|'${DRIVER_REPO}'(.*sdk.*)|) { print "$1\n"; }')
+
+wget ${DRIVER_REPO}/${SDK_FILE}
+chmod 777 ./${SDK_FILE}
+echo -e "no\n/opt/intel" | ./${SDK_FILE}
 ```
 
 The installer includes a file that sets environment variables to
@@ -125,7 +131,7 @@ SGX SSL install:
 
 ```bash
 cd openssl_source
-wget 'https://www.openssl.org/source/openssl-1.1.0j.tar.gz'
+wget 'https://www.openssl.org/source/openssl-1.1.0k.tar.gz'
 cd ..
 ```
 


### PR DESCRIPTION
This PR
* changes documentation to be based on latest DCAP infrastructure
* makes docker work on either DCAP or original SDK PSW installation
* It also bumps up docker to latest sgx sdk (2.6) and openssl 1.1.0 (1.1.0k) but does _neither_ update docker to dcap _nor_ update attestation to ECDSA, these will be later PRs ...