### PR TITLE
Change to address openssl server path reorg

### DIFF
--- a/docker/Dockerfile.pdo-dev
+++ b/docker/Dockerfile.pdo-dev
@@ -138,7 +138,9 @@ RUN git clone --branch ${SGX_SDK} https://github.com/01org/linux-sgx.git \
 
 # ("Untrusted") OpenSSL
 WORKDIR /tmp
-RUN wget https://www.openssl.org/source/openssl-${OPENSSL}.tar.gz
+RUN \
+    OPENSSL_MAJOR_VERSION=$(echo ${OPENSSL} | sed 's/\([^0-9.]\)*//g') \
+  && wget https://www.openssl.org/source/old/${OPENSSL_MAJOR_VERSION}/openssl-${OPENSSL}.tar.gz
 # && tar -zxvf openssl-${OPENSSL}.tar.gz \
 # && cd openssl-${OPENSSL}/ \
 # && ./config \

--- a/docs/host_install.md
+++ b/docs/host_install.md
@@ -131,7 +131,7 @@ SGX SSL install:
 
 ```bash
 cd openssl_source
-wget 'https://www.openssl.org/source/openssl-1.1.0k.tar.gz'
+wget 'https://www.openssl.org/source/old/1.1.0/openssl-1.1.0k.tar.gz'
 cd ..
 ```
 


### PR DESCRIPTION
Openssl released a new version and at same time also reorganized directory structure for older versions.

Note: this does not yet address the necessary changes to work with a new version of SDK, SGXSSL and new LTS version of openssl. This will require bigger changes to docker and install documentation, so will come later 