### PR TITLE
Add some functions to simplify contract building with wawaka

### DIFF
--- a/contracts/wawaka/common/StringArray.cpp
+++ b/contracts/wawaka/common/StringArray.cpp
@@ -16,8 +16,6 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <stdio.h>
-
 #include "StringArray.h"
 #include "WasmExtensions.h"
 
@@ -183,6 +181,15 @@ bool StringArray::equal(const StringArray& sarray) const
         return false;
 
     return (memcmp(value_, sarray.value_, size_) == 0);
+}
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+bool StringArray::null_terminated(void) const
+{
+    if (value_ == NULL || size_ == 0)
+        return false;
+
+    return (value_[size_ - 1] == 0);
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/contracts/wawaka/common/StringArray.h
+++ b/contracts/wawaka/common/StringArray.h
@@ -15,6 +15,9 @@
 
 #pragma once
 
+#include <stdint.h>
+#include <string.h>
+
 class StringArray
 {
 public:
@@ -35,6 +38,7 @@ public:
     bool set(uint8_t v, size_t p);
     bool take(uint8_t* buffer, size_t size);
     bool equal(const StringArray& sarray) const;
+    bool null_terminated(void) const;
 
     const size_t size(void) const;
     uint8_t* data(void);

--- a/contracts/wawaka/common/Util.h
+++ b/contracts/wawaka/common/Util.h
@@ -1,0 +1,22 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#define ASSERT_SENDER_IS_OWNER(_env, _rsp)                              \
+    do {                                                                \
+        if (strcmp(_env.creator_id_, _env.originator_id_) != 0)         \
+            return _rsp.error("only the owner may invoke this method"); \
+    } while (0)

--- a/contracts/wawaka/common/Value.cpp
+++ b/contracts/wawaka/common/Value.cpp
@@ -34,8 +34,17 @@ ww::value::Value::Value(void)
 // -----------------------------------------------------------------
 ww::value::Value::~Value(void)
 {
+    clear_value();
+}
+
+// -----------------------------------------------------------------
+void ww::value::Value::clear_value(void)
+{
     if (value_ != NULL)
+    {
         json_value_free(value_);
+        value_ = NULL;
+    }
 }
 
 // -----------------------------------------------------------------
@@ -53,8 +62,7 @@ const JSON_Value* ww::value::Value::get(void) const
 // -----------------------------------------------------------------
 const JSON_Value* ww::value::Value::set(const JSON_Value *value)
 {
-    if (value_ != NULL)
-        json_value_free(value_);
+    clear_value();
 
     if (value == NULL) {
         value_ = json_value_init_null();
@@ -75,20 +83,55 @@ bool ww::value::Value::deserialize(const char* value)
 
     JSON_Value* json_value = json_parse_string(value);
     if (json_value == NULL)
+    {
+        CONTRACT_SAFE_LOG(3, "value deserialize; failed to parse json string; %s", value);
         return false;
+    }
 
     // this forces a bit of correctness checking on JSON lookups in that
     // the incoming value object has to match the one in the object
     if (json_value_get_type(json_value) != expected_value_type_)
     {
+        CONTRACT_SAFE_LOG(3, "value deserialize; type mismatch on objects");
         free(json_value);
         return false;
     }
 
+    clear_value();
+
     value_ = json_value;
-    expected_value_type_ = (value_ == NULL ? JSONError : json_value_get_type(value_));
+    expected_value_type_ = json_value_get_type(value_);
 
     return true;
+}
+
+// -----------------------------------------------------------------
+bool ww::value::Value::serialize(StringArray& result) const
+{
+    if (value_ == NULL)
+    {
+        CONTRACT_SAFE_LOG(1, "failed serialization; no value");
+        return false;
+    }
+
+    // serialize the result
+    size_t serialized_size = json_serialization_size(value_);
+    char *serialized_response = (char *)malloc(serialized_size + 1);
+    if (serialized_response == NULL)
+    {
+        CONTRACT_SAFE_LOG(1, "failed serialization; failed allocation");
+        return false;
+    }
+
+    JSON_Status jret = json_serialize_to_buffer(value_, serialized_response, serialized_size + 1);
+    if (jret != JSONSuccess)
+    {
+        CONTRACT_SAFE_LOG(1, "failed serialization; invalid value");
+        free(serialized_response);
+        return false;
+    }
+
+    return result.take((uint8_t*)serialized_response, serialized_size+1);
 }
 
 // -----------------------------------------------------------------
@@ -98,11 +141,15 @@ char* ww::value::Value::serialize(void) const
     size_t serialized_size = json_serialization_size(value_);
     char *serialized_response = (char *)malloc(serialized_size + 1);
     if (serialized_response == NULL)
+    {
+        CONTRACT_SAFE_LOG(1, "failed serialization; failed allocation");
         return NULL;
+    }
 
     JSON_Status jret = json_serialize_to_buffer(value_, serialized_response, serialized_size + 1);
     if (jret != JSONSuccess)
     {
+        CONTRACT_SAFE_LOG(1, "failed serialization; invalid value");
         free(serialized_response);
         return NULL;
     }
@@ -117,6 +164,8 @@ char* ww::value::Value::serialize(void) const
 // -----------------------------------------------------------------
 ww::value::Boolean::Boolean(const bool value)
 {
+    clear_value();
+
     value_ = json_value_init_boolean(value);
     expected_value_type_ = (value_ == NULL ? JSONError : json_value_get_type(value_));
 }
@@ -130,8 +179,7 @@ bool ww::value::Boolean::get(void) const
 // -----------------------------------------------------------------
 bool ww::value::Boolean::set(bool value)
 {
-    if (value_ != NULL)
-        json_value_free(value_);
+    clear_value();
 
     value_ = json_value_init_boolean(value);
     expected_value_type_ = (value_ == NULL ? JSONError : json_value_get_type(value_));
@@ -146,6 +194,8 @@ bool ww::value::Boolean::set(bool value)
 // -----------------------------------------------------------------
 ww::value::String::String(const char* value)
 {
+    clear_value();
+
     value_ = json_value_init_string(value);
     expected_value_type_ = (value_ == NULL ? JSONError : json_value_get_type(value_));
 }
@@ -159,8 +209,7 @@ const char* ww::value::String::get(void) const
 // -----------------------------------------------------------------
 const char* ww::value::String::set(const char* value)
 {
-    if (value_ != NULL)
-        json_value_free(value_);
+    clear_value();
 
     value_ = json_value_init_string(value);
     expected_value_type_ = (value_ == NULL ? JSONError : json_value_get_type(value_));
@@ -175,8 +224,10 @@ const char* ww::value::String::set(const char* value)
 // -----------------------------------------------------------------
 ww::value::Number::Number(const double value)
 {
+    clear_value();
+
     value_ = json_value_init_number(value);
-    expected_value_type_ = json_value_get_type(value_);
+    expected_value_type_ = (value_ == NULL ? JSONError : json_value_get_type(value_));
 }
 
 // -----------------------------------------------------------------
@@ -188,8 +239,7 @@ double ww::value::Number::get(void) const
 // -----------------------------------------------------------------
 double ww::value::Number::set(double value)
 {
-    if (value_ != NULL)
-        json_value_free(value_);
+    clear_value();
 
     value_ = json_value_init_number(value);
     expected_value_type_ = (value_ == NULL ? JSONError : json_value_get_type(value_));
@@ -204,9 +254,20 @@ double ww::value::Number::set(double value)
 // -----------------------------------------------------------------
 ww::value::Object::Object(void)
 {
+    clear_value();
+
     value_ = json_value_init_object();
     expected_value_type_ = (value_ == NULL ? JSONError : json_value_get_type(value_));
 }
+
+ww::value::Object::Object(const ww::value::Object& source)
+{
+    clear_value();
+
+    value_ = json_value_deep_copy(source.value_);
+    expected_value_type_ = (value_ == NULL ? JSONError : json_value_get_type(value_));
+}
+
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 const char* ww::value::Object::get_string(const char* key) const
@@ -250,16 +311,80 @@ bool ww::value::Object::set_value(const char* name, const ww::value::Value& valu
 
     JSON_Value *json_value = json_value_deep_copy(value.get());
     if (json_value == NULL)
+    {
+        CONTRACT_SAFE_LOG(1, "object set value; allocation failed");
         return false;
+    }
 
     if (json_object_set_value(json_object(value_), name, json_value) != JSONSuccess)
     {
+        CONTRACT_SAFE_LOG(1, "object set value; failed to save property %s", name);
         free(json_value);
         return false;
     }
 
     return true;
 }
+
+// -----------------------------------------------------------------
+bool ww::value::Object::validate_schema(const ww::value::Value& schema) const
+{
+    JSON_Status result = json_validate(schema.get(), value_);
+    return result == JSONSuccess;
+}
+
+// -----------------------------------------------------------------
+bool ww::value::Object::validate_schema(const char* schema) const
+{
+    ww::value::Object parsed_schema;
+    if (! parsed_schema.deserialize(schema))
+    {
+        CONTRACT_SAFE_LOG(3, "validate schema; failed to parse schema <%s>", schema);
+        return false;
+    }
+
+    return validate_schema(parsed_schema);
+}
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// Class: ww::value::Structure
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+// -----------------------------------------------------------------
+ww::value::Structure::Structure(const char* schema)
+{
+    clear_value();
+
+    if (! deserialize(schema))
+    {
+        CONTRACT_SAFE_LOG(1, "structure constructor; failed to parse the schema <%s>", schema);
+    }
+}
+
+// -----------------------------------------------------------------
+bool ww::value::Structure::set_value(const char* name, const ww::value::Value& value)
+{
+    // for a structure, the value we are assignment must already exist in the
+    // object and the type must match
+    const JSON_Value *json_value = json_object_get_value(json_object(value_), name);
+    if (json_value == NULL)
+    {
+        CONTRACT_SAFE_LOG(4, "key %s does not exist in the structure", name);
+        return false;
+    }
+
+    // this forces a bit of correctness checking on JSON lookups in that
+    // the incoming value object has to match the one in the object
+    if (json_value_get_type(json_value) != value.get_type())
+    {
+        CONTRACT_SAFE_LOG(4, "value type mismatch in structure, %d != %d",
+                          json_value_get_type(json_value), value.get_type());
+        return false;
+    }
+
+    return ww::value::Object::set_value(name, value);
+}
+
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // Class: ww::value::Array
@@ -268,6 +393,8 @@ bool ww::value::Object::set_value(const char* name, const ww::value::Value& valu
 // -----------------------------------------------------------------
 ww::value::Array::Array(void)
 {
+    clear_value();
+
     value_ = json_value_init_array();
     expected_value_type_ = (value_ == NULL ? JSONError : json_value_get_type(value_));
 }

--- a/contracts/wawaka/common/Value.h
+++ b/contracts/wawaka/common/Value.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "parson.h"
+#include "StringArray.h"
 
 namespace ww
 {
@@ -25,6 +26,8 @@ namespace value
     {
         // storage associated value_ is owned by this value and must be free'd
     protected:
+        void clear_value(void);
+
         JSON_Value_Type expected_value_type_;
         JSON_Value *value_;
 
@@ -33,11 +36,14 @@ namespace value
         ~Value(void);
 
         char *serialize(void) const;
+        bool serialize(StringArray& result) const;
         bool deserialize(const char *message);
 
         JSON_Value_Type get_type(void) const;
         const JSON_Value* get(void) const;
         const JSON_Value* set(const JSON_Value *value);
+
+        bool is_null(void) const { return value_ == NULL; };
     };
 
     class Boolean : public Value
@@ -68,6 +74,7 @@ namespace value
     {
     public:
         Object(void);
+        Object(const Object& source);
 
         const char* get_string(const char* key) const;
         double get_number(const char* key) const;
@@ -78,6 +85,19 @@ namespace value
         //bool set_string(const char* name, const char* value);
         //bool set_number(const char* name, const double value);
         //bool set_boolean(const char* name, const bool value);
+        bool set_value(const char* name, const Value& value);
+
+        // pass in a schema object, true if the value has the same
+        // structure as the schema object
+        bool validate_schema(const Value& schema) const;
+        bool validate_schema(const char* schema) const;
+    };
+
+    class Structure : public Object
+    {
+    public:
+        Structure(const char* schema);
+
         bool set_value(const char* name, const Value& value);
     };
 


### PR DESCRIPTION
Add method to validate structures, especially useful for
validating parameters to a method.

Fixes a bug where json_free may have been called twice
on a value. This may be the cause of the memory error
@masomel saw with clang.

Signed-off-by: Mic Bowman <cmickeyb@gmail.com>