### PR TITLE
Update a number of the wawaka contract classes to improve memory management

### DIFF
--- a/contracts/wawaka/common/Cryptography.cpp
+++ b/contracts/wawaka/common/Cryptography.cpp
@@ -1,0 +1,378 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <malloc.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "Cryptography.h"
+#include "StringArray.h"
+#include "Util.h"
+#include "WasmExtensions.h"
+
+/* ----------------------------------------------------------------- *
+ * NAME: ww::crypto::random_identifier
+ * ----------------------------------------------------------------- */
+bool ww::crypto::random_identifier(StringArray& identifier)
+{
+    if (identifier.size() == 0)
+        identifier.resize(32);
+
+    return ::random_identifier(identifier.size(), identifier.data());
+}
+
+static void verify_null_terminated(const char *data_pointer, size_t data_size)
+{
+    if (data_pointer[data_size - 1] != '\0')
+    {
+        CONTRACT_SAFE_LOG(3, "NOT NULL TERMINATED");
+    }
+}
+
+/* ----------------------------------------------------------------- *
+ * NAME: ww::crypto::b64_encode
+ * ----------------------------------------------------------------- */
+bool ww::crypto::b64_encode(
+    const StringArray& message,
+    StringArray& encoded_message)
+{
+    uint8_t* data_pointer = NULL;
+    size_t data_size = 0;
+
+    if (! ::b64_encode(message.c_data(), message.size(), (char**)&data_pointer, &data_size))
+        return false;
+
+    if (data_pointer == NULL)
+    {
+        CONTRACT_SAFE_LOG(3, "invalid pointer from extension function b64_encode");
+        return false;
+    }
+
+    verify_null_terminated((const char*)data_pointer, data_size);
+    return copy_internal_pointer(encoded_message, data_pointer, data_size);
+}
+
+/* ----------------------------------------------------------------- *
+ * NAME: ww::crypto::
+ * ----------------------------------------------------------------- */
+bool ww::crypto::b64_decode(
+    const StringArray& encoded_message,
+    StringArray& message)
+{
+    uint8_t *data_pointer = NULL;
+    size_t data_size = 0;
+
+    verify_null_terminated((const char*)encoded_message.c_data(), encoded_message.size());
+
+    if (! ::b64_decode((const char*)encoded_message.c_data(), encoded_message.size(), &data_pointer, &data_size))
+        return false;
+
+    if (data_pointer == NULL)
+    {
+        CONTRACT_SAFE_LOG(3, "invalid pointer from extension function b64_decode");
+        return false;
+    }
+
+    return copy_internal_pointer(message, data_pointer, data_size);
+}
+
+/* ----------------------------------------------------------------- *
+ * NAME: ww::crypto::aes::generate_key
+ * ----------------------------------------------------------------- */
+bool ww::crypto::aes::generate_key(StringArray& key)
+{
+    uint8_t* data_pointer = NULL;
+    size_t data_size = 0;
+
+    if (! ::aes_generate_key(&data_pointer, &data_size))
+        return false;
+
+    if (data_pointer == NULL)
+    {
+        CONTRACT_SAFE_LOG(3, "invalid pointer from extension function aes_generate_key");
+        return false;
+    }
+
+    verify_null_terminated((const char*)data_pointer, data_size);
+
+    return copy_internal_pointer(key, data_pointer, data_size);
+}
+
+/* ----------------------------------------------------------------- *
+ * NAME: ww::crypto::
+ * ----------------------------------------------------------------- */
+bool ww::crypto::aes::generate_iv(StringArray& iv)
+{
+    uint8_t* data_pointer = NULL;
+    size_t data_size = 0;
+
+    StringArray identifier(32);
+    if (! ww::crypto::random_identifier(identifier))
+        return false;
+
+    if (! ::aes_generate_iv(identifier.c_data(), identifier.size(), &data_pointer, &data_size))
+        return false;
+
+    if (data_pointer == NULL)
+    {
+        CONTRACT_SAFE_LOG(3, "invalid pointer from extension function aes_generate_key");
+        return false;
+    }
+
+    return copy_internal_pointer(iv, data_pointer, data_size);
+}
+
+/* ----------------------------------------------------------------- *
+ * NAME: ww::crypto::
+ * ----------------------------------------------------------------- */
+bool ww::crypto::aes::encrypt_message(
+    const StringArray& message,
+    const StringArray& key,
+    const StringArray& iv,
+    StringArray& cipher)
+{
+    verify_null_terminated((const char*)key.c_data(), key.size());
+
+    uint8_t* data_pointer = NULL;
+    size_t data_size = 0;
+
+    if (! ::aes_encrypt_message(
+            message.c_data(), message.size(),
+            key.c_data(), key.size(),
+            iv.c_data(), iv.size(),
+            &data_pointer, &data_size))
+        return false;
+
+    if (data_pointer == NULL)
+    {
+        CONTRACT_SAFE_LOG(3, "invalid pointer from extension function aes_encrypt_message");
+        return false;
+    }
+
+    return copy_internal_pointer(cipher, data_pointer, data_size);
+}
+
+/* ----------------------------------------------------------------- *
+ * NAME: ww::crypto::
+ * ----------------------------------------------------------------- */
+bool ww::crypto::aes::decrypt_message(
+    const StringArray& cipher,
+    const StringArray& key,
+    const StringArray& iv,
+    StringArray& message)
+{
+    verify_null_terminated((const char*)key.c_data(), key.size());
+
+    uint8_t* data_pointer = NULL;
+    size_t data_size = 0;
+
+    if (! ::aes_decrypt_message(
+            cipher.c_data(), cipher.size(),
+            key.c_data(), key.size(),
+            iv.c_data(), iv.size(),
+            &data_pointer, &data_size))
+        return false;
+
+    if (data_pointer == NULL)
+    {
+        CONTRACT_SAFE_LOG(3, "invalid pointer from extension function aes_decrypt_message");
+        return false;
+    }
+
+    return copy_internal_pointer(message, data_pointer, data_size);
+}
+
+/* ----------------------------------------------------------------- *
+ * NAME: ww::crypto::
+ * ----------------------------------------------------------------- */
+bool ww::crypto::ecdsa::generate_keys(
+    StringArray& private_key,
+    StringArray& public_key)
+{
+    uint8_t* priv_data_pointer = NULL;
+    size_t priv_data_size = 0;
+
+    uint8_t* pub_data_pointer = NULL;
+    size_t pub_data_size = 0;
+
+    if (! ::ecdsa_create_signing_keys(
+            (char**)&priv_data_pointer, &priv_data_size,
+            (char**)&pub_data_pointer, &pub_data_size))
+        return false;
+
+    // there is a possibility that allocated memory would not be freed using the
+    // logic below (e.g. if the copy_internal_pointer fails); i don't believe this
+    // can be address well until exceptions are fully supported by WASM
+
+    if (priv_data_pointer == NULL)
+    {
+        CONTRACT_SAFE_LOG(3, "invalid pointer from extension function ecdsa_create_signing_keys");
+        return false;
+    }
+
+    verify_null_terminated((const char*)priv_data_pointer, priv_data_size);
+
+    if (! copy_internal_pointer(private_key, priv_data_pointer, priv_data_size))
+        return false;
+
+    if (pub_data_pointer == NULL)
+    {
+        CONTRACT_SAFE_LOG(3, "invalid pointer from extension function ecdsa_create_signing_keys");
+        return false;
+    }
+
+    verify_null_terminated((const char*)pub_data_pointer, pub_data_size);
+
+    return copy_internal_pointer(public_key, pub_data_pointer, pub_data_size);
+}
+
+/* ----------------------------------------------------------------- *
+ * NAME: ww::crypto::
+ * ----------------------------------------------------------------- */
+bool ww::crypto::ecdsa::sign_message(
+    const StringArray& message,
+    const StringArray& private_key,
+    StringArray& signature)
+{
+    verify_null_terminated((const char*)private_key.c_data(), private_key.size());
+
+    uint8_t* data_pointer = NULL;
+    size_t data_size = 0;
+
+    if (! ::ecdsa_sign_message(
+            message.c_data(), message.size(),
+            (const char*)private_key.c_data(), private_key.size(),
+            &data_pointer, &data_size))
+        return false;
+
+    if (data_pointer == NULL)
+    {
+        CONTRACT_SAFE_LOG(3, "invalid pointer from extension function ecdsa_sign_message");
+        return false;
+    }
+
+    return copy_internal_pointer(signature, data_pointer, data_size);
+}
+
+/* ----------------------------------------------------------------- *
+ * NAME: ww::crypto::
+ * ----------------------------------------------------------------- */
+bool ww::crypto::ecdsa::verify_signature(
+    const StringArray& message,
+    const StringArray& public_key,
+    const StringArray& signature)
+{
+    verify_null_terminated((const char*)public_key.c_data(), public_key.size());
+
+    uint8_t* data_pointer = NULL;
+    size_t data_size = 0;
+
+    return ::ecdsa_verify_signature(
+        message.c_data(), message.size(),
+        (const char*)public_key.c_data(), public_key.size(),
+        signature.c_data(), signature.size());
+}
+
+/* ----------------------------------------------------------------- *
+ * NAME: ww::crypto::
+ * ----------------------------------------------------------------- */
+bool ww::crypto::rsa::generate_keys(
+    StringArray& private_key,
+    StringArray& public_key)
+{
+    uint8_t* priv_data_pointer = NULL;
+    size_t priv_data_size = 0;
+
+    uint8_t* pub_data_pointer = NULL;
+    size_t pub_data_size = 0;
+
+    if (! ::rsa_generate_keys(
+            (char**)&priv_data_pointer, &priv_data_size,
+            (char**)&pub_data_pointer, &pub_data_size))
+        return false;
+
+    // there is a possibility that allocated memory would not be freed using the
+    // logic below (e.g. if the copy_internal_pointer fails); i don't believe this
+    // can be address well until exceptions are fully supported by WASM
+
+    if (priv_data_pointer == NULL)
+    {
+        CONTRACT_SAFE_LOG(3, "invalid pointer from extension function rsa_generate_keys");
+        return false;
+    }
+
+    if (! copy_internal_pointer(private_key, priv_data_pointer, priv_data_size))
+        return false;
+
+    if (pub_data_pointer == NULL)
+    {
+        CONTRACT_SAFE_LOG(3, "invalid pointer from extension function rsa_generate_keys");
+        return false;
+    }
+
+    return copy_internal_pointer(public_key, pub_data_pointer, pub_data_size);
+}
+
+/* ----------------------------------------------------------------- *
+ * NAME: ww::crypto::
+ * ----------------------------------------------------------------- */
+bool ww::crypto::rsa::encrypt_message(
+    const StringArray& message,
+    const StringArray& public_key,
+    StringArray& cipher)
+{
+    uint8_t* data_pointer = NULL;
+    size_t data_size = 0;
+
+    if (! ::rsa_encrypt_message(
+            message.c_data(), message.size(),
+            (const char*)public_key.c_data(), public_key.size(),
+            &data_pointer, &data_size))
+        return false;
+
+    if (data_pointer == NULL)
+    {
+        CONTRACT_SAFE_LOG(3, "invalid pointer from extension function rsa_encrypt_message");
+        return false;
+    }
+
+    return copy_internal_pointer(cipher, data_pointer, data_size);
+}
+
+/* ----------------------------------------------------------------- *
+ * NAME: ww::crypto::
+ * ----------------------------------------------------------------- */
+bool ww::crypto::rsa::decrypt_message(
+    const StringArray& cipher,
+    const StringArray& private_key,
+    StringArray& message)
+{
+    uint8_t* data_pointer = NULL;
+    size_t data_size = 0;
+
+    if (! ::rsa_decrypt_message(
+            cipher.c_data(), cipher.size(),
+            (const char*)private_key.c_data(), private_key.size(),
+            &data_pointer, &data_size))
+        return false;
+
+    if (data_pointer == NULL)
+    {
+        CONTRACT_SAFE_LOG(3, "invalid pointer from extension function rsa_decrypt_message");
+        return false;
+    }
+
+    return copy_internal_pointer(message, data_pointer, data_size);
+}

