### PR TITLE
Upgrade to SGX 2.10 plus some ubuntu version clean-up

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+build/_dev/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,9 @@ env:
   matrix:
     # parallelize builds for the different interpreters
     - PDO_INTERPRETER=gipsy
-    - PDO_INTERPRETER=wawaka
-    - PDO_INTERPRETER=wawaka-opt
+    # TODO: Re-enable below once wawaka builds again with standard (non-fastcomp) emsdk backend
+    #- PDO_INTERPRETER=wawaka
+    #- PDO_INTERPRETER=wawaka-opt
 
 before_install:
 

--- a/docker/Dockerfile.pdo-build
+++ b/docker/Dockerfile.pdo-build
@@ -17,7 +17,6 @@
 #   Build Private Data Objects.
 #
 #  Configuration (build) paramaters
-#  - proxy configuration: 			https_proxy http_proxy ftp_proxy  (default: undefined)
 #  - base image with pdo dev environ: 		PDO_DEV_IMAGE (default: pdo-dev)
 #    (presumably built from Dockerfile.pde-dev)
 #  - sgx-mode:					SGX_MODE (default: SIM)
@@ -29,13 +28,12 @@
 
 # Build:
 #   $ docker build -f docker/Dockerfile.pdo-build -t pdo-build docker
-#   if behind a proxy, you might want to add also below options
-#   --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy --build-arg ftp_proxy=$ftp_proxy
-#   if you want to build with different version than from pdo-dev, add a build arg PDO_DEV_IMAGE e.g., --build-arg PDO_DEV_IMAGE=pdo-build-xenial
-#   similarly, add --build-arg for any of the other above-listed configuration parameters
-#   if you want to build with the source locally commented, then use root-directory of
-#   source tree as context directory and add '--build-arg PDO_REPO_URL=file:///tmp/build-src/.git', e.g.,
+#   - if you want to build with different version than from pdo-dev, add a build arg PDO_DEV_IMAGE e.g., --build-arg PDO_DEV_IMAGE=pdo-build-xenial
+#     similarly, add --build-arg for any of the other above-listed configuration parameters
+#   - if you want to build with the source locally committed, then use root-directory of
+#     source tree as context directory and add '--build-arg PDO_REPO_URL=file:///tmp/build-src/.git', e.g.,
 #      docker build -f docker/Dockerfile.pdo-dev -t pdo-build --build-arg PDO_REPO_URL=file:///tmp/build-src/.git .
+#   - if you are behind a proxy, see the comments in Dockerfile.pdo-dev
 #
 # Run:
 #   $ cd <directory where you checked out private-data-objects>
@@ -45,8 +43,6 @@
 #     add options '--device=/dev/isgx -v /var/run/aesmd:/var/run/aesmd ')
 #     Note: your host SGX PSW runtime should be at a similar level than the one in the container
 #     or the PSW/aesmd might cause enclave launch problems
-#   - if behind a proxy, you might want to add also below options
-#     --env https_proxy=$https_proxy --env http_proxy=$http_proxy --env ftp_proxy=$ftp_proxy
 #   - Regardless of SGX_MODE, we build with the default fake SGX values and some
 #     default PDO_LEDGER_URL (http://rest-api:8008). If these are different at runtime, e.g.,
 #     because the ledger changes and/or you run in SGX HW mode and your sgx keys are at a
@@ -62,6 +58,7 @@
 #     '--security-opt seccomp=unconfined --security-opt apparmor=unconfined --cap-add=SYS_PTRACE '
 #   - for develooping based on source in host you might map source into container with an option
 #     like -v $(pwd):/project/pdo/src/private-data-objects/
+#   - if you are behind a proxy, see the comments in Dockerfile.pdo-dev
 #
 
 ARG PDO_DEV_IMAGE=pdo-dev

--- a/docker/Dockerfile.pdo-dev
+++ b/docker/Dockerfile.pdo-dev
@@ -213,8 +213,8 @@ RUN mkdir -p /project/pdo/wasm/src \
  && cd /project/pdo/wasm/src \
  && git clone https://github.com/emscripten-core/emsdk.git \
  && cd emsdk \
- && ./emsdk install latest-fastcomp \
- && ./emsdk activate latest-fastcomp \
+ && ./emsdk install latest \
+ && ./emsdk activate latest \
  && echo 'cd /project/pdo/wasm/src/emsdk/; if [ -z "$BASH_SOURCE" ]; then BASH_SOURCE=./emsdk_env.sh; . ./emsdk_env.sh; unset BASH_SOURCE; else . ./emsdk_env.sh; fi' >> /etc/profile.d/pdo.sh
 # Note: above convoluted BASH_SOURCE hack is necessary as (a) emsdk_env.sh 
 #       assumes we run in bash but (b) as we build we actually run in sh

--- a/docker/Dockerfile.pdo-dev
+++ b/docker/Dockerfile.pdo-dev
@@ -17,18 +17,20 @@
 #   Builds the environment with all prerequistes needed to build Private Data Objects.
 #
 #  Configuration (build) paramaters
