### PR TITLE
Update wawaka to WAMR-03-30-2020

### DIFF
--- a/build/common-config.sh
+++ b/build/common-config.sh
@@ -44,9 +44,12 @@ var_set() {
 
 	env_val[WASM_MODE]="${WASM_MODE:-INTERP}"
 	env_desc[WASM_MODE]="
-		WASM_MODE indicates the mode of the wasm runtime. If the
-                variable is set to 'INTERP', the runtime will be built to
-                run intepreted wasm bytecode contracts. If the variable is
+		WASM_MODE indicates the execution mode of the wasm runtime.
+                If the variable is set to 'INTERP', the runtime will be
+                built to run intepreted wasm bytecode contracts. If the
+                variable is set to 'INTERP_OPT', the runtime will be
+                built to run the optimized interpreter for wasm bytecode
+                contracts. If the variable is
                 set to 'AOT', the runtime will be built to run AoT-compiled
                 native wasm contracts.
 	"

--- a/common/interpreter/wawaka_wasm/CMakeLists.txt
+++ b/common/interpreter/wawaka_wasm/CMakeLists.txt
@@ -36,7 +36,7 @@ IF (NOT DEFINED ENV{WASM_MODE})
 ENDIF()
 
 SET(WASM_SRC "$ENV{WASM_SRC}")
-SET(WASM_MODE "INTERP")
+SET(WASM_MODE "$ENV{WASM_MODE}")
 
 # Reset default linker flags
 set (CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
@@ -63,14 +63,20 @@ IF (WASM_MODE STREQUAL "AOT")
   # Disable Interpreter for AoT mode
   set (WAMR_BUILD_INTERP 0)
   set (WAMR_BUILD_FAST_INTERP 0)
-ELSE()
+  message(STATUS "Building wawaka in AOT mode")
+  message(FATAL_ERROR "AoT mode is not currently implemented")
+ELSE ()
   # Disable AoT by default
   set (WAMR_BUILD_AOT 0)
   set (WAMR_BUILD_INTERP 1)
-  if (NOT DEFINED WAMR_BUILD_FAST_INTERP)
-    # Disable fast interpreter by default
+  if (WASM_MODE STREQUAL "INTERP_OPT")
+    set (WAMR_BUILD_FAST_INTERP 1)
+    message(STATUS "Building wawaka in optimized INTERP mode")
+  else()
+    # Disable optimized interpreter by default
     set (WAMR_BUILD_FAST_INTERP 0)
-  endif ()
+    message(STATUS "Building wawaka in INTERP mode")
+  endif()
 ENDIF()
 
 # Disable JIT by default for all runtime modes.

--- a/common/interpreter/wawaka_wasm/CMakeLists.txt
+++ b/common/interpreter/wawaka_wasm/CMakeLists.txt
@@ -63,6 +63,7 @@ IF (WASM_MODE STREQUAL "AOT")
   # Disable Interpreter for AoT mode
   set (WAMR_BUILD_INTERP 0)
   set (WAMR_BUILD_FAST_INTERP 0)
+  add_definitions (-DAOT_WASM_RT=1)
   message(STATUS "Building wawaka in AOT mode")
   message(FATAL_ERROR "AoT mode is not currently implemented")
 ELSE ()

--- a/common/interpreter/wawaka_wasm/README.md
+++ b/common/interpreter/wawaka_wasm/README.md
@@ -47,14 +47,14 @@ source ./emsdk_env.sh
 If wawaka is configured as the contract interpreter, the libraries implementing the WASM interpreter
 will be built for use with Intel SGX. The source for the WAMR interpreter is
 included as a submodule in the interpreters/ folder, and will
-always point to the latest tagged commit that we have validated: `WAMR-03-19-2020`.
+always point to the latest tagged commit that we have validated: `WAMR-03-30-2020`.
 If the PDO parent repo was not cloned with the `--recurse-submodules` flag,
 you will have to explictly pull the submodule source.
 
 ```
 cd ${PDO_SOURCE_ROOT}/interpreters/wasm-micro-runtime
 git submodule update --init
-git checkout WAMR-03-19-2020 # optional
+git checkout WAMR-03-30-2020 # optional
 ```
 
 The WAMR API is built during the Wawaka build, so no additional
@@ -62,12 +62,21 @@ build steps are required to set up WAMR.
 
 ### Set the environment variables ###
 
-By default, PDO will be built with the Gipsy Scheme contract interpreter. To use the experimental wawaka interpreter, set the environment variables `WASM_SRC` (default is the submodule directory with the WAMR source) and `PDO_INTERPRETER` (the name of the contract interpreter to use.
+By default, PDO will be built with the Gipsy Scheme contract interpreter. To use the experimental wawaka interpreter, set the environment variables `WASM_SRC` (default is the submodule directory with the WAMR source), `PDO_INTERPRETER` (the name of the contract interpreter to use), and `WASM_MODE` (the
+execution mode of the wawaka WASM runtime).
 
 ```bash
 export WASM_SRC=${PDO_SOURCE_ROOT}/interpreters/wasm-micro-runtime
 export PDO_INTERPRETER=wawaka
+export WASM_MODE=INTERP
 ```
+
+PDO supports two WAMR interpreter modes: classic
+interpreter and optimized interpreter (more details at
+[WAMR documentation](https://github.com/bytecodealliance/wasm-micro-runtime/blob/master/doc/build_wamr.md#configure-interpreter)).
+By default, PDO builds the classic interpreter. To enable the
+optimized interpreter, set the `WASM_MODE` environment variable
+to `INTERP_OPT`.
 
 ### Build PDO ###
 
@@ -94,7 +103,8 @@ pdo-test-contract --no-ledger --interpreter wawaka --contract mock-contract \
 
 ### Setup
 
-By default, wawaka will be built for interpreted wasm contracts. If you would like to enable
+By default, wawaka will be built for interpreted wasm contracts.
+If you would like to enable
 ahead-of-time (AoT) compiled wasm contracts, set the environment variable `WASM_MODE` (default: `INTERP`):
 
 ```bash

--- a/common/interpreter/wawaka_wasm/WawakaInterpreter.cpp
+++ b/common/interpreter/wawaka_wasm/WawakaInterpreter.cpp
@@ -42,8 +42,14 @@ extern bool RegisterNativeFunctions(void);
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+#ifdef AOT_WASM_RT
+const std::string WawakaInterpreter::identity_ = "wawaka-aot";
+#else
 const std::string WawakaInterpreter::identity_ = "wawaka";
+#endif
 
+// TODO: Produce verifiable info about runtime built into this enclave
+// See issue #255
 std::string pdo::contracts::GetInterpreterIdentity(void)
 {
     return WawakaInterpreter::identity_;

--- a/docker/Dockerfile.pdo-build
+++ b/docker/Dockerfile.pdo-build
@@ -25,7 +25,7 @@
 #  - pdo repo branch to use:			PDO_REPO_BRANCH (default: master)
 #  - build in debug mode:			PDO_DEBUG_BUILD (default: 0)
 #  - contract interpreter (gipsy or wawaka):	PDO_INTERPRETER (default: gipsy)
-#  - wamr version:		                WAMR    (default: WAMR-03-19-2020)
+#  - wamr version:		                WAMR    (default: WAMR-03-30-2020)
 
 # Build:
 #   $ docker build -f docker/Dockerfile.pdo-build -t pdo-build docker
@@ -104,7 +104,7 @@ ENV PDO_INTERPRETER=${PDO_INTERPRETER}
 
 # - web-assembly/wasm/wawaka
 #   - Configure WAMR source
-ARG WAMR=WAMR-03-19-2020
+ARG WAMR=WAMR-03-30-2020
 RUN cd /project/pdo/src/private-data-objects/interpreters/wasm-micro-runtime \
  && git checkout ${WAMR}\
  && echo "export WASM_SRC=$(pwd)" >> /etc/profile.d/pdo.sh

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -101,12 +101,24 @@ the contract enclave.
 
 <!-- -------------------------------------------------- -->
 ### `WASM_SRC`
-(default: `${PDO_SOURCE_ROOT}/wasm`)
+(default: `${PDO_SOURCE_ROOT}/interpreters/wasm-micro-runtime`)
 
-`WASM_SRC` points to the installation of the micro-wasm source. This
+`WASM_SRC` points to the installation of the wasm-micro-runtime. This
 is used to build the WASM interpreter for the wawaka contract interpreter.
-Clone branch/tag 'tag-11-28-2019' of the micro-wasm source from 
-https://github.com/intel/wasm-micro-runtime
+The git submodule points to the latest tagged commit of [WAMR](https://github.com/bytecodealliance/wasm-micro-runtime) we have validated:
+`WAMR-03-30-2020`.
+
+<!-- -------------------------------------------------- -->
+### `WASM_MODE`
+(default: `INTERP`)
+
+`WASM_MODE` indicates the execution mode of the wasm runtime.
+If the variable is set to `INTERP`, the runtime will be
+built to run intepreted wasm bytecode contracts. If the
+variable is set to `INTERP_OPT`, the runtime will be
+built to run the optimized interpreter for wasm bytecode
+contracts. If the variable is set to `AOT`, the runtime will
+be built to run AoT-compiled native wasm contracts.
 
 <!-- -------------------------------------------------- -->
 <!-- -------------------------------------------------- -->


### PR DESCRIPTION
This new WAMR release allows us to enable the optimized WASM interpreter. The default wawaka execution mode is the "classic" un-optimized interpreter. The optimized interpreter mode can be enabled by setting the environment variable `WASM_MODE=INTERP_OPT`