### PR TITLE
Add documentation for AoT-wasm support in Wawaka

### DIFF
--- a/build/common-config.sh
+++ b/build/common-config.sh
@@ -37,10 +37,20 @@ var_set() {
 
 	env_val[WASM_SRC]="${WASM_SRC:-${PDO_SOURCE_ROOT}/interpreters/wasm-micro-runtime}"
 	env_desc[WASM_SRC]="
-		WASM_SRC points to the installation of the micro-wasm
+		WASM_SRC points to the installation of the wasm micro runtime
 		source in order to build the wasm interpreter
 	"
 	env_key_sort[$i]="WASM_SRC"; i=$i+1; export WASM_SRC=${env_val[WASM_SRC]};
+
+       env_val[WASM_MODE]="${WASM_MODE:-INTERP}"
+	env_desc[WASM_MODE]="
+		WASM_MODE indicates the mode of the wasm runtime. If the
+                variable is set to 'INTERP', the runtime will be built to
+                run intepreted wasm bytecode contracts. If the variable is
+                set to 'AOT', the runtime will be built to run AoT-compiled
+                native wasm contracts.
+	"
+	env_key_sort[$i]="WASM_MODE"; i=$i+1; export WASM_MODE=${env_val[WASM_MODE]};
 
 	env_val[PDO_INTERPRETER]="${PDO_INTERPRETER:-gipsy}"
 	env_desc[PDO_INTERPRETER]="

--- a/build/common-config.sh
+++ b/build/common-config.sh
@@ -42,7 +42,7 @@ var_set() {
 	"
 	env_key_sort[$i]="WASM_SRC"; i=$i+1; export WASM_SRC=${env_val[WASM_SRC]};
 
-       env_val[WASM_MODE]="${WASM_MODE:-INTERP}"
+	env_val[WASM_MODE]="${WASM_MODE:-INTERP}"
 	env_desc[WASM_MODE]="
 		WASM_MODE indicates the mode of the wasm runtime. If the
                 variable is set to 'INTERP', the runtime will be built to

--- a/common/interpreter/wawaka_wasm/CMakeLists.txt
+++ b/common/interpreter/wawaka_wasm/CMakeLists.txt
@@ -23,7 +23,12 @@ IF (NOT EXISTS "$ENV{WASM_SRC}")
   MESSAGE(FATAL_ERROR "WASM_SRC environment variable not defined!")
 ENDIF()
 
+IF (NOT DEFINED ENV{WASM_MODE})
+  MESSAGE(FATAL_ERROR "WASM_MODE environment variable not defined!")
+ENDIF()
+
 SET(WASM_SRC "$ENV{WASM_SRC}")
+SET(WASM_MODE "INTERP")
 
 # Reset default linker flags
 set (CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
@@ -44,20 +49,24 @@ if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif ()
 
-if (NOT DEFINED WAMR_BUILD_INTERP)
-  # Enable Interpreter by default
-  set (WAMR_BUILD_INTERP 1)
-endif ()
-
-if (NOT DEFINED WAMR_BUILD_AOT)
-  # Disable AOT by default.
+IF (WASM_MODE STREQUAL "AOT")
+  # Enable AOT.
+  set (WAMR_BUILD_AOT 1)
+  # Disable Interpreter for AoT mode
+  set (WAMR_BUILD_INTERP 0)
+  set (WAMR_BUILD_FAST_INTERP 0)
+ELSE()
+  # Disable AoT by default
   set (WAMR_BUILD_AOT 0)
-endif ()
+  set (WAMR_BUILD_INTERP 1)
+  if (NOT DEFINED WAMR_BUILD_FAST_INTERP)
+    # Disable fast interpreter by default
+    set (WAMR_BUILD_FAST_INTERP 0)
+  endif ()
+ENDIF()
 
-if (NOT DEFINED WAMR_BUILD_JIT)
-  # Disable JIT by default.
-  set (WAMR_BUILD_JIT 0)
-endif ()
+# Disable JIT by default for all runtime modes.
+set (WAMR_BUILD_JIT 0)
 
 if (NOT DEFINED WAMR_BUILD_LIBC_BUILTIN)
   # Enable libc builtin support by default
@@ -67,11 +76,6 @@ endif ()
 if (NOT DEFINED WAMR_BUILD_LIBC_WASI)
   # Disable libc wasi support by default
   set (WAMR_BUILD_LIBC_WASI 0)
-endif ()
-
-if (NOT DEFINED WAMR_BUILD_FAST_INTERP)
-  # Disable fast interpreter by default
-  set (WAMR_BUILD_FAST_INTERP 0)
 endif ()
 
 SET(PDO_INCLUDE_DIRS ".")

--- a/common/interpreter/wawaka_wasm/CMakeLists.txt
+++ b/common/interpreter/wawaka_wasm/CMakeLists.txt
@@ -23,6 +23,14 @@ IF (NOT EXISTS "$ENV{WASM_SRC}")
   MESSAGE(FATAL_ERROR "WASM_SRC environment variable not defined!")
 ENDIF()
 
+# Make sure wasm-micro-runtime submodule has been cloned
+file(GLOB WAMR_SUBMOD "$ENV{WASM_SRC}")
+list(LENGTH WAMR_SUBMOD SUBMOD_CONTENTS)
+IF (SUBMOD_CONTENTS EQUAL 0)
+  # submodule directory is empty
+  MESSAGE(FATAL_ERROR "WAMR git submodule has not been cloned. Please run `git submodule update --init` first.")
+ENDIF()
+
 IF (NOT DEFINED ENV{WASM_MODE})
   MESSAGE(FATAL_ERROR "WASM_MODE environment variable not defined!")
 ENDIF()

--- a/common/interpreter/wawaka_wasm/README.md
+++ b/common/interpreter/wawaka_wasm/README.md
@@ -89,6 +89,37 @@ pdo-test-contract --no-ledger --interpreter wawaka --contract mock-contract \
     --expressions ./mock-contract/test-long.exp --loglevel info
 ```
 
+## Ahead-of-Time Compiled WASM
+** Disclaimer: Support for this feature is under active development and will be rolled-out at a later date. AoT mode cannot currently be enabled for testing. **
+
+### Setup
+
+By default, wawaka will be built for interpreted wasm contracts. If you would like to enable
+ahead-of-time (AoT) compiled wasm contracts, set the environment variable `WASM_MODE` (default: `INTERP`):
+
+```bash
+export WASM_MODE=AOT
+```
+
+With AoT wasm enabled, the `wamrc` compiler (including dependencies)
+shipped as part of the WAMR codebase will be built
+as part of the PDO build.
+
+### Building and running wawaka Contracts
+
+We provide a new cmake function `BUILD_AOT_CONTRACT` that
+automatically invokes `wamrc` on a given wasm bytecode file,
+and generates the corresponding `.aot` binary file. 
+To build an AoT-compiled wawaka contract, add the following call to the contract's
+`CMakeList.txt`:
+
+```
+BUILD_AOT_CONTRACT(<contract name> <contract source list>)
+```
+
+Running an AoT-compiled wawaka contract requires no additional steps,
+as the WAMR runtime transparently detects the input wasm code's format.
+
 ## Basics of a Contract ##
 
 Note that compilation into WASM that will run in the contract enclave can be somewhat tricky. Specifically, all symbols whether used or not must be bound. The wawaka interpreter will fail if it attempts to load WASM code with unbound symbols.

--- a/contracts/wawaka/CMakeLists.txt
+++ b/contracts/wawaka/CMakeLists.txt
@@ -75,6 +75,23 @@ FUNCTION(BUILD_CONTRACT contract)
   INSTALL(FILES ${b64contract} DESTINATION ${CONTRACT_INSTALL_DIRECTORY})
 ENDFUNCTION()
 
+FUNCTION(BUILD_AOT_CONTRACT contract)
+  ADD_EXECUTABLE(${contract} ${ARGN} ${COMMON_SOURCE} ${LIBRARY_SOURCE} )
+  SET(b64contract ${CMAKE_CURRENT_BINARY_DIR}/_${contract}.b64)
+  ADD_CUSTOM_COMMAND(
+    TARGET ${contract}
+    POST_BUILD
+    COMMAND $ENV{WASM_SRC}/wamr-compiler/build/wamrc
+    ARGS -sgx --format=aot -o ${contract}.aot ${contract}.wasm
+    COMMAND base64
+    ARGS -w 0 ${contract}.aot > ${b64contract})
+  SET_SOURCE_FILES_PROPERTIES(${b64contract} PROPERTIES GENERATED TRUE)
+  SET_DIRECTORY_PROPERTIES(PROPERTY ADDITIONAL_MAKE_CLEAN_FILES ${b64contract})
+  # this can be replaced in later versions of CMAKE with target_link_properties
+  SET_PROPERTY(TARGET ${contract} APPEND_STRING PROPERTY LINK_FLAGS "${EMCC_LINK_OPTIONS}")
+  INSTALL(FILES ${b64contract} DESTINATION ${CONTRACT_INSTALL_DIRECTORY})
+ENDFUNCTION()
+
 ADD_SUBDIRECTORY(interface-test)
 ADD_SUBDIRECTORY(mock-contract)
 ADD_SUBDIRECTORY(interpreter-test)


### PR DESCRIPTION
This includes a new cmake function to automatically build the AoT-compiled contracts from wasm bytecode. Setting the `WASM_MODE=AOT` environment variable is currently a no-op.