-#  - proxy configuration: 	https_proxy http_proxy ftp_proxy, no_proxy  (default: undefined)
-#  - ubuntu base image to use: 	UBUNTU_VERSION (default: 18.04-server)
-#  - sgx sdk version: 		SGXSDK (default: 2.9.1)
-#  - openssl version: 		OPENSSL (default: 1.1.1d)
-#  - sgxssl version: 		SGXSSL  (default: 2.9_1.1.1d)
-#  - additional apt packages:	ADD_APT_PKGS (default: )
+#  - ubuntu version to use: 	  UBUNTU_VERSION (default: 18.04)
+#  - ubuntu name to use: 	  UBUNTU_NAME (default: bionic)
+#  - sgx sdk/psw version: 	  SGX (default: 2.10)
+#  - openssl version: 		  OPENSSL (default: 1.1.1g)
+#  - sgxssl version: 		  SGXSSL  (default: 2.10_1.1.1g)
+#  - additional apt packages:	  ADD_APT_PKGS (default: )
 
 # Build:
 #   $ docker build docker -f docker/Dockerfile.pdo-dev -t pdo-dev
-#   if behind a proxy, you might want to add also below options
-#   --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy --build-arg ftp_proxy=$ftp_proxy --build-arg=$no_proxy
-#   if you want to build with different version than 16.04/xenial, add a build arg UBUNTU_VERSION, e.g., for 18.04 do --build-arg UBUNTU_VERSION=bionic
+#   - if you want to build with different version than 18.04/bionic, say 20.04/focal, 
+#     add --build-arg UBUNTU_VERSION=18.04  --build-arg UBUNTU_NAME=focal
+#   - if behind a proxy, make sure you've configured ~/.docker/config.json with your proxy setting
+#     and the docker daemon itself also has the proxy properly configured, for systemd based hosts
+#     like ubuntu see https://docs.docker.com/config/daemon/systemd/#httphttps-proxy
 #
 # Run:
 #   $ cd <directory where you checked out private-data-objects>
@@ -40,26 +42,30 @@
 #     etc etc
 #     Note: your host SGX PSW runtime should be at a similar level than the one in the container
 #     or the PSW/aesmd might cause enclave launch problems
-#   - if behind a proxy, you might want to add also below options
-#     --env https_proxy=$https_proxy --env http_proxy=$http_proxy --env ftp_proxy=$ftp_proxy --env no_proxy=$no_proxy
+#   - if behind a proxy, make sure you've configured ~/.docker/config.json with your proxy setting
 #   - if you want to debug with gdb and alike, you also might want to add options
 #     '--security-opt seccomp=unconfined --security-opt apparmor=unconfined --cap-add=SYS_PTRACE '
 #   - for develooping based on source in host you might map source into container with an option
 #     like -v $(pwd):/project/pdo/src/private-data-objects/
 
 ARG UBUNTU_VERSION=18.04
-# 16.04 -> xenial, 17.10 -> artful, 18.04 -> bionic
-# NOTE: xenial might not work anymore (see below), preferred choice is bionic ..
+ARG UBUNTU_NAME=bionic
+# NOTE: 
+# - unfortunately, we do need both name (for repo) and version (for sgx directories), only docker image supports both ..
+#   18.04 <-> bionic, 20.04 <-> focal
+# - right now, full sgx support exists only for bionic; 
+#   xenial (16.04) has support only PSW but not SDK; 
+#   support for focal is still in the making but hopefully will exist soon...
 
 FROM ubuntu:${UBUNTU_VERSION}
 
-ARG UBUNTU_VERSION=18.04-server
-# for bizare docker reason, we have to redefine it here ...
+# Dockerfile limitations force a repetition of global args
+ARG UBUNTU_VERSION
+ARG UBUNTU_NAME
 
-ARG SGXSDK=2.9.1
-ARG SDKBIN=2.9.101.2
-ARG OPENSSL=1.1.1d
-ARG SGXSSL=2.9_1.1.1d
+ARG SGX=2.10
+ARG OPENSSL=1.1.1g
+ARG SGXSSL=2.10_1.1.1g
 
 ARG ADD_APT_PKGS=
 
@@ -67,7 +73,9 @@ ARG ADD_APT_PKGS=
 # TODO(xenial): we need to manually install protobuf 3 as xenial has v2
 # Note: ocamlbuild is required by PREREQ but does not exist for xenial. However, the relevant componets are part of 'ocaml' package, later ubuntu split up that package ...
 RUN apt-get update \
- && apt-get install -y -q\
+ && DEBIAN_FRONTEND="noninteractive" \
+  # above makes sure any install of 'tzdata' or alike (as e.g., pulled in via ubuntu 20.04) does not hang ...
+  apt-get install -y -q\
     autoconf \
     automake \
     build-essential \
@@ -80,10 +88,12 @@ RUN apt-get update \
     libcurl4-openssl-dev \
     liblmdb-dev \
     libprotobuf-dev \
+    libsecp256k1-dev \
     libssl-dev \
     libtool \
     make \
     ocaml \
+    ocamlbuild \
     pkg-config \
     protobuf-compiler \
     python \
@@ -96,10 +106,8 @@ RUN apt-get update \
     unzip \
     virtualenv \
     wget \
+    xxd \
     $ADD_APT_PKGS \
- && if [ "$UBUNTU_VERSION" = "18.04-server" ] || [ "$UBUNTU_VERSION" = "17.10" ]; then \
-	apt-get install -y -q libsecp256k1-dev ocamlbuild xxd; \
-    fi \
  && apt-get -y -q upgrade \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
@@ -111,67 +119,81 @@ RUN apt-get update \
 #   also does not work as it is not always called
  && sed -i '1s;^;. /etc/profile.d/pdo.sh\n;' /etc/bash.bashrc
 
