### PR TITLE
Upgrade wawaka to latest WAMR-04-15-2020 tag

### DIFF
--- a/common/interpreter/wawaka_wasm/README.md
+++ b/common/interpreter/wawaka_wasm/README.md
@@ -47,14 +47,14 @@ source ./emsdk_env.sh
 If wawaka is configured as the contract interpreter, the libraries implementing the WASM interpreter
 will be built for use with Intel SGX. The source for the WAMR interpreter is
 included as a submodule in the interpreters/ folder, and will
-always point to the latest tagged commit that we have validated: `WAMR-03-30-2020`.
+always point to the latest tagged commit that we have validated: `WAMR-04-15-2020`.
 If the PDO parent repo was not cloned with the `--recurse-submodules` flag,
 you will have to explictly pull the submodule source.
 
 ```
 cd ${PDO_SOURCE_ROOT}/interpreters/wasm-micro-runtime
 git submodule update --init
-git checkout WAMR-03-30-2020 # optional
+git checkout WAMR-04-15-2020 # optional
 ```
 
 The WAMR API is built during the Wawaka build, so no additional

--- a/docker/Dockerfile.pdo-build
+++ b/docker/Dockerfile.pdo-build
@@ -26,7 +26,7 @@
 #  - build in debug mode:			PDO_DEBUG_BUILD (default: 0)
 #  - contract interpreter (gipsy or wawaka):	PDO_INTERPRETER (default: gipsy)
 #  - Wawaka runtime mode:			WASM_MODE (default: INTERP)
-#  - wamr version:		                WAMR    (default: WAMR-03-30-2020)
+#  - wamr version:		                WAMR    (default: WAMR-04-15-2020)
 
 # Build:
 #   $ docker build -f docker/Dockerfile.pdo-build -t pdo-build docker
@@ -108,7 +108,7 @@ ENV WASM_MODE=${WASM_MODE}
 
 # - web-assembly/wasm/wawaka
 #   - Configure WAMR source
-ARG WAMR=WAMR-03-30-2020
+ARG WAMR=WAMR-04-15-2020
 RUN cd /project/pdo/src/private-data-objects/interpreters/wasm-micro-runtime \
  && git checkout ${WAMR}\
  && echo "export WASM_SRC=$(pwd)" >> /etc/profile.d/pdo.sh

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -108,7 +108,7 @@ the contract enclave.
 `WASM_SRC` points to the installation of the wasm-micro-runtime. This
 is used to build the WASM interpreter for the wawaka contract interpreter.
 The git submodule points to the latest tagged commit of [WAMR](https://github.com/bytecodealliance/wasm-micro-runtime) we have validated:
-`WAMR-03-30-2020`.
+`WAMR-04-15-2020`.
 
 <!-- -------------------------------------------------- -->
 ### `WASM_MODE`


### PR DESCRIPTION
This PR upgrades our WAMR submodule to the latest 04-15-2020 tag.

Notable updates to WAMR:
- Implement register/call native API with raw arguments
- Make heap and linear memory contiguous to refine compilation time and footprint