### PR TITLE
Add extensions functions to Gipsy to support conversion to/from JSON.

### DIFF
--- a/common/interpreter/gipsy_scheme/SchemeExtensions.cpp
+++ b/common/interpreter/gipsy_scheme/SchemeExtensions.cpp
@@ -1136,7 +1136,8 @@ static pointer json_to_expression_r(scheme* sc, JSON_Value* value)
         pe::ThrowIf<pe::RuntimeError>(true, "unknown error in JSON processing");
     }
 
-    // should never reach here
+    // should never reach here, place holder to avoid warning
+    return sc->NIL;
 }
 
 /* ----------------------------------------------------------------- */
@@ -1193,7 +1194,7 @@ static JSON_Value *expression_to_json_r(scheme *sc, pointer expr)
             {
                 pointer elem = sc->vptr->pair_car(next);
                 int length = sc->vptr->list_length(sc, elem);
-                pe::ThrowIf<pe::RuntimeError>(length != 2, "invalid JSON object representation");
+                pe::ThrowIf<pe::RuntimeError>(length != 2, "unable to convert s-expression to JSON, unsupported structure");
 
                 pointer key = sc->vptr->pair_car(elem);
                 pointer val = sc->vptr->pair_car(sc->vptr->pair_cdr(elem));
@@ -1284,7 +1285,8 @@ static JSON_Value *expression_to_json_r(scheme *sc, pointer expr)
         throw;
     }
 
-    // should never reach here
+    // should never reach here, place holder to avoid warning
+    return NULL;
 }
 
 

--- a/common/interpreter/gipsy_scheme/tests/README.md
+++ b/common/interpreter/gipsy_scheme/tests/README.md
@@ -8,35 +8,11 @@ https://creativecommons.org/licenses/by/4.0/
 This directory contains several tests for the Scheme extensions defined
 for the Gipsy contract interpreter.
 