+# Install SGX PSW packages
+RUN echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu ${UBUNTU_NAME} main" >> /etc/apt/sources.list \
+ && wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add - \
+ && apt-get update \
+ && apt-get install -y \
+    # We do not need daemons like AESMD as we run them on host (side-steps also
+    # issues with config of /etc/aesmd.conf like proxy ..). Without this option
+    # aesmd and lots of other plugsin are automatically pulled in. 
+    # See SGX Installation notes and, in particular, linux/installer/docker/Dockerfile
+    # in linux-sgx git repo of sdk/psw source. 
+    --no-install-recommends \
+    # - dependencies
+      build-essential python \
+    # - sgx packages
+    #   - runtime
+      libsgx-urts \
+    # (also pulls in libsgx-enclave-common)
+    #   - basic architectural services, e.g., launch & attestation
+      # sgx-aesm-service (see above why commented out)
+      libsgx-uae-service
+      # Note: 
+      # - above is "old" style from epid days. Since sdk 2.7 libsgx-uae-service is
+      #   split into subpackages
+      #   - launch service
+      #     libsgx-launch 
+      #   - algorithm agnostic attestation service
+      #     libsgx-quote-ex 
+      #   - EPID-based attestation service 
+      #     libsgx-epid 
+      #   - DCAP-based attesation service
+      #     libsgx-dcap* ...
+      #   correspondingly, also libsgx_uae_service.so and <sgx_uae_service.h>
+      #   is split into corresponding smaller libraries and header-files to make
+      #   integration with DCAP easier and minimize pulling in unnecessary dependencies
+
 # Install SGX SDK
-# we install from source as with binary distribution it's difficult to get library dependencies correct
-# and work-around the somewhat hacky way we have to install PSW (where we really only need the rts libs
-# but not the aesmd service which we assume to run in the host)
-# Notes:
-# - to make PSW installer work we have to
-#   - disable test for presence of kernel modules (as during build we are not really seeing them)
-#   - skip install and configure of aesmd service
-# - install before openssl as this might cause additional trouble
-
-RUN echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' >> /etc/apt/sources.list
-RUN wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add -
-RUN apt-get update
-
-# Install PSW packages
-RUN apt-get install -y \
-# - dependencies
-   build-essential python \
-# - sgx packages
-  libsgx-enclave-common sgx-aesm-service \
-# -> do not really need aesmd, there is now some option
-# by which we can prevent installing aesmd ..
-# proxy config?!
-# additional packages
-# - launch service
-  libsgx-launch libsgx-urts \
-# - EPID-based attestation service
-  libsgx-epid \
-# - algorithm agnostic attestation service
-  libsgx-quote-ex \
-# - untrusted architectural enclave (AE) service; needed for HW mode
-  libsgx-uae-service
-
 RUN mkdir -p /opt/intel
 WORKDIR /opt/intel
-RUN wget -q https://download.01.org/intel-sgx/sgx-linux/${SGXSDK}/distro/ubuntu${UBUNTU_VERSION}/sgx_linux_x64_sdk_${SDKBIN}.bin && \
-    chmod +x sgx_linux_x64_sdk_${SDKBIN}.bin && \
-    echo -e "no\n/opt/intel" | ./sgx_linux_x64_sdk_${SDKBIN}.bin
-RUN echo ". /opt/intel/sgxsdk/environment" >> /etc/profile.d/pdo.sh
+RUN SGX_SDK_BIN_REPO=https://download.01.org/intel-sgx/sgx-linux/${SGX}/distro/ubuntu${UBUNTU_VERSION}-server \
+  && SGX_SDK_BIN_FILE=$(cd /tmp; wget --spider --recursive --level=1 --no-parent ${SGX_SDK_BIN_REPO} 2>&1 | perl  -ne 'if (m|'${SGX_SDK_BIN_REPO}'/(sgx_linux_x64_sdk.*)|) { print "$1\n"; }') \
+  && wget -q ${SGX_SDK_BIN_REPO}/${SGX_SDK_BIN_FILE} \
+  && chmod +x ${SGX_SDK_BIN_FILE} \
+  && echo -e "no\n/opt/intel" | ./${SGX_SDK_BIN_FILE} \
+  && rm ${SGX_SDK_BIN_FILE} \
+  && echo ". /opt/intel/sgxsdk/environment" >> /etc/profile.d/pdo.sh
 
-# LVI mitigations, needed to compile sgxssl requires a
+# LVI mitigations, needed to compile sgxssl, requires a
 #   recent version of binutils (>= 2.32). Ubuntu 18.04 only
 #   has 2.30 but Intel ships binary distro for 2.32.51.20190719
-RUN wget -q https://download.01.org/intel-sgx/sgx-linux/${SGXSDK}/as.ld.objdump.gold.r1.tar.gz
-RUN mkdir sgxsdk.extras && \
-    cd sgxsdk.extras && \
-    tar -zxf ../as.ld.objdump.gold.r1.tar.gz
-RUN echo "export PATH=/opt/intel/sgxsdk.extras/external/toolset:${PATH}" >> /etc/profile.d/pdo.sh
-ENV PATH="/opt/intel/sgxsdk.extras/external/toolset:${PATH}"
+RUN [ "$UBUNTU_VERSION" = "18.04" ] \
+  && SGX_SDK_BINUTILS_REPO=https://download.01.org/intel-sgx/sgx-linux/${SGX} \
+  && SGX_SDK_BINUTILS_FILE=$(cd /tmp; wget --spider --recursive --level=1 --no-parent ${SGX_SDK_BINUTILS_REPO} 2>&1 | perl  -ne 'if (m|'${SGX_SDK_BINUTILS_REPO}'/(as.ld.objdump.*)|) { print "$1\n"; }') \
+  && wget -q ${SGX_SDK_BINUTILS_REPO}/${SGX_SDK_BINUTILS_FILE} \
+  && mkdir sgxsdk.extras \
+  && cd sgxsdk.extras \
+  && tar -zxf ../${SGX_SDK_BINUTILS_FILE} \
+  && rm ../${SGX_SDK_BINUTILS_FILE} \
+  && echo "export PATH=/opt/intel/sgxsdk.extras/external/toolset/ubuntu${UBUNTU_VERSION}:${PATH}" >> /etc/profile.d/pdo.sh
+# Note: above install file contains binutitls for all supported distros. 
+#   So to same some space (~100m) & make smaller images one could delete
+#   all subdirectores other than ${UBUNTU_VERSION} ...
+ENV PATH="/opt/intel/sgxsdk.extras/external/toolset/ubuntu${UBUNTU_VERSION}:${PATH}"
 
 # SGXSSL
