### PR TITLE
Fix INTERP mode memory corruption in WAMR

### DIFF
--- a/build/tests/wawaka/memory-test.json
+++ b/build/tests/wawaka/memory-test.json
@@ -76,7 +76,7 @@
         "expected":"1000"
     },
     {
-        "description" : "big value test {KeywordParameters}",
+        "description" : "big value test 2 KB",
         "MethodName": "big_value_test",
         "KeywordParameters": {
             "num_chars" : 2000
@@ -84,7 +84,7 @@
         "expected": "2000"
     },
     {
-        "description" : "big value test {KeywordParameters}",
+        "description" : "big value test 4 KB",
         "MethodName": "big_value_test",
         "KeywordParameters": {
             "num_chars" : 4000
@@ -92,7 +92,7 @@
         "expected": "4000"
     },
     {
-        "description" : "big value test {KeywordParameters}",
+        "description" : "big value test 8 KB",
         "MethodName": "big_value_test",
         "KeywordParameters": {
             "num_chars" : 8000
@@ -100,7 +100,7 @@
         "expected": "8000"
     },
     {
-        "description" : "big value test {KeywordParameters}",
+        "description" : "big value test 16 KB",
         "MethodName": "big_value_test",
         "KeywordParameters": {
             "num_chars" : 16000
@@ -108,10 +108,27 @@
         "expected": "16000"
     },
     {
-        "description" : "big value test 64 KB should {invert} with \"out of memory\" exception",
+        "description" : "big value test 32 KB",
+        "MethodName": "big_value_test",
+        "KeywordParameters": {
+            "num_chars" : 32000
+        },
+        "expected": "32000"
+    },
+    {
+        "description" : "big value test 64 KB should {invert} with WAMR \"out of memory\" exception",
         "MethodName": "big_value_test",
         "KeywordParameters": {
             "num_chars" : 64000
+        },
+        "invert": "fail",
+        "expected": "internal pdo error"
+    },
+    {
+        "description" : "big value test 128 KB should {invert} with WAMR \"out of memory\" exception",
+        "MethodName": "big_value_test",
+        "KeywordParameters": {
+            "num_chars" : 128000
         },
         "invert": "fail",
         "expected": "internal pdo error"
@@ -125,7 +142,7 @@
         "expected":"1000"
     },
     {
-        "description" : "big key test {KeywordParameters}",
+        "description" : "big key test 2 KB",
         "MethodName": "big_key_test",
         "KeywordParameters": {
             "num_chars" : 2000
@@ -133,7 +150,7 @@
         "expected": "2000"
     },
     {
-        "description" : "big key test {KeywordParameters}",
+        "description" : "big key test 4 KB",
         "MethodName": "big_key_test",
         "KeywordParameters": {
             "num_chars" : 4000
@@ -141,7 +158,23 @@
         "expected": "4000"
     },
     {
-        "description" : "big key test 32 KB should {invert} with \"out of memory\" exception",
+        "description" : "big key test 8 KB",
+        "MethodName": "big_key_test",
+        "KeywordParameters": {
+            "num_chars" : 8000
+        },
+        "expected": "8000"
+    },
+    {
+        "description" : "big key test 16 KB",
+        "MethodName": "big_key_test",
+        "KeywordParameters": {
+            "num_chars" : 16000
+        },
+        "expected": "16000"
+    },
+    {
+        "description" : "big key test 32 KB should {invert} with WAMR \"out of memory\" exception",
         "MethodName": "big_key_test",
         "KeywordParameters": {
             "num_chars" : 32000
@@ -150,7 +183,7 @@
         "expected": "internal pdo error"
     },
     {
-        "description" : "big key test 64 KB should {invert} with \"out of memory\" exception",
+        "description" : "big key test 64 KB should {invert} with WAMR \"out of memory\" exception",
         "MethodName": "big_key_test",
         "KeywordParameters": {
             "num_chars" : 64000
@@ -191,6 +224,38 @@
         "expected": "4000"
     },
     {
+        "description" : "many keys test 8K",
+        "MethodName": "many_keys_test",
+        "KeywordParameters": {
+            "num_keys" : 8000
+        },
+        "expected": "8000"
+    },
+    {
+        "description" : "many keys test 16K",
+        "MethodName": "many_keys_test",
+        "KeywordParameters": {
+            "num_keys" : 16000
+        },
+        "expected": "16000"
+    },
+    {
+        "description" : "many keys test 32K",
+        "MethodName": "many_keys_test",
+        "KeywordParameters": {
+            "num_keys" : 32000
+        },
+        "expected": "32000"
+    },
+    {
+        "description" : "many keys test 64K",
+        "MethodName": "many_keys_test",
+        "KeywordParameters": {
+            "num_keys" : 64000
+        },
+        "expected": "64000"
+    },
+    {
         "description" : "deep recursion test {KeywordParameters}",
         "MethodName": "deep_recursion_test",
         "KeywordParameters": {
@@ -224,6 +289,15 @@
             "num_chars" : 1000
         },
         "expected": "100000"
+    },
+    {
+        "description" : "many KV pairs test 1K * 1K",
+        "MethodName": "many_kv_pairs_test",
+        "KeywordParameters": {
+            "num_keys" : 1000,
+            "num_chars" : 1000
+        },
+        "expected": "1000000"
     },
     {
         "description" : "deep recursion test {KeywordParameters}",

--- a/common/interpreter/wawaka_wasm/WawakaInterpreter.cpp
+++ b/common/interpreter/wawaka_wasm/WawakaInterpreter.cpp
@@ -142,10 +142,10 @@ void WawakaInterpreter::load_contract_code(
     const std::string& code)
 {
     char error_buf[128];
-    ByteArray binary_code = Base64EncodedStringToByteArray(code);
+    binary_code_ = Base64EncodedStringToByteArray(code);
 
     SAFE_LOG(PDO_LOG_DEBUG, "initialize the wasm interpreter");
-    wasm_module = wasm_runtime_load((uint8*)binary_code.data(), binary_code.size(), error_buf, sizeof(error_buf));
+    wasm_module = wasm_runtime_load((uint8*)binary_code_.data(), binary_code_.size(), error_buf, sizeof(error_buf));
     if (wasm_module == NULL)
         SAFE_LOG(PDO_LOG_CRITICAL, "load failed with error <%s>", error_buf);
 
@@ -262,6 +262,9 @@ int32 WawakaInterpreter::evaluate_function(
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 void WawakaInterpreter::Finalize(void)
 {
+    // Clear the code buffer
+    binary_code_.clear();
+
     // Destroy the environment
     if (wasm_exec_env != NULL)
     {

--- a/common/interpreter/wawaka_wasm/WawakaInterpreter.h
+++ b/common/interpreter/wawaka_wasm/WawakaInterpreter.h
@@ -38,6 +38,7 @@ private:
     wasm_module_t wasm_module = NULL;
     wasm_module_inst_t wasm_module_inst = NULL;
     wasm_exec_env_t wasm_exec_env = NULL;
+    ByteArray binary_code_;
 
     void parse_response_string(
         int32 response_app,


### PR DESCRIPTION
This PR fixes the memory corruption bug due to large KV store values when running wawaka in `WASM_MODE=INTERP`. The test that are now fixed have been added to the memory-test suite.