### PR TITLE
Fix broken links in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Initial Committers
 * Byron Marohn (byron-marohn - byron.marohn@intel.com)
 * Eugene Yarmosh (EugeneYYY - yevgeniy.y.yarmosh@intel.com)
 * Holly Harmon (harmonh - holly.harmon@intel.com)
+* Marcela Melara (masomel - marcela.melara@intel.com)
 * Mic Bowman (cmickeyb - cmickeyb@gmail.com)
 * Michael Steiner (g2flyer - michael.steiner@intel.com)
 * Prakash Narayana Moorthy (prakashngit - prakash.narayana.moorthy@intel.com)

--- a/client/docs/BUILD.md
+++ b/client/docs/BUILD.md
@@ -57,8 +57,8 @@ prompt> pip install twisted
 
 ### <a name="quick">Quick way to build (& install):
 
-Make sure the environment variables are defined (see the top level
-[REQUIREMENTS](../../REQUIREMENTS.md) document), then run:
+Make sure the environment variables are defined (see the
+[environment guide](../../docs/environment.md)), then run:
 ```bash
 prompt> make build_all && make install
 ```

--- a/common/BUILD.md
+++ b/common/BUILD.md
@@ -4,7 +4,7 @@ https://creativecommons.org/licenses/by/4.0/
 --->
 # Building the common libraries
 