-RUN git clone 'https://github.com/intel/intel-sgx-ssl.git'
-RUN cd intel-sgx-ssl && \
-    . /opt/intel/sgxsdk/environment && \
-    git checkout lin_${SGXSSL} && \
-    cd openssl_source && \
-    wget -q https://www.openssl.org/source/openssl-${OPENSSL}.tar.gz && \
-    cd ../Linux && \
-    make SGX_MODE=SIM DESTDIR=/opt/intel/sgxssl all test && \
-    make install
-RUN echo "export SGX_SSL=/opt/intel/sgxssl" >> /etc/profile.d/pdo.sh
+RUN git clone 'https://github.com/intel/intel-sgx-ssl.git' \
+  && cd intel-sgx-ssl \
+  && . /opt/intel/sgxsdk/environment \
+  && git checkout lin_${SGXSSL} \
+  && cd openssl_source \
+  && wget -q https://www.openssl.org/source/openssl-${OPENSSL}.tar.gz \
+  && cd ../Linux \
+  && make SGX_MODE=SIM DESTDIR=/opt/intel/sgxssl all test \
+  && make install \
+  && make clean \
+  && echo "export SGX_SSL=/opt/intel/sgxssl" >> /etc/profile.d/pdo.sh
 
 # Install contract interpreter related stuff
 
@@ -195,7 +217,7 @@ RUN mkdir -p /project/pdo/wasm/src \
  && ./emsdk activate latest-fastcomp \
  && echo 'cd /project/pdo/wasm/src/emsdk/; if [ -z "$BASH_SOURCE" ]; then BASH_SOURCE=./emsdk_env.sh; . ./emsdk_env.sh; unset BASH_SOURCE; else . ./emsdk_env.sh; fi' >> /etc/profile.d/pdo.sh
 # Note: above convoluted BASH_SOURCE hack is necessary as (a) emsdk_env.sh 
-#   assumes we run in bash but (b) as we build we actually run in sh
+#       assumes we run in bash but (b) as we build we actually run in sh
 
 # environment setup as required by PDO
 # Note

--- a/docker/Dockerfile.pdo-tp
+++ b/docker/Dockerfile.pdo-tp
@@ -19,25 +19,20 @@
 #    only 18.04 we need a separate container from the main PDO container pdo-build)
 #
 #  Configuration (build) paramaters
-#  - proxy configuration:               https_proxy http_proxy ftp_proxy  (default: undefined)
 #  - pdo repo to use:                   PDO_REPO_URL  (default: https://github.com/hyperledger-labs/private-data-objects.git)
 #  - pdo repo branch to use:            PDO_REPO_BRANCH (default: master)
 
 # Build:
 #   $ docker build -f docker/Dockerfile.pdo-tp -t pdo-tp docker
-#   if behind a proxy, you might want to add also below options
-#   --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy --build-arg ftp_proxy=$ftp_proxy
-#   if you want to build with the source locally commented, then use root-directory of
-#   source tree as context directory and add '--build-arg PDO_REPO_URL=file:///tmp/build-src/.git', e.g.,
+#   - if you want to build with the source locally committed, then use root-directory of
+#    source tree as context directory and add '--build-arg PDO_REPO_URL=file:///tmp/build-src/.git', e.g.,
 #      docker build -f docker/Dockerfile.pdo-dev -t pdo-build --build-arg PDO_REPO_URL=file:///tmp/build-src/.git .
+#   - if you are behind a proxy, see the comments in Dockerfile.pdo-dev
 #
 # Run:
 #   $ cd ....../private-datdda-objects
 #   $ docker run -it pdo-tp
-#   Notes:
-#   - if behind a proxy, you might want to add also below options
-#     --env https_proxy=$https_proxy --env http_proxy=$http_proxy --env ftp_proxy=$ftp_proxy
-#
+#   - if you are behind a proxy, see the comments in Dockerfile.pdo-dev
 
 # Get source of PDO
 # to allow using local development branch we copy whatever docker directory is passed

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -28,19 +28,15 @@ ifeq ($(SGX_MODE),HW)
    DOCKER_COMPOSE_COMMAND := env SGX_DEVICE_PATH=${SGX_DEVICE_PATH} ${DOCKER_COMPOSE_COMMAND}
 endif
 ifdef http_proxy
-   DOCKER_BUILD_OPTS += --build-arg http_proxy=${http_proxy}
    DO_PROXY = 1
 endif
 ifdef https_proxy
-   DOCKER_BUILD_OPTS += --build-arg https_proxy=${https_proxy}
    DO_PROXY = 1
 endif
 ifdef ftp_proxy
-   DOCKER_BUILD_OPTS += --build-arg ftp_proxy=${ftp_proxy}
    DO_PROXY = 1
 endif
 ifdef no_proxy
