### PR TITLE
Docker support for wawaka  & continuous integration via travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+# Copyright Intel Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+dist: bionic
+language: minimal
+
+sudo: required
+services:
+  docker
+
+addons:
+  apt:
+    packages:
+
+env:
+  global:
+
+before_install:
+
+script:
+  # travis doesn't check out the branch itself but for our make to work we
+  # need a branch or alike. So check create a local one ...
+  - git checkout -b we-need-a-branch-for-below-to-work
+  # do integration tests for all available interpreters (in SGX_MODE=SIM mode,
+  # though, only ...)
+  # - gipsy/scheme
+  - PDO_INTERPRETER=gipsy make -C docker test
+  # - wawaka/wasm
+  - PDO_INTERPRETER=wawaka make -C docker test-env-setup # replace with test once integration tests also work with wawaka

--- a/common/tests/test_cryptoWrapper.py
+++ b/common/tests/test_cryptoWrapper.py
@@ -204,7 +204,7 @@ else:
   exit(-1)
 
 c = list(ciphertext)
-c[0] = c[0] + 1
+c[0] = (c[0] + 1) % 256 # Make sure it stays a byte or swig might fail find the correct C++ function below
 ciphertext = tuple(c)
 try:
  crypto.SKENC_DecryptMessage(key, iv, ciphertext)

--- a/docker/Dockerfile.pdo-build
+++ b/docker/Dockerfile.pdo-build
@@ -24,6 +24,7 @@
 #  - pdo repo to use:				PDO_REPO_URL  (default: https://github.com/hyperledger-labs/private-data-objects.git)
 #  - pdo repo branch to use:			PDO_REPO_BRANCH (default: master)
 #  - build in debug mode:			PDO_DEBUG_BUILD (default: 0)
+#  - contract interpreter (gipsy or wawaka):	PDO_INTERPRETER (default: gipsy)
 
 # Build:
 #   $ docker build -f docker/Dockerfile.pdo-build -t pdo-build docker
@@ -97,9 +98,14 @@ ENV SGX_MODE=${SGX_MODE}
 ARG PDO_DEBUG_BUILD=0
 ENV PDO_DEBUG_BUILD=${PDO_DEBUG_BUILD}
 
+ARG PDO_INTERPRETER=gipsy
+ENV PDO_INTERPRETER=${PDO_INTERPRETER}
+
 RUN \
-# read pdo environmentexplicitly as build shell doesn't do automatically (aargh ..). see comment in Dockerfile.pdo-dev
-     . /etc/profile.d/pdo.sh \
+# as we added now PDO source, also define PDO_SOURCE_ROOT to pdo env, ..
+ echo "export PDO_SOURCE_ROOT=/project/pdo/src/private-data-objects" >> /etc/profile.d/pdo.sh \
+# .. read pdo environment explicitly as build shell doesn't do automatically (aargh ..). see comment in Dockerfile.pdo-dev
+ && . /etc/profile.d/pdo.sh \
 # .. and overwrite auto-detection of SGX_MODE with whatever we compile below ...
  && echo "export SGX_MODE=${SGX_MODE}" >> /etc/profile.d/pdo.sh \
 # finally set up other env variables via config script based on

--- a/docker/Dockerfile.pdo-dev
+++ b/docker/Dockerfile.pdo-dev
@@ -169,7 +169,10 @@ RUN git clone  --branch ${SGXSSL} https://github.com/intel/intel-sgx-ssl.git \
  && rm -rf /tmp/intel-sgx-ssl \
  && echo "export SGX_SSL=/opt/intel/sgxssl" >> /etc/profile.d/pdo.sh
 
-# Install Tinyscheme
+# Install contract interpreter related stuff
+
+# - tinyscheme
+#   Install Tinyscheme
 RUN mkdir -p /opt/tinyscheme
 WORKDIR /opt/tinyscheme
 RUN wget https://downloads.sourceforge.net/project/tinyscheme/tinyscheme/tinyscheme-1.41/tinyscheme-1.41.zip \
@@ -178,6 +181,25 @@ RUN wget https://downloads.sourceforge.net/project/tinyscheme/tinyscheme/tinysch
  && cd tinyscheme-1.41  \
  && make FEATURES='-DUSE_DL=1 -DUSE_PLIST=1' \
  && echo "export TINY_SCHEME_SRC=$(pwd)" >> /etc/profile.d/pdo.sh
+
+# - web-assembly/wasm/wawaka
+#   - Get WAMR code
+RUN mkdir -p /project/wasm/src/
+WORKDIR /project/wasm/src
+RUN git clone https://github.com/intel/wasm-micro-runtime \
+ && cd wasm-micro-runtime \
+ && echo "export WASM_SRC=$(pwd)" >> /etc/profile.d/pdo.sh
+
+#   - get emscripten tooling
+RUN cd /project/wasm/src \
+ && git clone https://github.com/emscripten-core/emsdk.git \
+ && cd emsdk \
+ && ./emsdk install latest-fastcomp \
+ && ./emsdk activate latest-fastcomp \
+ && echo 'cd /project/wasm/src/emsdk/; if [ -z "$BASH_SOURCE" ]; then BASH_SOURCE=./emsdk_env.sh; . ./emsdk_env.sh; unset BASH_SOURCE; else . ./emsdk_env.sh; fi' >> /etc/profile.d/pdo.sh
+# Note: above convoluted BASH_SOURCE hack is necessary as (a) emsdk_env.sh 
+#   assumes we run in bash but (b) as we build we actually run in sh
+
 
 # environment setup as required by PDO
 # Note

--- a/docker/sawtooth-pdo.yaml
+++ b/docker/sawtooth-pdo.yaml
@@ -54,6 +54,7 @@ services:
         PDO_REPO_URL: ${PDO_REPO_URL:-https://github.com/hyperledger-labs/private-data-objects.git}
         PDO_REPO_BRANCH: ${PDO_REPO_BRANCH:-master}
         SGX_MODE: SIM
+        PDO_INTERPRETER: ${PDO_INTERPRETER:-gipsy}
     container_name: sawtooth-pdo-sim-build
     hostname: sawtooth-pdo-build
     depends_on:


### PR DESCRIPTION
Subject more or-or-less says it all.  Two additional notes
- currently, gipsy is the default interpreter for docker but this can be changed via build-arg (or environment variable, if you run docker via docker/Makefile) PDO_INTERPRETER.  Note though that right now `make -C docker test` will fail (as expected) in run-tests.sh for wawaka. 
- for travis, the current config will run 'make -C docker test' for gipsy (i.e., runs clean build and all automated tests) and 'make -C docker test-env-setup` for wawaka (i.e., it runs all builds and unit-tests run as part of build, but does not run run-tests.sh as this fails for now).  Once we have unified run-tests for both wawaka and gipsy we can change it so for both interpreters all tests are executed as a PR-acceptance-test ...

PS: as "bonus" this PR fixes also a fails-with-1/256-probability-bug in the python crypto tests ..