--- a/contracts/wawaka/common/Cryptography.h
+++ b/contracts/wawaka/common/Cryptography.h
@@ -1,0 +1,89 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <string.h>
+
+#include "StringArray.h"
+
+namespace ww
+{
+namespace crypto
+{
+    bool random_identifier(StringArray& identifier);
+
+    bool b64_encode(
+        const StringArray& message,
+        StringArray& encoded_message);
+
+    bool b64_decode(
+        const StringArray& encoded_message,
+        StringArray& message);
+
+    namespace aes
+    {
+        bool generate_key(StringArray& key);
+        bool generate_iv(StringArray& iv);
+
+        bool encrypt_message(
+            const StringArray& message,
+            const StringArray& key,
+            const StringArray& iv,
+            StringArray& encrypted_message);
+
+        bool decrypt_message(
+            const StringArray& message,
+            const StringArray& key,
+            const StringArray& iv,
+            StringArray& encrypted_message);
+    };
+
+    namespace ecdsa
+    {
+        bool generate_keys(
+            StringArray& private_key,
+            StringArray& public_key);
+
+        bool sign_message(
+            const StringArray& message,
+            const StringArray& private_key,
+            StringArray& signature);
+
+        bool verify_signature(
+            const StringArray& message,
+            const StringArray& public_key,
+            const StringArray& signature);
+    };
+
+    namespace rsa
+    {
+        bool generate_keys(
+            StringArray& private_key,
+            StringArray& public_key);
+
+        bool encrypt_message(
+            const StringArray& message,
+            const StringArray& public_key,
+            StringArray& encrypted_message);
+
+        bool decrypt_message(
+            const StringArray& message,
+            const StringArray& private_key,
+            StringArray& encrypted_message);
+    };
+};                              /* namespace crypto */
+};                              /* namespac ww */