-   DOCKER_BUILD_OPTS += --build-arg no_proxy=${no_proxy}
    DO_PROXY = 1
 endif
 ifdef DO_PROXY

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -50,17 +50,24 @@ DOCKER_COMPOSE_OPTS += $(foreach cf, $(DOCKER_COMPOSE_FILES), -f $(cf))
 all:
 
 pdo-dev-image:
-	# sparse lmdb files cause docker to run out of disk space. As we include ..
-	# as git root for build of pdo-build docker file, we should  not have run tests
-	# inside the default build location
-	if [ -x ../build/_dev/opt/pdo/data ]; then \
-		echo -e "\n\nWARNING: you have a local "bare-metal" build in ../build/_dev. If that includes lmdb-files, below docker-compose might run out of disk space!!\n\n"; \
-	fi
 	# unconditionally build, count on docker caching to not rebuild if not necessary
 	docker build $(DOCKER_BUILD_OPTS) -f Dockerfile.pdo-dev -t pdo-dev .
 
 pdo-composition: pdo-dev-image
 	env PDO_REPO_BRANCH=$$(git rev-parse --abbrev-ref HEAD) $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS) build
+	# Note:
+	# - using `sawtooth-pdo.local-code.yaml` in above will cause the docker context to be `../`.
+	#   To make sure that we do not pull in (too much) unnecessary stuff, we explicitly excludes 
+	#   various files/dirs in `../.dockerignore`.
+	#   There are two negative effect for not excluding enough
+	#   - if some non-essential file changed (e.g., build artificats on host which are
+	#     all not needed in docker), docker caching might not work well and docker will rebuild
+	#     layers even though it could have cached (and hence run faster).
+	#   - the the build-time layer will become unecessarily big (note: as we do multi-stage, the size of
+	#     of the built container image should not be affected). This is in particular an issue with lmdb
+	#     files which are created by tests in default location ../build/_dev. These files are
+	#     sparse but docker expands to them to their nominal size (several gb) and could cause
+	#     running out of disk space during the build...
 
 test: pdo-composition test-with-no-build
 

--- a/docker/sawtooth-pdo.proxy.yaml
+++ b/docker/sawtooth-pdo.proxy.yaml
@@ -18,7 +18,8 @@
 # https_proxy and no_proxy defined
 # Note: for vanilla docker >=17.07 you can define proxy in ~/.docker/config.json 
 # (see https://docs.docker.com/network/proxy/) but this seems to be ignored by
-# docker-compose ...
+# docker-compose installed in docker-compose versions in ubuntu 18.04. Later
+# versions, e.g., the one in 20.04, will honor that and will make this file obsolete ..
 
 version: "2.1"
 
@@ -26,11 +27,6 @@ services:
 
   # PDO EHS, PS and client ...
   pdo-build:
-    build:
-      args:
-        http_proxy: ${http_proxy}
-        https_proxy: ${https_proxy}
-        no_proxy: ${no_proxy},shell,rest-api,validator,settings-tp,pdo-tp,pdo-build
     environment:
       http_proxy: "${http_proxy}"
       https_proxy: "${https_proxy}"
@@ -38,11 +34,6 @@ services:
 
   # PDO Transaction processor
   pdo-tp:
-    build:
-      args:
-        http_proxy: ${http_proxy}
-        https_proxy: ${https_proxy}
-        no_proxy: ${no_proxy},shell,rest-api,validator,settings-tp,pdo-tp,pdo-build
     environment:
       http_proxy: "${http_proxy}"
       https_proxy: "${https_proxy}"

--- a/docs/host_install.md
+++ b/docs/host_install.md
@@ -74,34 +74,36 @@ Following commands will download and install PSW:
 ```bash
 echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | sudo tee /etc/apt/sources.list.d/intel-sgx.list
 wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | sudo apt-key add -
-apt-get update
-apt-get build-essential python #dependencies
-apt-get install -y libsgx-enclave-common sgx-aesm-service libsgx-urts libsgx-launch libsgx-epid libsgx-quote-ex libsgx-uae-service
+sudo apt-get update
+sudo apt-get build-essential python #dependencies
+sudo apt-get install -y sgx-aesm-service libsgx-urts libsgx-uae-service
 ```
 
-if you want to debug and/or develop, also install following packages
+if you want to debug, also install following packages
 ```bash
-apt-get install -y libsgx-enclave-common-dbgsym libsgx-enclave-common-dev
+sudo apt-get install -y libsgx-enclave-common-dbgsym sgx-aesm-service-dbgsym libsgx-urts-dbgsym libsgx-uae-service-dbgsym
 ```
+
+Note: If you are behind a proxy, you will have to configure the proxy settings
+in `/etc/aesmd.confg` and restart aesmd with `systemctl restart aesmd.
 
 ## Install the SGX SDK
 
-Private Data Objects has been tested with version 2.9.1 of the SGX
+Private Data Objects has been tested with version 2.10 of the SGX
 SDK. You can download prebuilt binaries for the SDK and kernel drivers
-from [01.org](https://download.01.org/intel-sgx/sgx-linux/2.9.1/distro/ubuntu18.04-server/).
+from [01.org](https://download.01.org/intel-sgx/sgx-linux/2.10/distro/ubuntu18.04-server/).
 
-The following commands will download and install version 2.9.1 of the SGX
+The following commands will download and install version 2.10 of the SGX
 SDK. When asked for the installation directory, we suggest that you install
 the SDK into the directory `/opt/intel`.
 
 ```bash
