### PR TITLE
CCF version moved to 0.11 from 0.9

### DIFF
--- a/build/__tools__/expand-config
+++ b/build/__tools__/expand-config
@@ -97,6 +97,7 @@ ContractEtc = os.path.join(ContractHome, "etc")
 ContractKeys = os.path.join(ContractHome, "keys")
 ContractLogs = os.path.join(ContractHome, "logs")
 ContractData = os.path.join(ContractHome, "data")
+LedgerKeyRoot = os.environ.get("PDO_LEDGER_KEY_ROOT", os.path.join(ContractHome, "ccf", "keys"))
 HttpsProxy = os.environ.get("https_proxy", "")
 
 config_map = {
@@ -109,6 +110,7 @@ config_map = {
     'logs' : ContractLogs,
     'ledger' : LedgerURL,
     'ledger_type': LedgerType,
+    'ledger_key_root' : LedgerKeyRoot,
     'eservice_key_format': EserviceKeyFormat,
     'proxy' : HttpsProxy,
     'spid' : SPID,

--- a/build/common-config.sh
+++ b/build/common-config.sh
@@ -138,10 +138,16 @@ var_set() {
 	"
 	env_key_sort[$i]="PDO_SPID_API_KEY"; i=$i+1; export PDO_SPID_API_KEY=${env_val[PDO_SPID_API_KEY]}
 
-	env_val[PDO_LEDGER_KEY_ROOT]="${PDO_LEDGER_KEY_ROOT:-${PDO_INSTALL_ROOT}/opt/pdo/etc/keys/ledger}"
+	if [[ "${PDO_LEDGER_TYPE}" == "ccf" ]]
+	then
+		env_val[PDO_LEDGER_KEY_ROOT]="${PDO_LEDGER_KEY_ROOT:-${PDO_INSTALL_ROOT}/opt/pdo/ccf/keys}"
+	else
+		env_val[PDO_LEDGER_KEY_ROOT]="${PDO_LEDGER_KEY_ROOT:-${PDO_INSTALL_ROOT}/opt/pdo/etc/keys/ledger}"
+	fi
+
 	env_desc[PDO_LEDGER_KEY_ROOT]="
 		PDO_LEDGER_KEY_ROOT is the root directory where the system keys are stored
-		for ledger integration; files in this directory are not automatically generated. When ccf is used 
+		for ledger integration; files in this directory are not automatically generated. When ccf is used
 		as ledger, the ccf keys {networkcert.pem, userccf_cert.pem, userccf_privk.pem} must be
 		placed under this folder. These keys get generated during ccf deployment.
 	"

--- a/ccf_transaction_processor/CMakeLists.txt
+++ b/ccf_transaction_processor/CMakeLists.txt
@@ -25,7 +25,7 @@ include(${CCF_DIR}/cmake/ccf_app.cmake)
 # the PDO TP app will be signed with the RSA key whose locaation is
 # pointed to by PDO_ENCLAVE_CODE_SIGN_PEM
 IF (NOT EXISTS "$ENV{PDO_ENCLAVE_CODE_SIGN_PEM}")
-  MESSAGE(FATAL_ERROR "PDO_ENCLAVE_CODE_SIGN_PEM environment variable not defined!")
+  MESSAGE(FATAL_ERROR "The enclave signing key pointed to by PDO_ENCLAVE_CODE_SIGN_PEM environment variable does not exist!")
 ENDIF()
 SET(PDO_ENCLAVE_CODE_SIGN_PEM "$ENV{PDO_ENCLAVE_CODE_SIGN_PEM}")
 

--- a/ccf_transaction_processor/Makefile
+++ b/ccf_transaction_processor/Makefile
@@ -78,7 +78,7 @@ clean-install :
 config : $(ETCDIR)/cchost.toml $(ETCDIR)/gov.lua
 
 $(ETCDIR)/cchost.toml : etc/cchost.toml
-	@ echo create configuration files for cchost
+	@ echo create configuration file for cchost
 	@ . $(abspath $(CCFDSTDIR)/bin/activate) && \
 		$(CNFGEN) --template $(notdir $<) --template-directory $(dir $<) \
 			--output-directory $(dir $@) \
@@ -123,8 +123,8 @@ install-pdo-tp : build-pdo-tp
 	cp $(addprefix scripts/,$(PDO_PYTHON_SCRIPTS)) $(BINDIR)
 
 keys :
-	cd $(KEYDIR) && $(CCFDIR)/tests/keygenerator.sh --name=member0 --gen-key-share
-	cd $(KEYDIR) && $(CCFDIR)/tests/keygenerator.sh --name=user0 --gen-key-share
+	cd $(KEYDIR) && $(CCFDIR)/tests/keygenerator.sh --name memberccf --gen-enc-key
+	cd $(KEYDIR) && $(CCFDIR)/tests/keygenerator.sh --name userccf --gen-enc-key
 
 .PHONY : all build build-ccf build-pdo-tp
 .PHONY : clean clean-build clean-install

--- a/ccf_transaction_processor/etc/cchost.toml
+++ b/ccf_transaction_processor/etc/cchost.toml
@@ -2,11 +2,11 @@
 enclave-file = "${home}/ccf/lib/libpdoenc.virtual.so"
 enclave-type = "virtual"
 consensus = "raft"
-rpc-address = "${host_address}:6006"
-node-address = "${host_address}:6007"
+rpc-address = "${host_address}:6600"
+node-address = "${host_address}:7700"
 
 [start]
 network-cert-file = "${home}/ccf/keys/networkcert.pem"
 network-enc-pubk-file = "${home}/ccf/keys/network_enc_pubk.pem"
-member-info = "${home}/ccf/keys/member0_cert.pem,${home}/ccf/keys/member0_kshare_pub.pem"
+member-info = "${home}/ccf/keys/memberccf_cert.pem,${home}/ccf/keys/memberccf_enc_pubk.pem"
 gov-script = "${home}/ccf/etc/gov.lua"

--- a/ccf_transaction_processor/scripts/configure_ccf_network.py
+++ b/ccf_transaction_processor/scripts/configure_ccf_network.py
@@ -23,6 +23,7 @@ import http
 import os
 import sys
 import toml
+import time
 
 # pick up the logger used by the rest of CCF
 from loguru import logger as LOG
@@ -39,6 +40,19 @@ from infra.clients import CCFClient
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
 def open_network_script(client, options, config) :
+
+    # activate the member (new from ccf release 0.11)
+    try:
+        r = client.rpc("ack/update_state_digest")
+        state_digest = bytearray(r.result["state_digest"])
+        r = client.rpc("ack", params={"state_digest": list(state_digest)}, signed=True)
+        if r.error is not None:
+            LOG.error('failed to activate the member {}'.format(r.error))
+            sys.exit(-1)
+    except :
+        LOG.error('failed to activate the member')
+        sys.exit(-1)
+
     script = """
     tables = ...
     return Calls:call("open_network")
@@ -104,10 +118,11 @@ def Main() :
 
     parser.add_argument('--logfile', help='Name of the log file, __screen__ for standard output', type=str)
     parser.add_argument('--loglevel', help='Logging level', default='WARNING', type=str)
-
     parser.add_argument('--ccf-config', help='Name of the CCF configuration file', default = default_config, type=str)
-    parser.add_argument('--member-name', help="Name of the member adding the user", default = "member0", type=str)
-    parser.add_argument('--user-name', help="Name of the user being added", default = "user0", type=str)
+    parser.add_argument('--member-name', help="Name of the member adding the user", default = "memberccf", type=str)
+    parser.add_argument('--user-name', help="Name of the user being added", default = "userccf", type=str)
+    parser.add_argument('--add-node', help="Add a new node to existing CCF network", action="store_true")
+    parser.add_argument('--node-id', help="id of the node to be added to the ccf network", type=int)
 
     options = parser.parse_args()
 
@@ -138,7 +153,7 @@ def Main() :
             key=member_key,
             ca = network_cert,
             format='json',
-            prefix='members',
+            prefix='gov',
             description="none",
             version="2.0",
             connection_timeout=3,

--- a/ccf_transaction_processor/scripts/fetch_ledger_authority.py
+++ b/ccf_transaction_processor/scripts/fetch_ledger_authority.py
@@ -43,7 +43,7 @@ def fetch_ledger_authority(client, options, config):
             sys.exit(-1)
 
         if result.result is None :
-            LOG.error('failed to generate ledger authority: {0}, '.format(result.error['message']))
+            LOG.error('failed to generate ledger authority: {0}, '.format(result.error))
             sys.exit(-1)
 
     except :
@@ -68,7 +68,7 @@ def Main() :
     parser.add_argument('--loglevel', help='Logging level', default='WARNING', type=str)
 
     parser.add_argument('--ccf-config', help='Name of the CCF configuration file', default = default_config, type=str)
-    parser.add_argument('--user-name', help="Name of the user being added", default = "user0", type=str)
+    parser.add_argument('--user-name', help="Name of the user being added", default = "userccf", type=str)
     parser.add_argument("--output-file", help="Name of the file where the key will be saved", default = default_output, type=str)
 
     options = parser.parse_args()
@@ -101,7 +101,7 @@ def Main() :
             key=user_key_file,
             ca = network_cert,
             format='json',
-            prefix='users',
+            prefix='app',
             description="none",
             version="2.0",
             connection_timeout=3,

--- a/ccf_transaction_processor/scripts/generate_ledger_authority.py
+++ b/ccf_transaction_processor/scripts/generate_ledger_authority.py
@@ -43,7 +43,7 @@ def generate_ledger_authority(client, options, config):
             sys.exit(-1)
 
         if result.result is None :
-            LOG.error('failed to generate ledger authority: {0}, '.format(result.error['message']))
+            LOG.error('failed to generate ledger authority: {0}, '.format(result.error))
             sys.exit(-1)
 
     except :
@@ -61,7 +61,7 @@ def Main() :
     parser.add_argument('--loglevel', help='Logging level', default='WARNING', type=str)
 
     parser.add_argument('--ccf-config', help='Name of the CCF configuration file', default = default_config, type=str)
-    parser.add_argument('--user-name', help="Name of the user being added", default = "user0", type=str)
+    parser.add_argument('--user-name', help="Name of the user being added", default = "userccf", type=str)
 
     options = parser.parse_args()
 
@@ -93,7 +93,7 @@ def Main() :
             key=user_key_file,
             ca = network_cert,
             format='json',
-            prefix='users',
+            prefix='app',
             description="none",
             version="2.0",
             connection_timeout=3,

--- a/ccf_transaction_processor/scripts/ping_test.py
+++ b/ccf_transaction_processor/scripts/ping_test.py
@@ -20,6 +20,7 @@ import os
 import sys
 import time
 import toml
+from urllib.parse import urlparse
 
 # pick up the logger used by the rest of CCF
 from loguru import logger as LOG
@@ -28,13 +29,15 @@ from loguru import logger as LOG
 ContractHome = os.environ.get("PDO_HOME") or os.path.realpath("/opt/pdo")
 CCF_Bin = os.path.join(ContractHome, "ccf", "bin")
 CCF_Etc = os.path.join(ContractHome, "ccf", "etc")
-CCF_Keys = os.path.join(ContractHome, "ccf", "keys")
+CCF_Keys = os.environ.get("PDO_LEDGER_KEY_ROOT") or os.path.join(ContractHome, "ccf", "keys")
 
 sys.path.insert(1, CCF_Bin)
+sys.path.insert(1, "../CCF/tests")
+
 from infra.clients import CCFClient
 
 # -----------------------------------------------------------------
-def ping_test(client, options, config):
+def ping_test(client, options):
     num_pings = options.num_pings
 
     start_time = time.time()
@@ -55,10 +58,8 @@ def Main() :
 
     parser.add_argument('--logfile', help='Name of the log file, __screen__ for standard output', type=str)
     parser.add_argument('--loglevel', help='Logging level', default='INFO', type=str)
-
     parser.add_argument('--ccf-config', help='Name of the CCF configuration file', default = os.path.join(CCF_Etc, 'cchost.toml'), type=str)
-    parser.add_argument('--member-name', help="Name of the member adding the user", default = "member0", type=str)
-    parser.add_argument('--user-name', help="Name of the user being added", default = "user0", type=str)
+    parser.add_argument('--user-name', help="Name of the user being added", default = "userccf", type=str)
     parser.add_argument("--num-pings", help="Number of ping operations to do", default = 100, type=int)
 
     options = parser.parse_args()
@@ -71,13 +72,16 @@ def Main() :
     try :
         config = toml.load(options.ccf_config)
     except :
-        LOG.error('unable to load ccf configuration file {0}'.format(options.ccf_config))
+        LOG.info('unable to load ccf configuration file {0}'.format(options.ccf_config))
         pass
 
-    member_cert = os.path.join(CCF_Keys, "{}_cert.pem".format(options.member_name))
-    member_key = os.path.join(CCF_Keys, "{}_privk.pem".format(options.member_name))
-    network_cert = config["start"]["network-cert-file"]
-    (host, port) = config["rpc-address"].split(':')
+    network_cert = os.path.join(CCF_Keys, "networkcert.pem")
+
+    if os.environ.get("PDO_LEDGER_URL") is not None:
+        url =  os.environ.get("PDO_LEDGER_URL")
+        (host, port) = urlparse(url).netloc.split(':')
+    else :
+        (host, port) = config["rpc-address"].split(':')
 
     user_cert_file = os.path.join(CCF_Keys, "{}_cert.pem".format(options.user_name))
     user_key_file = os.path.join(CCF_Keys, "{}_privk.pem".format(options.user_name))
@@ -90,7 +94,7 @@ def Main() :
             key=user_key_file,
             ca = network_cert,
             format='json',
-            prefix='users',
+            prefix='app',
             description="none",
             version="2.0",
             connection_timeout=3,
@@ -99,7 +103,7 @@ def Main() :
         LOG.error('failed to connect to CCF service')
         sys.exit(-1)
 
-    ping_test(user_client, options, config)
+    ping_test(user_client, options)
 
     sys.exit(0)
 

--- a/ccf_transaction_processor/scripts/start_ccf_network.sh
+++ b/ccf_transaction_processor/scripts/start_ccf_network.sh
@@ -33,15 +33,18 @@ if [ -f ${F_SERVICEHOME}/run/cchost.pid ]; then
     fi
 fi
 
-rm -f ${F_SERVICEHOME}/keys/network_cert.pem ${F_SERVICEHOME}/keys/network_enc_pubk.pem
+rm -rf ${F_SERVICEHOME}/run/*
+rm -f ${F_SERVICEHOME}/logs/*.log
+
+rm -f ${F_SERVICEHOME}/keys/networkcert.pem ${F_SERVICEHOME}/keys/network_enc_pubk.pem
 rm -f ${F_SERVICEHOME}/keys/ledger_authority_pub.pem
 
-say attempt to start cchost
-try ${F_SERVICEHOME}/bin/start_cchost.sh start
+say attempt to start ccf node
+try ${F_SERVICEHOME}/bin/start_cchost.sh
 
 sleep 5
 
-say configure ccf network
+say configure ccf network : ACK the member, open network, add user
 try ${F_SERVICEHOME}/bin/configure_ccf_network.py --logfile __screen__ --loglevel WARNING
 
 sleep 5
@@ -52,6 +55,4 @@ try ${F_SERVICEHOME}/bin/generate_ledger_authority.py --logfile __screen__ --log
 sleep 5
 
 echo save the ledger authority key
-try ${F_SERVICEHOME}/bin/fetch_ledger_authority.py --loglevel WARNING
-
-echo CCF service ready for use
+try ${F_SERVICEHOME}/bin/fetch_ledger_authority.py --logfile __screen__ --loglevel WARNING

--- a/ccf_transaction_processor/scripts/start_cchost.sh
+++ b/ccf_transaction_processor/scripts/start_cchost.sh
@@ -28,20 +28,9 @@ if [ $SGX_MODE == "SIM" ]; then
    CCHOST=${F_SERVICEHOME}/bin/cchost.virtual
 fi
 
-if [ -f ${F_SERVICEHOME}/run/cchost.pid ]; then
-    if ps -p $(cat ${F_SERVICEHOME}/run/cchost.pid) > /dev/null
-    then
-        yell cchost appears to be running already
-        exit -1
-    fi
-fi
-
-rm -f ${F_SERVICEHOME}/run/*
-rm -f ${F_SERVICEHOME}/logs/*.log
-
 EFILE="${F_SERVICEHOME}/logs/error.log"
 OFILE="${F_SERVICEHOME}/logs/output.log"
 
 cd ${F_SERVICEHOME}/run
-${CCHOST} --config ${F_SERVICEHOME}/etc/cchost.toml $1 > $OFILE 2> $EFILE &
+${CCHOST} --config ${F_SERVICEHOME}/etc/cchost.toml > $OFILE 2> $EFILE &
 echo $! > ${F_SERVICEHOME}/run/cchost.pid

--- a/ccf_transaction_processor/transaction_processor/pdo_tp.h
+++ b/ccf_transaction_processor/transaction_processor/pdo_tp.h
@@ -65,10 +65,10 @@ namespace ccfapp
     {
         private:
 
-            Store::Map<string, EnclaveInfo>& enclavetable; // key is encalve_id
-            Store::Map<string, ContractInfo>& contracttable; // key is contract_id
-            Store::Map<string, ContractStateInfo>& ccltable; // key is contract_id + state_hash (string addition)
-            Store::Map<string, map<string, string>>& signer; //There is at most one entry in this map. if there is an
+            kv::Map<string, EnclaveInfo>& enclavetable; // key is encalve_id
+            kv::Map<string, ContractInfo>& contracttable; // key is contract_id
+            kv::Map<string, ContractStateInfo>& ccltable; // key is contract_id + state_hash (string addition)
+            kv::Map<string, map<string, string>>& signer; //There is at most one entry in this map. if there is an
                                                             //entry key="signer".  value is pubk:privk
 
             // functions to verify signatures, only wite methods sign transactions, read methods do not.
@@ -103,8 +103,8 @@ namespace ccfapp
 
         public:
 
-            TPHandlerRegistry (Store& store);
-            void init_handlers(Store& store) override;
+            TPHandlerRegistry (kv::Store& store);
+            void init_handlers(kv::Store& store) override;
             map<string, tls::PublicKeyPtr> enclave_pubk_verifier; // the key is the enclave verifying key
                               // shouldn't there be a table for this?
 
@@ -117,7 +117,7 @@ namespace ccfapp
         TPHandlerRegistry  tp_handlers;
 
     public:
-        TransactionProcessor(Store& store);
+        TransactionProcessor(kv::Store& store);
     };
 }
 

--- a/python/pdo/submitter/ccf/ccf_submitter.py
+++ b/python/pdo/submitter/ccf/ccf_submitter.py
@@ -87,7 +87,7 @@ class CCFSubmitter(sub.Submitter):
                                                 description=None,
                                                 version="2.0",
                                                 format="json",
-                                                prefix="users",
+                                                prefix="app",
                                                 connection_timeout=3,
                                                 request_timeout=3,
                                             )
@@ -117,7 +117,7 @@ class CCFSubmitter(sub.Submitter):
                 raise
 
         #read failed even after retries
-        raise Exception(response.error['message'])
+        raise Exception(response.error)
 
 # -----------------------------------------------------------------
     def submit_rpc_to_ccf(self, tx_method, tx_params) :
@@ -152,7 +152,7 @@ class CCFSubmitter(sub.Submitter):
             if response.result: # result will be "True" for enclave registration transaction
                 return tx_params['signature'] #PDO expects the submitter to return the transaction signature
             else:
-                raise Exception(response.error['message'])
+                raise Exception(response.error)
         except Exception as e:
             raise
 
@@ -175,7 +175,7 @@ class CCFSubmitter(sub.Submitter):
             if response.result: # result will be "True" for contract registration transaction
                 return crypto.byte_array_to_hex(tx_params['signature'])
             else:
-                raise Exception(response.error['message'])
+                raise Exception(response.error)
         except Exception as e:
             raise
 
@@ -198,7 +198,7 @@ class CCFSubmitter(sub.Submitter):
             if response.result: # result will be "True" for add encalve to contract transaction
                 return tx_params['signature'] #PDO expects the submitter to return the transaction signature
             else:
-                raise Exception(response.error['message'])
+                raise Exception(response.error)
         except Exception as e:
             raise
 
@@ -237,7 +237,7 @@ class CCFSubmitter(sub.Submitter):
             if response.result: # result will be True for successful init transaction
                 return tx_params['nonce'] # this will represent the transaction id
             else:
-                raise Exception(response.error['message'])
+                raise Exception(response.error)
         except Exception as e:
             raise
 
@@ -283,7 +283,7 @@ class CCFSubmitter(sub.Submitter):
             if response.result: # result will be True for successful init transaction
                 return tx_params['nonce'] #this will represent the transaction id
             else:
-                raise Exception(response.error['message'])
+                raise Exception(response.error)
         except Exception as e:
             raise
 


### PR DESCRIPTION
1. Moved CCF tag to 0.11 from 0.9. Several API changes to address the move

2. ping_test can now be invoked from a remote machine where CCF is not installed.

Signed-off-by: prakashngit <prakash.narayana.moorthy@intel.com>