-The tests require a stock tinyscheme interpreter and source, and a
-shared library with the Scheme extensions defined.
-
-## Install TinyScheme ##
-
-Tinyscheme can be installed with apt:
-`sudo apt install tinyscheme`
-
-Source for TinyScheme is available from
-[sourceforge.net](https://sourceforge.net/projects/tinyscheme/files/).
-
-For testing purposes, you cannot compile against the tinyscheme package
-included with the `PrivateDataObjects` repository; the structure of the
-scheme interpreter extension interface has changed.
-
-## Build the Extensions ##
-
-The Scheme extensions can be built as a TinyScheme extension library by
-building `pcontract.so` in the Gipsy interpreter directory. Note that to
-build `pcontract.so` you need to change the TINYSCHEME macro to point to
-the TinyScheme source directory. For example:
-
-`make TINYSCHEME=~/dev/packages/tinyscheme-1.41/ pcontract.so`
-
 ## Run the Tests ##
 
 From the tests directory, the tests can be run with the following
 command:
 
-`LD_LIBRARY_PATH=.. tinyscheme -1 test.scm`
+`${PDO_SOURCE_ROOT}/contracts/bin/gipsyscheme.sh test.scm`
 
-The file `test.scm` loads the environment, aes, ecdsa and rsa tests.
+The file `test.scm` loads the environment, aes, ecdsa, rsa and json tests.

--- a/common/interpreter/gipsy_scheme/tests/README.md
+++ b/common/interpreter/gipsy_scheme/tests/README.md
@@ -13,6 +13,6 @@ for the Gipsy contract interpreter.
 From the tests directory, the tests can be run with the following
 command:
 
-`${PDO_SOURCE_ROOT}/contracts/bin/gipsyscheme.sh test.scm`
+`${PDO_SOURCE_ROOT}/contracts/bin/gipsyscheme test.scm`
 
 The file `test.scm` loads the environment, aes, ecdsa, rsa and json tests.

--- a/common/interpreter/gipsy_scheme/tests/json.scm
+++ b/common/interpreter/gipsy_scheme/tests/json.scm
@@ -1,0 +1,42 @@
+;; Copyright 2019 Intel Corporation
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(display "START JSON\n")
+
+(catch error-print
+       (define (simple-expression v) (equal? v (json-to-expression (expression-to-json v))))
+
+       (test "single value tests")
+       (assert (simple-expression 1) "failed to convert integer")
+       (assert (simple-expression 1.5) "failed to convert real")
+       (assert (simple-expression #t) "failed to convert boolean true")
+       (assert (simple-expression #f) "failed to convert boolean false")
+       (assert (simple-expression "abc") "failed to convert string")
+       (assert (simple-expression #(1 2 3)) "failed to convert vector")
+       (assert (simple-expression '()) "failed to convert nil")
+       (assert (simple-expression '(("a" 0))) "failed to convert simple list")
+
+       (test "invalid json")
+       (catch-success (pdo-util::error-wrap (json-to-expression "{"))
+                      "uncaught malformed json")
+
+       (test "invalid expression")
+       (catch-success (pdo-util::error-wrap (expression-to-json '("a" "b")))
+                      "uncaught malformed expression")
+       (catch-success (pdo-util::error-wrap (expression-to-json '(("a" ("b")))))
+                      "uncaught malformed expression")
+
+       )
+
+(display "FINISH JSON\n")

--- a/common/interpreter/gipsy_scheme/tests/json.scm
+++ b/common/interpreter/gipsy_scheme/tests/json.scm
@@ -27,6 +27,58 @@
        (assert (simple-expression '()) "failed to convert nil")
        (assert (simple-expression '(("a" 0))) "failed to convert simple list")
 
+       (test "simple object tests")
+       (define simple-object-1
+         '(("key11" 1)
+           ("key12" #t)
+           ("key13" "a")))
+
+       (assert (simple-expression simple-object-1) "failed to convert simple-object-1")
+
+       (define simple-object-2
+         '(("key21" #(1 2 3))
+           ("key22" 2.5)
+           ("key23" "a")))
+
+       (assert (simple-expression simple-object-2) "failed to convert simple-object-2")
+
+       (test "complex object tests")
+       (define complex-object-1
+         (list (list "object1" simple-object-1) (list "object2" simple-object-2)))
+
+       (assert (simple-expression complex-object-1) "failed to convert complex-object-1")
+
+       (define complex-object-2
+         (vector (list (list "object1" simple-object-1)) (list (list "object2" simple-object-2))))
+
+       (assert (simple-expression complex-object-2) "failed to convert complex-object-2")
+
+       (define complex-object-3
+         (list (list "object3"
+                     (vector (list (list "object1" simple-object-1))
+                             (list (list "object2" simple-object-2))))
+               (list "object4" complex-object-1)
+               (list "object5" complex-object-2)))
+
+       (assert (simple-expression complex-object-3) "failed to convert complex-object-3")
+
+       (test "json validation")
+       (assert (validate-json (expression-to-json 1) "0") "failed to validate integer")
+       (assert (validate-json (expression-to-json 1.5) "1.0") "failed to validate number")
+       (assert (validate-json (expression-to-json #t) "true") "failed to validate boolean")
+       (assert (validate-json (expression-to-json "abc") "\"\"") "failed to validate string")
+       (assert (validate-json (expression-to-json #(1 2 3)) "[1]") "failed to validate vector of numbers")
+       (assert (validate-json
+                (expression-to-json simple-object-1) "{\"key11\":0, \"key12\":true, \"key13\":\"\"}")
+               "failed to validate simple-object-1")
+       (assert (validate-json
+                (expression-to-json simple-object-2) "{\"key21\":[0], \"key22\":1.0, \"key23\":\"\"}")
+               "failed to validate simple-object-2")
+
+       (catch-success (pdo-util::error-wrap
+                       (validate-json (expression-to-json simple-object-1) "{\"key11\":\"\",}"))
+                      "uncaught invalid json")
+
        (test "invalid json")
        (catch-success (pdo-util::error-wrap (json-to-expression "{"))
                       "uncaught malformed json")

--- a/common/interpreter/gipsy_scheme/tests/test.scm
+++ b/common/interpreter/gipsy_scheme/tests/test.scm
@@ -12,10 +12,6 @@
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
 
-(load-extension "pcontract")
-(load "../packages/init-package.scm")
-(load "../packages/catch-package.scm")
-
 (define pdo-util
   (package
    (define (error-wrap result)
@@ -45,3 +41,4 @@
 (load "aes.scm")
 (load "ecdsa.scm")
 (load "rsa.scm")
+(load "json.scm")


### PR DESCRIPTION
Added json-to-expression, expression-to-json and validate-json functions
to Gipsy. While this is in preparation for unifying the interpreter API
it also provides useful functions. Note that not all s-expressions can
be converted to JSON. Specifically:

- basic types, string, numbers, booleans are converted as expected
- symbols are not converted at all
- vectors are converted to vectors
- lists must be associative arrays, i.e. a list of two element lists; these are converted to a JSON object

Tests of the new functions are provided in the Gipsy tests directory.

Signed-off-by: Mic Bowman <mic.bowman@intel.com>