-UBUNTU_VERSION=ubuntu18.04-server
-DRIVER_REPO= https://download.01.org/intel-sgx/sgx-linux/2.9.1/distro/${UBUNTU_VERSION}/
-SDK_FILE=sgx_linux_x64_sdk_2.9.101.2.bin
+DRIVER_REPO=https://download.01.org/intel-sgx/sgx-linux/2.10/distro/ubuntu18.04-server/
+SDK_FILE=sgx_linux_x64_sdk_2.10.100.2.bin
 
-wget ${DRIVER_REPO}/${SDK_FILE}
-chmod 777 ./${SDK_FILE}
-echo -e "no\n/opt/intel" | ./${SDK_FILE}
+wget ${DRIVER_REPO}/${SDK_FILE} -P /tmp
+chmod a+x /tmp/${SDK_FILE}
+echo -e "no\n/opt/intel" | sudo /tmp/${SDK_FILE}
 ```
 
 The installer includes a file that sets environment variables to
@@ -128,22 +130,22 @@ that contain the necessary LVI mitigations. The following
 commands will download and install these binaries:
 
 ```bash
-wget "https://download.01.org/intel-sgx/sgx-linux/2.9.1/as.ld.objdump.gold.r1.tar.gz"
-mkdir /opt/intel/sgxsdk.extras
-tar -xzf as.ld.objdump.gold.r1.tar.gz -C /opt/intel/sgxsdk.extras
-export PATH=/opt/intel/sgxsdk.extras/external/toolset:${PATH}
+wget "https://download.01.org/intel-sgx/sgx-linux/2.10/as.ld.objdump.gold.r2.tar.gz" -P /tmp
+sudo mkdir /opt/intel/sgxsdk.extras
+sudo tar -xzf /tmp/as.ld.objdump.gold.r2.tar.gz -C /opt/intel/sgxsdk.extras
+export PATH=/opt/intel/sgxsdk.extras/external/toolset/ubuntu18.04:${PATH}
 ```
 
 ## Build and Install SGX SSL
 
 SGX OpenSSL is a compilation of OpenSSL specifically for use within SGX
-enclaves. We have tested PDO with SGX SSL version 2.9.1.
+enclaves. We have tested PDO with SGX SSL version `lin_2.10_1.1.1g`
 
 Detailed instructions for building and installing SGX SSL is available
 from the
 [Intel SGX SSL github repository](https://github.com/intel/intel-sgx-ssl).
 
-Follow these steps to compile and install version 2.9.1:
+Follow these steps to compile and install version `lin_2.10_1.1.1g`:
 
 - Ensure you have the SGX SDK environment variables activated:
 ```bash
@@ -155,11 +157,11 @@ source /opt/intel/sgxsdk/environment
 git clone 'https://github.com/intel/intel-sgx-ssl.git'
 ```
 
-- Check out the recommended version (lin_2.9_1.1.1d):
+- Check out the recommended version (`lin_2.10_1.1.1g`):
 
 ```bash
 cd intel-sgx-ssl
-git checkout lin_2.9_1.1.1d
+git checkout lin_2.10_1.1.1g
 ```
 
 - Download the OpenSSL source package that will form the base of this
@@ -167,7 +169,7 @@ SGX SSL install:
 
 ```bash
 cd openssl_source
-wget 'https://www.openssl.org/source/openssl-1.1.1d.tar.gz'
+wget 'https://www.openssl.org/source/openssl-1.1.1g.tar.gz'
 cd ..
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -131,7 +131,28 @@ page. Copy the contents of the SPID into the file
 
 SGX can run in either simulation or hardware mode. No kernel driver is
 required to run in simulation mode. However, if you plan to run with SGX
-hardware support, it is necessary to install the SGX kernel driver. The
+hardware support, it is necessary to install the SGX kernel driver. 
+
+<!-- DCAP kernel driver installation -->
+The following commands will download and install the driver version 1.3 of
+the DCAP SGX kernel driver (for Ubuntu 18.04 server):
+
+```bash
+DRIVER_REPO=https://download.01.org/intel-sgx/sgx-dcap/1.7/linux/distro/ubuntu18.04-server/
+DRIVER_FILE=sgx_linux_x64_driver_1.35.bin
+
+wget ${DRIVER_REPO}/${DRIVER_FILE} -P /tmp
+chmod a+x /tmp/${DRIVER_FILE}
+sudo ./${DRIVER_FILE}
+```
+Note:
+- as of early August 2020, the sdk drivers (e.g., `sgx_linux_x64_driver_2.6.0_602374c.bin`) will cause BUS errors in some circumstance and is currently not supported by PDO
+- the DCAP driver, though, requires hardware which supports FLC (Flexible Launch Control)
+- the DCAP driver supports DKMS, so contrary to the sdk driver, you will _not_ have to re-install
+  the kernel driver after each kernel update.
+
+<!-- SDK kernel driver installation: currently disabled due to BUS Errors
+The
 following commands will download and install the driver version 2.6 of
 the SGX kernel driver (for Ubuntu 18.04 server):
 