--- a/contracts/wawaka/common/StringArray.cpp
+++ b/contracts/wawaka/common/StringArray.cpp
@@ -92,8 +92,12 @@ bool StringArray::clear(void)
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 bool StringArray::resize(const size_t size)
 {
+    // StringArray does not attempt to reuse memory, we clear
+    // the allocation and start afresh
     clear();
 
+    // if size is 0, then this is equivalent to a clear meaning
+    // that space is deallocated
     if (size == 0)
         return true;
 

--- a/contracts/wawaka/common/StringArray.h
+++ b/contracts/wawaka/common/StringArray.h
@@ -20,15 +20,17 @@
 
 class StringArray
 {
-public:
-    uint8_t *value_;
-    size_t size_;
+protected:
+    uint8_t *value_ = NULL;
+    size_t size_ = 0;
 
+public:
     StringArray(void);
     StringArray(const size_t size);
     StringArray(const uint8_t* buffer, size_t size);
     StringArray(const char* buffer);
     StringArray(const StringArray& value);
+
     ~StringArray(void);
 
     bool clear(void);
@@ -36,9 +38,10 @@ public:
     bool assign(const uint8_t* buffer, size_t size);
     bool assign(const char* buffer);
     bool set(uint8_t v, size_t p);
-    bool take(uint8_t* buffer, size_t size);
     bool equal(const StringArray& sarray) const;
     bool null_terminated(void) const;
+
+    bool take(uint8_t* buffer, size_t size);
 
     const size_t size(void) const;
     uint8_t* data(void);

--- a/contracts/wawaka/common/Util.cpp
+++ b/contracts/wawaka/common/Util.cpp
@@ -16,6 +16,8 @@
 #include <malloc.h>
 #include <stdint.h>
 
+#include "Util.h"
+
 #include <new>
 
 void * operator new(size_t sz) throw(std::bad_alloc)
@@ -31,4 +33,23 @@ void * operator new[](size_t sz) throw(std::bad_alloc)
 void operator delete(void *ptr) _NOEXCEPT
 {
     free(ptr);
+}
+
+/* ----------------------------------------------------------------- *
+ * NAME: copy_internal_pointer
+ * ----------------------------------------------------------------- */
+bool copy_internal_pointer(
+    StringArray& result,
+    uint8_t* pointer,
+    uint32_t size)
+{
+#ifdef SAFE_INTERNAL_COPY
+    // the safe way
+    bool success = result.assign(pointer, size);
+    free(pointer);
+    return success;
+#else
+    // the efficient way
+    return result.take(pointer, size);
+#endif
 }

--- a/contracts/wawaka/common/Util.h
+++ b/contracts/wawaka/common/Util.h
@@ -15,8 +15,25 @@
 
 #pragma once
 
+#include <stdint.h>
+
+#include "StringArray.h"
+
+#define ASSERT_CONDITION(_cond, _rsp) \
+    do { \
+    if (! _cond)
+
+
 #define ASSERT_SENDER_IS_OWNER(_env, _rsp)                              \
     do {                                                                \
         if (strcmp(_env.creator_id_, _env.originator_id_) != 0)         \
             return _rsp.error("only the owner may invoke this method"); \
     } while (0)
+
+// set to 0 for more memory efficient implementation
+#define SAFE_INTERNAL_COPY
+
+bool copy_internal_pointer(
+    StringArray& result,
+    uint8_t* pointer,
+    uint32_t size);

--- a/contracts/wawaka/common/Value.cpp
+++ b/contracts/wawaka/common/Value.cpp
@@ -93,7 +93,7 @@ bool ww::value::Value::deserialize(const char* value)
     if (json_value_get_type(json_value) != expected_value_type_)
     {
         CONTRACT_SAFE_LOG(3, "value deserialize; type mismatch on objects");
-        free(json_value);
+        json_value_free(json_value);
         return false;
     }
 
@@ -114,47 +114,26 @@ bool ww::value::Value::serialize(StringArray& result) const
         return false;
     }
 
-    // serialize the result
-    size_t serialized_size = json_serialization_size(value_);
-    char *serialized_response = (char *)malloc(serialized_size + 1);
+    char *serialized_response = (char *)serialize();
     if (serialized_response == NULL)
-    {
-        CONTRACT_SAFE_LOG(1, "failed serialization; failed allocation");
         return false;
-    }
 
-    JSON_Status jret = json_serialize_to_buffer(value_, serialized_response, serialized_size + 1);
-    if (jret != JSONSuccess)
-    {
-        CONTRACT_SAFE_LOG(1, "failed serialization; invalid value");
-        free(serialized_response);
-        return false;
-    }
+    bool success = result.assign(serialized_response);
+    free(serialized_response);
 
-    return result.take((uint8_t*)serialized_response, serialized_size+1);
+    return success;
 }
 
 // -----------------------------------------------------------------
 char* ww::value::Value::serialize(void) const
 {
-    // serialize the result
-    size_t serialized_size = json_serialization_size(value_);
-    char *serialized_response = (char *)malloc(serialized_size + 1);
-    if (serialized_response == NULL)
+    if (value_ == NULL)
     {
-        CONTRACT_SAFE_LOG(1, "failed serialization; failed allocation");
+        CONTRACT_SAFE_LOG(1, "failed serialization; no value");
         return NULL;
     }
 
-    JSON_Status jret = json_serialize_to_buffer(value_, serialized_response, serialized_size + 1);
-    if (jret != JSONSuccess)
-    {
-        CONTRACT_SAFE_LOG(1, "failed serialization; invalid value");
-        free(serialized_response);
-        return NULL;
-    }
-
-    return serialized_response;
+    return json_serialize_to_string(value_);
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -290,7 +269,7 @@ int ww::value::Object::get_boolean(const char* key) const
 // -----------------------------------------------------------------
 bool ww::value::Object::get_value(const char* name, ww::value::Value& value) const
 {
-    const JSON_Value *json_value = json_object_get_value(json_object(value_), name);
+    const JSON_Value *json_value = json_object_dotget_value(json_object(value_), name);
     if (json_value == NULL)
         return false;
 
@@ -309,17 +288,24 @@ bool ww::value::Object::set_value(const char* name, const ww::value::Value& valu
     if (name == NULL)
         return false;
 
-    JSON_Value *json_value = json_value_deep_copy(value.get());
-    if (json_value == NULL)
+    const JSON_Value *old_json_value = value.get();
+    if (old_json_value == NULL)
+    {
+        CONTRACT_SAFE_LOG(1, "unable to set value for NULL object");
+        return false;
+    }
+
+    JSON_Value *new_json_value = json_value_deep_copy(old_json_value);
+    if (new_json_value == NULL)
     {
         CONTRACT_SAFE_LOG(1, "object set value; allocation failed");
         return false;
     }
 
-    if (json_object_set_value(json_object(value_), name, json_value) != JSONSuccess)
+    if (json_object_set_value(json_object(value_), name, new_json_value) != JSONSuccess)
     {
         CONTRACT_SAFE_LOG(1, "object set value; failed to save property %s", name);
-        free(json_value);
+        json_value_free(new_json_value);
         return false;
     }
 
@@ -448,7 +434,7 @@ bool ww::value::Array::append_value(const ww::value::Value& value)
 
     if (json_array_append_value(json_array(value_), json_value) != JSONSuccess)
     {
-        free(json_value);
+        json_value_free(json_value);
         return false;
     }
 

--- a/contracts/wawaka/common/Value.cpp
+++ b/contracts/wawaka/common/Value.cpp
@@ -118,6 +118,11 @@ bool ww::value::Value::serialize(StringArray& result) const
     if (serialized_response == NULL)
         return false;
 
+    // as we understand the stability of allocation more
+    // fully we can avoid the copy by using take rather
+    // than assign
+    // bool success = result.take(serialized_reponse);
+
     bool success = result.assign(serialized_response);
     free(serialized_response);
 
@@ -302,7 +307,7 @@ bool ww::value::Object::set_value(const char* name, const ww::value::Value& valu
         return false;
     }
 
-    if (json_object_set_value(json_object(value_), name, new_json_value) != JSONSuccess)
+    if (json_object_dotset_value(json_object(value_), name, new_json_value) != JSONSuccess)
     {
         CONTRACT_SAFE_LOG(1, "object set value; failed to save property %s", name);
         json_value_free(new_json_value);
@@ -352,7 +357,7 @@ bool ww::value::Structure::set_value(const char* name, const ww::value::Value& v
 {
     // for a structure, the value we are assignment must already exist in the
     // object and the type must match
-    const JSON_Value *json_value = json_object_get_value(json_object(value_), name);
+    const JSON_Value *json_value = json_object_dotget_value(json_object(value_), name);
     if (json_value == NULL)
     {
         CONTRACT_SAFE_LOG(4, "key %s does not exist in the structure", name);

--- a/contracts/wawaka/common/Value.h
+++ b/contracts/wawaka/common/Value.h
@@ -50,6 +50,8 @@ namespace value
     {
     public:
         Boolean(const bool value);
+        Boolean(void) : Boolean(true) {};
+
         bool get(void) const;
         bool set(bool value);
     };
@@ -58,6 +60,8 @@ namespace value
     {
     public:
         String(const char* value);
+        String(void) : String("") {};
+
         const char* get(void) const;
         const char* set(const char* value);
     };
@@ -66,6 +70,8 @@ namespace value
     {
     public:
         Number(const double value);
+        Number(void) : Number(0.0) {};
+
         double get(void) const;
         double set(double value);
     };

--- a/contracts/wawaka/interpreter-test/interpreter-test.cpp
+++ b/contracts/wawaka/interpreter-test/interpreter-test.cpp
@@ -27,7 +27,6 @@
 #include "Response.h"
 #include "StringArray.h"
 #include "Value.h"
-//#include "WasmExtensions.h"
 
 static KeyValueStore meta_store("meta");
 static KeyValueStore value_store("values");

--- a/contracts/wawaka/memory-test/memory-test.cpp
+++ b/contracts/wawaka/memory-test/memory-test.cpp
@@ -57,7 +57,7 @@ bool many_keys_test(const Message& msg, const Environment& env, Response& rsp)
     int i = 0;
     for (i = 0; i < num_keys; i++) {
         StringArray key(12);
-        sprintf((char *)key.value_, "%d", i);
+        sprintf((char *)key.data(), "%d", i);
         if (!meta_store.set(key, default_val))
             return rsp.error("failed to store value");
     }
@@ -94,7 +94,7 @@ bool big_value_test(const Message& msg, const Environment& env, Response& rsp)
 
     StringArray value(num_chars);
     for (int i = 0; i < num_chars; i++) {
-        value.set((char)*default_val.value_, i);
+        value.set((char)*default_val.c_data(), i);
     }
 
     if (!meta_store.set(default_key, value))
@@ -115,12 +115,12 @@ bool many_kv_pairs_test(const Message& msg, const Environment& env, Response& rs
     int i = 0;
     StringArray value(num_chars);
     for (i = 0; i < num_chars; i++) {
-        value.set((char)*default_val.value_, i);
+        value.set((char)*default_val.c_data(), i);
     }
 
     for (i = 0; i < num_keys; i++) {
         StringArray key(12);
-        sprintf((char *)key.value_, "%d", i);
+        sprintf((char *)key.data(), "%d", i);
         if (!meta_store.set(key, value))
             return rsp.error("failed to store value");
     }


### PR DESCRIPTION
Add wrappers for the crytography and encoding extension functions
to use StringArray correctly.

Isolate all handling of memory from extension functions in a copy
from internal pointers. Currently this is set for safe mode (meaning
that we copy and free immediately) though a performant mode that
moves management of the pointers into StringArray.

Improve memory management in StringArray and Value.

Add "dot" operations for object retrieval in Value.
Add structures to Value.

Signed-off-by: Mic Bowman <mic.bowman@intel.com>