-Make sure you have environment variables `SGX_SDK`, `SGX_SSL` and `TINY_SCHEME_SRC` defined (see [BUILD.md](../BUILD.md)) and then run
+Make sure you have environment variables `SGX_SDK`, `SGX_SSL` and `TINY_SCHEME_SRC` defined (see [environment.md](../docs/environment.md)) and then run
 ```
 mkdir build
 cd build

--- a/common/README.md
+++ b/common/README.md
@@ -21,18 +21,18 @@ https://software.intel.com/en-us/sgx-sdk/download
 Directories
 -----------
 
-Dir                           Content
------------------------------ -----------------------------------------------------------------------
-  crypto/                     .cpp/.h for OpenSSL based crypto functions
-  .                           .cpp/.h error handling and common types
-  packages/base64/            .cpp/.h of Renee Nyffinger base64 encoding/decoding
-  packages/parson/            .cpp/.h of Parson JSON  encoding/decoding
-  interpreter/                The contract interpreter implementation (currently based on TinyScheme)
-  tests/                      unit tests for crypto library
-  tests/untrusted             test untrusted Crypto library
-  tests/trusted               test trusted Crypto library
-  tests/trusted/app           trusted Crypto test app
-  tests/trusted/enclave       trusted Crypto test enclave
+| Dir                        |   Content |
+| -------------------------- | ----------------------------------------------------------------------- |
+|  crypto/                   |  .cpp/.h for OpenSSL based crypto functions |
+|  .                         |  .cpp/.h error handling and common types |
+|  packages/base64/          |  .cpp/.h of Renee Nyffinger base64 encoding/decoding |
+|  packages/parson/          |  .cpp/.h of Parson JSON  encoding/decoding |
+|  interpreter/              |  The contract interpreter implementation (currently based on TinyScheme) |
+|  tests/                    |  unit tests for crypto library |
+|  tests/untrusted           |  test untrusted Crypto library |
+|  tests/trusted             |  test trusted Crypto library |
+|  tests/trusted/app         |  trusted Crypto test app |
+|  tests/trusted/enclave     |  trusted Crypto test enclave |
 
 Python Wrapper
 -------------------------------------------------------------------------------------------------------

--- a/docs/docker_install.md
+++ b/docs/docker_install.md
@@ -132,17 +132,17 @@ self-contained/single machine installation.
 
 For more advanced docker-compose usage, check the headers in the yaml
 files:
-  - [sawtooth-pdo.yaml](sawtooth-pdo.yaml)
-  - [sawtooth-pdo.local-code.yaml](sawtooth-pdo.local-code.yaml)
-  - [sawtooth-pdo.proxy.yaml](sawtooth-pdo.proxy.yaml)
-  - [sawtooth-pdo.sgx.yaml](sawtooth-pdo.sgx.yaml)
-  - [sawtooth-pdo.debugging.yaml](sawtooth-pdo.debugging.yaml)
+  - [sawtooth-pdo.yaml](../docker/sawtooth-pdo.yaml)
+  - [sawtooth-pdo.local-code.yaml](../docker/sawtooth-pdo.local-code.yaml)
+  - [sawtooth-pdo.proxy.yaml](../docker/sawtooth-pdo.proxy.yaml)
+  - [sawtooth-pdo.sgx.yaml](../docker/sawtooth-pdo.sgx.yaml)
+  - [sawtooth-pdo.debugging.yaml](../docker/sawtooth-pdo.debugging.yaml)
 
 Similarly, the Dockerfiles also have additional information in the header if you want
 to use them separately:
-  - [Dockerfile.pdo-dev](Dockerfile.pdo-dev)
-  - [Dockerfile.pdo-build](Dockerfile.pdo-build)
-  - [Dockerfile.pdo-tp](Dockerfile.pdo-tp)
+  - [Dockerfile.pdo-dev](../docker/Dockerfile.pdo-dev)
+  - [Dockerfile.pdo-build](../docker/Dockerfile.pdo-build)
+  - [Dockerfile.pdo-tp](../docker/Dockerfile.pdo-tp)
 
 
 ## Makefile customization

--- a/docs/host_install.md
+++ b/docs/host_install.md
@@ -167,7 +167,7 @@ application requests. This repository contains the code required to build
 Transaction Processors that handle PDO requests.
 
 Follow the
-[setup document](sawtooth/docs/SETUP.md)
+[setup document](../sawtooth/docs/SETUP.md)
 to install both Sawtooth and the custom Sawtooth Transaction Processors.
 
 Note that the Sawtooth components do not depend on any other components of the

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -11,13 +11,13 @@ components.
 
 General information about how the sawtooth transaction processors work and how
 to use the pdo-cli command-line application to query the state of the Sawtooth
-blockchain can be found [here](sawtooth/docs/USAGE.md).
+blockchain can be found [here](../sawtooth/docs/USAGE.md).
 
 Information about the three different types of transaction processors used by
 Private Data Objects is here:
-- [Contract Registry](sawtooth/docs/cregistry.md)
-- [Enclave Registry](sawtooth/docs/eregistry.md)
-- [Coordination and Commit Log](sawtooth/docs/ccl.md)
+- [Contract Registry](../sawtooth/docs/cregistry.md)
+- [Enclave Registry](../sawtooth/docs/eregistry.md)
+- [Coordination and Commit Log](../sawtooth/docs/ccl.md)
 
 # Common library
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -68,7 +68,7 @@ information about contracts is available
 This project comes bundled with a few example contracts which you can
 experiment with. Here is a brief overview of each one:
 
-- [mock-contract](../contracts/mock-contract/mock-contract.scm)
+- [mock-contract](../contracts/test-contracts/mock-contract.scm)
 A very simple contract which allows the contract owner to increment and
 retrieve a stored value. Other parties can not interact with the contract.
 

--- a/eservice/docs/BUILD.md
+++ b/eservice/docs/BUILD.md
@@ -63,8 +63,8 @@ prompt> pip install twisted
 
 ### <a name="quick">Quick way to build (& install):
 
-Make sure the environment variables are defined (see the top level
-[PREREQUISITES](../../PREREQUISITES.md) document), then run:
+Make sure the environment variables are defined (see the
+[environment guide](../../docs/environment.md)), then run:
 ```bash
 prompt> make build_all && make install
 ```

--- a/pservice/docs/BUILD.md
+++ b/pservice/docs/BUILD.md
@@ -61,8 +61,8 @@ prompt> pip install twisted
 
 ### <a name="quick">Quick way to build (& install):
 
-Make sure the environment variables are defined (see the top level
-[PREREQUISITES](../../PREREQUISITES.md) document), then run:
+Make sure the environment variables are defined (see the
+[environment guide](../../docs/environment.md)), then run:
 ```bash
 prompt> make build_all && make install
 ```


### PR DESCRIPTION
Addresses #241 

I would also recommend removing docs/docker_install.md since it is basically identical to docker/README.md.