@@ -143,11 +164,11 @@ wget ${DRIVER_REPO}/${DRIVER_FILE} -P /tmp
 chmod a+x /tmp/${DRIVER_FILE}
 sudo ./${DRIVER_FILE}
 ```
-
 Note: above installs the kernel module for the currently running kernel. You will have to reinstall the kernel driver once you boot into a new kernel.
 (If you have HW which has FLC (and hence can run DCAP), you could also 
  alternatively install the kernel module which is part of DCAP. 
  That supports DKMS and would save you from the re-install ...)
+-->
 
 ## Configuration
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -131,8 +131,12 @@ page. Copy the contents of the SPID into the file
 
 SGX can run in either simulation or hardware mode. No kernel driver is
 required to run in simulation mode. However, if you plan to run with SGX
-hardware support, it is necessary to install the SGX kernel driver. 
+hardware support, it is necessary to install the SGX kernel driver.
+Depending on your particular hardware, you will have to install
+different drivers.
 
+
+##### HW with support for DCAP / Flexible Launch Control (FLC)
 <!-- DCAP kernel driver installation -->
 The following commands will download and install the driver version 1.3 of
 the DCAP SGX kernel driver (for Ubuntu 18.04 server):
@@ -146,14 +150,15 @@ chmod a+x /tmp/${DRIVER_FILE}
 sudo ./${DRIVER_FILE}
 ```
 Note:
-- as of early August 2020, the sdk drivers (e.g., `sgx_linux_x64_driver_2.6.0_602374c.bin`) will cause BUS errors in some circumstance and is currently not supported by PDO
-- the DCAP driver, though, requires hardware which supports FLC (Flexible Launch Control)
+- the DCAP driver will _not_ work if your hardware does not supports FLC (Flexible Launch Control).
 - the DCAP driver supports DKMS, so contrary to the sdk driver, you will _not_ have to re-install
   the kernel driver after each kernel update.
 
-<!-- SDK kernel driver installation: currently disabled due to BUS Errors
-The
-following commands will download and install the driver version 2.6 of
+
+##### HW which does not support Flexible Launch Control (FLC)
+<!-- SDK kernel driver installation -->
+
+The following commands will download and install the SDK driver version 2.6 of
 the SGX kernel driver (for Ubuntu 18.04 server):
 
 ```bash
@@ -164,11 +169,25 @@ wget ${DRIVER_REPO}/${DRIVER_FILE} -P /tmp
 chmod a+x /tmp/${DRIVER_FILE}
 sudo ./${DRIVER_FILE}
 ```
