### PR TITLE
remove block write-back in KVS for read-only operations

### DIFF
--- a/common/state/cache.cpp
+++ b/common/state/cache.cpp
@@ -154,6 +154,8 @@ void pstate::Cache::sync_entry(unsigned int block_num)
 
         // sync done
         bce.modified = false;
+
+        synced_entries_ ++;
     }
 }
 
@@ -218,7 +220,9 @@ void pstate::Cache::done(unsigned int block_num, bool modified)
     block_cache_entry_t& bce = block_cache_[block_num];
     bce.references--;
     if (modified)
+    {
         bce.modified = modified;
+    }
 }
 
 void pstate::Cache::pin(unsigned int block_num)
@@ -245,3 +249,7 @@ void pstate::Cache::modified(unsigned int block_num)
     bce.modified = true;
 }
 
+unsigned int pstate::Cache::synced_entries()
+{
+    return synced_entries_;
+}

--- a/common/state/cache.h
+++ b/common/state/cache.h
@@ -45,6 +45,7 @@ namespace state
     private:
         // the block_warehouse_ reference is related to the block_warehouse member of dn_io
         block_warehouse& block_warehouse_;
+        unsigned int synced_entries_;
 
         void replacement_policy_MRU();
 
@@ -58,7 +59,7 @@ namespace state
             data_node* dn;
         };
 
-        Cache(block_warehouse& bw): block_warehouse_(bw) {}
+        Cache(block_warehouse& bw): block_warehouse_(bw), synced_entries_(0) {}
 
         std::map<unsigned int, block_cache_entry_t> block_cache_;
         cache_slots slots_;
@@ -77,6 +78,7 @@ namespace state
         void pin(unsigned int block_num);
         void unpin(unsigned int block_num);
         void modified(unsigned int block_num);
+        unsigned int synced_entries();
     };
 }
 }

--- a/common/state/state_kv.cpp
+++ b/common/state/state_kv.cpp
@@ -92,14 +92,18 @@ void pdo::state::State_KV::Finalize(ByteArray& outId)
         // flush cache first
         dn_io_.cache_.flush();
 
-        // serialize block ids
-        dn_io_.block_warehouse_.serialize_block_ids(rootNode_);
+        // if the cache synced modified entries, recompute root block id
+        if(dn_io_.cache_.synced_entries() > 0)
+        {
+            // serialize block ids
+            dn_io_.block_warehouse_.serialize_block_ids(rootNode_);
 
-        // evict root block
-        ByteArray baBlock = rootNode_.GetBlock();
-        state_status_t ret = sebio_evict(baBlock, SEBIO_NO_CRYPTO, rootNode_.GetBlockId());
-        pdo::error::ThrowIf<pdo::error::ValueError>(
-            ret != STATE_SUCCESS, "kv root node unload, sebio returned an error");
+            // evict root block
+            ByteArray baBlock = rootNode_.GetBlock();
+            state_status_t ret = sebio_evict(baBlock, SEBIO_NO_CRYPTO, rootNode_.GetBlockId());
+            pdo::error::ThrowIf<pdo::error::ValueError>(
+                ret != STATE_SUCCESS, "kv root node unload, sebio returned an error");
+        }
 
         // output the root id
         outId = rootNode_.GetBlockId();

--- a/common/tests/state/untrusted/test.cpp
+++ b/common/tests/state/untrusted/test.cpp
@@ -28,13 +28,21 @@
 /* Application entry */
 int main(int argc, char* argv[])
 {
-    SAFE_LOG(PDO_LOG_DEBUG, "Test UNTRUSTED State API.\n");
-
+    int ret = -1;
     pdo::lmdb_block_store::BlockStoreOpen(TEST_DATABASE_NAME);
 
     SAFE_LOG(PDO_LOG_DEBUG, "Test State KV: start\n");
-    test_state_kv();
-    SAFE_LOG(PDO_LOG_DEBUG, "Test State KV:end\n");
+    try
+    {
+        test_state_kv();
+        SAFE_LOG(PDO_LOG_DEBUG, "Test State KV: SUCCESSFUL!\n");
+        ret = 0;
+    }
+    catch(...)
+    {
+        SAFE_LOG(PDO_LOG_ERROR, "Test State KV: FAILED\n");
+        ret = -1;
+    }
 
     pdo::lmdb_block_store::BlockStoreClose();
 
@@ -42,6 +50,5 @@ int main(int argc, char* argv[])
     unlink(TEST_DATABASE_NAME);
     unlink(TEST_DATABASE_LOCK_NAME);
 
-    SAFE_LOG(PDO_LOG_DEBUG, "Test UNTRUSTED State API SUCCESSFUL!\n");
-    return 0;
+    return ret;
 }

--- a/common/tests/state/untrusted/test_cache.cpp
+++ b/common/tests/state/untrusted/test_cache.cpp
@@ -37,12 +37,25 @@ state_status_t custom_fetch(const pstate::StateBlockId& block_id,
     return sebio_fetch_from_block_store(block_id, crypto_algo, block);
 }
 
+// We intercept the evict call to count the number of block evictions
+unsigned int evict_calls = 0;
+state_status_t custom_evict(
+    const pdo::state::StateBlock& block, sebio_crypto_algo_e crypto_algo, ByteArray& idOnEviction)
+{
+    evict_calls ++;
+    return sebio_evict_to_block_store(block, crypto_algo, idOnEviction);
+}
+
+void init_test_cache()
+{
+    sebio_set({{}, SEBIO_NO_CRYPTO, &custom_fetch, &custom_evict});
+}
+
 void test_cache()
 {
     const ByteArray state_encryption_key_(16, 0);
     ByteArray id;
 //################## TEST CACHE EXISTENCE #############################################################################
-    sebio_set({{}, SEBIO_NO_CRYPTO, &custom_fetch, &sebio_evict_to_block_store});
     try
     {
         SAFE_LOG(PDO_LOG_INFO, "start test cache existence\n");

--- a/common/tests/state/untrusted/test_cache.h
+++ b/common/tests/state/untrusted/test_cache.h
@@ -15,4 +15,5 @@
 
 #pragma once
 
+void init_test_cache();
 void test_cache();


### PR DESCRIPTION
This PR improves the KVS as follows:
- it removes block write-back for read-only ops
- it removes the pre-allocation of a new append-block (which may not be needed)
- it includes tests with read-only operations for checking state hash invariance and zero state block write-backs 

Signed-off-by: Bruno Vavala <bruno.vavala@intel.com>