### PR TITLE
Updates to WASM toolchain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,8 @@ env:
   matrix:
     # parallelize builds for the different interpreters
     - PDO_INTERPRETER=gipsy
-    # TODO: Re-enable below once wawaka builds again with standard (non-fastcomp) emsdk backend
-    #- PDO_INTERPRETER=wawaka
-    #- PDO_INTERPRETER=wawaka-opt
+    - PDO_INTERPRETER=wawaka
+    - PDO_INTERPRETER=wawaka-opt
 
 before_install:
 

--- a/common/interpreter/wawaka_wasm/README.md
+++ b/common/interpreter/wawaka_wasm/README.md
@@ -35,6 +35,7 @@ cd ${PDO_SOURCE_ROOT}
 
 git clone https://github.com/emscripten-core/emsdk.git
 cd ${PDO_SOURCE_ROOT}/emsdk
+git checkout 1.39.20 # last release to support fastcomp backend
 
 ./emsdk install latest-fastcomp
 ./emsdk activate latest-fastcomp

--- a/common/interpreter/wawaka_wasm/README.md
+++ b/common/interpreter/wawaka_wasm/README.md
@@ -47,14 +47,14 @@ source ./emsdk_env.sh
 If wawaka is configured as the contract interpreter, the libraries implementing the WASM interpreter
 will be built for use with Intel SGX. The source for the WAMR interpreter is
 included as a submodule in the interpreters/ folder, and will
-always point to the latest tagged commit that we have validated: `WAMR-04-15-2020`.
+always point to the latest tagged commit that we have validated: `WAMR-07-10-2020`.
 If the PDO parent repo was not cloned with the `--recurse-submodules` flag,
 you will have to explictly pull the submodule source.
 
 ```
 cd ${PDO_SOURCE_ROOT}/interpreters/wasm-micro-runtime
 git submodule update --init
-git checkout WAMR-04-15-2020 # optional
+git checkout WAMR-07-10-2020 # optional
 ```
 
 The WAMR API is built during the Wawaka build, so no additional

--- a/docker/Dockerfile.pdo-build
+++ b/docker/Dockerfile.pdo-build
@@ -24,7 +24,7 @@
 #  - pdo repo branch to use:			PDO_REPO_BRANCH (default: master)
 #  - build in debug mode:			PDO_DEBUG_BUILD (default: 0)
 #  - contract interpreter (gipsy or wawaka):	PDO_INTERPRETER (default: gipsy)
-#  - wamr version:		                WAMR    (default: WAMR-04-15-2020)
+#  - wamr version:		                WAMR    (default: WAMR-07-10-2020)
 
 # Build:
 #   $ docker build -f docker/Dockerfile.pdo-build -t pdo-build docker
@@ -100,7 +100,7 @@ ENV PDO_INTERPRETER=${PDO_INTERPRETER}
 
 # - web-assembly/wasm/wawaka
 #   - Configure WAMR source
-ARG WAMR=WAMR-04-15-2020
+ARG WAMR=WAMR-07-10-2020
 RUN cd /project/pdo/src/private-data-objects/interpreters/wasm-micro-runtime \
  && git checkout ${WAMR}\
  && echo "export WASM_SRC=$(pwd)" >> /etc/profile.d/pdo.sh

--- a/docker/Dockerfile.pdo-dev
+++ b/docker/Dockerfile.pdo-dev
@@ -213,8 +213,9 @@ RUN mkdir -p /project/pdo/wasm/src \
  && cd /project/pdo/wasm/src \
  && git clone https://github.com/emscripten-core/emsdk.git \
  && cd emsdk \
- && ./emsdk install latest \
- && ./emsdk activate latest \
+ && git checkout 1.39.20 \
+ && ./emsdk install latest-fastcomp \
+ && ./emsdk activate latest-fastcomp \
  && echo 'cd /project/pdo/wasm/src/emsdk/; if [ -z "$BASH_SOURCE" ]; then BASH_SOURCE=./emsdk_env.sh; . ./emsdk_env.sh; unset BASH_SOURCE; else . ./emsdk_env.sh; fi' >> /etc/profile.d/pdo.sh
 # Note: above convoluted BASH_SOURCE hack is necessary as (a) emsdk_env.sh 
 #       assumes we run in bash but (b) as we build we actually run in sh

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -111,7 +111,7 @@ the contract enclave.
 `WASM_SRC` points to the installation of the wasm-micro-runtime. This
 is used to build the WASM interpreter for the wawaka contract interpreter.
 The git submodule points to the latest tagged commit of [WAMR](https://github.com/bytecodealliance/wasm-micro-runtime) we have validated:
-`WAMR-04-15-2020`.
+`WAMR-07-10-2020`.
 
 <!-- -------------------------------------------------- -->
 ### `WASM_MEM_CONFIG`


### PR DESCRIPTION
This PR introduces two changes:

- Upgrade of the WAMR release used in Wawaka to `WAMR-07-10-2020`. No changes to Wawaka were needed.
- Explicit usage of the last emsdk release to support the fastcomp backend. Docker now checks out the `1.39.20` tag. This change is a workaround until we can stably support one of the newer WASM build toolchains.