### PR TITLE
mallinfo-based LOG_MEMORY define

### DIFF
--- a/common/tests/state/untrusted/test_state_kv.cpp
+++ b/common/tests/state/untrusted/test_state_kv.cpp
@@ -38,6 +38,22 @@ void test_state_kv() {
     size_t test_key_length = TEST_KEY_STRING_LENGTH;
     ByteArray id;
 
+//################ TEST LOG MEMORY ####################################################################################
+    try
+    {
+        LOG_MEMORY;
+        pstate::State_KV skv(state_encryption_key_);
+        LOG_MEMORY;
+        kv_ = &skv;
+        kv_->Finalize(id);
+        kv_ = NULL;
+    }
+    catch (...)
+    {
+        SAFE_LOG(PDO_LOG_ERROR, "error testing LOG_MEMORY");
+        throw;
+    }
+
 //################ TEST PUT ###########################################################################################
     try
     {


### PR DESCRIPTION
This PR provides a useful tool for fine-grained memory usage tracking.
It leverages
* the standard `mallinfo` function in the untrusted environment, and 
* the `dlmallinfo` function in the trusted environment, which is available in the SGX SDK.

Signed-off-by: Bruno Vavala <bruno.vavala@intel.com>