-Note: above installs the kernel module for the currently running kernel. You will have to reinstall the kernel driver once you boot into a new kernel.
-(If you have HW which has FLC (and hence can run DCAP), you could also 
- alternatively install the kernel module which is part of DCAP. 
- That supports DKMS and would save you from the re-install ...)
--->
+Note:
+- as of August 2020, the sdk drivers will cause BUS errors in some circumstance on FLC HW and PDO is currently not supported in that configuration.
+- above installs the kernel module for the currently running kernel. You will have to reinstall the kernel driver once you boot into a new kernel.
+
+
+#### Validating HW mode
+
+To validate that your SGX HW installation & and corresponding PDO
+configuration is working properly, the  easiest way is to install
+docker as discussed below and then run
+```bash
+	make SGX_MODE=HW -C docker test
+```
+This will build PDO and automatically execute the tests described in
+the Section [Validate the Installation](usage.md#validating) in HW mode.
+Without docker, just define the SGX_MODE environment variable to
+hardware mode (`export SGX_MODE=HW`) and manually follow the steps in
+that section.
+
 
 ## Configuration
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -136,22 +136,18 @@ following commands will download and install the driver version 2.6 of
 the SGX kernel driver (for Ubuntu 18.04 server):
 
 ```bash
-apt-get install dkms
+DRIVER_REPO=https://download.01.org/intel-sgx/sgx-linux/2.10/distro/ubuntu18.04-server
+DRIVER_FILE=sgx_linux_x64_driver_2.6.0_602374c.bin
 
-DRIVER_VERSION=2.6.0_95eea6f
-UBUNTU_VERSION=18.04-server
-DRIVER_REPO= https://download.01.org/intel-sgx/sgx-linux/2.9.1/distro/ubuntu${UBUNTU_VERSION}/
-DRIVER_FILE=sgx_linux_x64_driver_${DRIVER_VERSION}.bin
-
-wget ${DRIVER_REPO}/${DRIVER_FILE}
-chmod 777 ./${DRIVER_FILE}
+wget ${DRIVER_REPO}/${DRIVER_FILE} -P /tmp
+chmod a+x /tmp/${DRIVER_FILE}
 sudo ./${DRIVER_FILE}
 ```
-<!--
-   Note: docu 'apt install build-essential ocaml automake autoconf
-   libtool wget python libssl-dev' all of which are not necessary
-   but omits necessary 'kms' ..
-   -->
+
+Note: above installs the kernel module for the currently running kernel. You will have to reinstall the kernel driver once you boot into a new kernel.
+(If you have HW which has FLC (and hence can run DCAP), you could also 
+ alternatively install the kernel module which is part of DCAP. 
+ That supports DKMS and would save you from the re-install ...)
 
 ## Configuration
 

--- a/eservice/pdo/eservice/pdo_enclave.py
+++ b/eservice/pdo/eservice/pdo_enclave.py
@@ -97,7 +97,7 @@ def __set_cdi_policy(config):
     """
     global _cdi_policy
 
-    if _cdi_policy is None:
+    if config and _cdi_policy is None:
         _cdi_policy = json.dumps(config['EnclavePolicy'])
 
     logger.debug("Enclave CDI policy: %s", _cdi_policy)
@@ -224,7 +224,7 @@ def send_to_contract_encoded(sealed_data, encrypted_session_key, encrypted_reque
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
-def get_enclave_service_info(spid) :
+def get_enclave_service_info(spid, config=None) :
     """Retrieve information about the enclave. This function should
     only be called outside of the normal initialization of the enclave
     and corresponding libraries.
@@ -235,10 +235,10 @@ def get_enclave_service_info(spid) :
     if _pdo :
         raise Exception('get_enclave_service_info must be called exclusively')
 
-    if _cdi_policy is None:
-        raise Exception('cannot load enclave without cdi policy')
-
     enclave.SetLogger(logger)
+
+    # set the policy based on the configuration
+    __set_cdi_policy(config)
 
     signed_enclave = __find_enclave_library(None)
     logger.debug("Attempting to load enclave at: %s", signed_enclave)

--- a/eservice/pdo/eservice/pdo_helper.py
+++ b/eservice/pdo/eservice/pdo_helper.py
@@ -40,13 +40,13 @@ from pdo.submitter.create import create_submitter
 import logging
 logger = logging.getLogger(__name__)
 
-__all__ = [ "Enclave", "initialize_enclave", "shutdown_enclave" ]
+__all__ = [ "Enclave", "initialize_enclave", "shutdown_enclave", "parse_enclave_policy" ]
 
 # helper function to read list of .pem key files
 def __parse_pem_file_list(key_list, search_path):
     keys = []
     for key_file in key_list:
-        logger.error('opening key file %s', key_file)
+        logger.debug('opening key file %s', key_file)
         full_file = putils.find_file_in_path(key_file, search_path)
         with open(full_file, 'r') as k:
             key = k.read()
@@ -54,7 +54,7 @@ def __parse_pem_file_list(key_list, search_path):
         keys.append(key)
     return keys
 
-def __parse_enclave_policy(policy_config, key_path):
+def parse_enclave_policy(policy_config, key_path):
     enclave_policy = { "AcceptAllCode" : policy_config['AcceptAllCode'] } # convert str to bool
     enclave_policy["TrustedCompilerKeys"] = __parse_pem_file_list(policy_config['TrustedCompilerKeys'], key_path)
     enclave_policy["TrustedLedgerKey"] = policy_config['TrustedLedgerKey']
@@ -78,7 +78,7 @@ def initialize_enclave(config) :
     try :
         enclave_config = config['EnclaveModule']
         # add the enclave policy
-        enclave_config['EnclavePolicy'] = __parse_enclave_policy(config['EnclavePolicy'], config['Key']['SearchPath'])
+        enclave_config['EnclavePolicy'] = parse_enclave_policy(config['EnclavePolicy'], config['Key']['SearchPath'])
         pdo_enclave.initialize_with_configuration(enclave_config)
     except KeyError as ke :
         raise Exception('missing enclave module configuration')
@@ -100,10 +100,10 @@ def shutdown_enclave() :
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
-def get_enclave_service_info(spid) :
+def get_enclave_service_info(spid, config=None) :
     """get_enclave_service_info -- Retrieve enclave MRENCLAVE & BASENAME
     """
-    return pdo_enclave.get_enclave_service_info(spid)
+    return pdo_enclave.get_enclave_service_info(spid, config=config)
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------

--- a/eservice/pdo/eservice/scripts/EServiceEnclaveInfoCLI.py
+++ b/eservice/pdo/eservice/scripts/EServiceEnclaveInfoCLI.py
@@ -33,12 +33,14 @@ import time
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
 
-def GetBasename(spid, save_path) :
+def GetBasename(spid, save_path, config) :
     attempts = 0
     while True :
         try :
             logger.debug('initialize the enclave')
-            info = pdo_enclave_helper.get_enclave_service_info(spid)
+            enclave_config = {}
+            enclave_config['EnclavePolicy'] = pdo_enclave_helper.parse_enclave_policy(config['EnclavePolicy'], config['Key']['SearchPath'])
+            info = pdo_enclave_helper.get_enclave_service_info(spid, config=enclave_config)
 
             logger.info('save MR_ENCLAVE and MR_BASENAME to %s', save_path)
             with open(save_path, "w") as file :
@@ -72,6 +74,8 @@ def GetIasCertificates(config) :
     # the creation of signup info includes getting a verification report from IAS
     try :
         enclave_config = config['EnclaveModule']
+        # add the enclave policy
+        enclave_config['EnclavePolicy'] = pdo_enclave_helper.parse_enclave_policy(config['EnclavePolicy'], config['Key']['SearchPath'])
         pdo_enclave.initialize_with_configuration(enclave_config)
         nonce = '{0:016X}'.format(123456789)
         enclave_data = pdo_enclave.create_signup_info(nonce, nonce)
@@ -94,7 +98,7 @@ def GetIasCertificates(config) :
     return
 
 def LocalMain(config, spid, save_path) :
-    GetBasename(spid, save_path)
+    GetBasename(spid, save_path, config)
     GetIasCertificates(config)
 
     sys.exit(0)


### PR DESCRIPTION
Mostly an upgrade from 2.9.1 to 2.10 with additional pruning out of obsolete xenial/16.04 (non-)support while also laying the ground for 20.04.  Also a number of fixes and small clean-ups.

To make it work with HW mode, it also includes a commit with a bug-fix related CDI introduced in an earlier commit.

Lastly, due to some emsdk changes, fastcomp didn't build properly anymore in docker.  As a temporary "emergency" fix we install the (new) llvm backend.  However, as wawaka doesn't build yet with that backend, the corresponding travis builds are temporarily disabled in `.travis.yml`.


Note: while there is no complete sgx support yet for 20.04, it seems to be on its way (e.g., the modified binutils include 20.04 versions [even though in that case they shouldn't really be necessary as 20.04 has a recent enough version ..]).  As a side note, it seems that our sgx packing folks try amazingly hard to change in each version subtle things that you cannot just bump version numbers ... :-(