### PR TITLE
Add the exchange contract family for wawaka.

### DIFF
--- a/contracts/wawaka/exchange/CMakeLists.txt
+++ b/contracts/wawaka/exchange/CMakeLists.txt
@@ -14,10 +14,9 @@
 
 CMAKE_MINIMUM_REQUIRED(VERSION 3.2 FATAL_ERROR)
 
-INCLUDE(contract-build.cmake)
+FILE(GLOB COMMON_EXCHANGE_SOURCE contracts/exchange_base.cpp contracts/common/*.cpp)
+SET(ISSUER_AUTHORITY_BASE contracts/issuer_authority_base.cpp)
 
-ADD_SUBDIRECTORY(interface-test)
-ADD_SUBDIRECTORY(mock-contract)
-ADD_SUBDIRECTORY(interpreter-test)
-ADD_SUBDIRECTORY(memory-test)
-ADD_SUBDIRECTORY(exchange)
+BUILD_CONTRACT(asset_type contracts/asset_type.cpp ${COMMON_EXCHANGE_SOURCE})
+BUILD_CONTRACT(vetting_organization contracts/vetting_organization.cpp ${ISSUER_AUTHORITY_BASE} ${COMMON_EXCHANGE_SOURCE})
+BUILD_CONTRACT(issuer contracts/issuer.cpp ${ISSUER_AUTHORITY_BASE} ${COMMON_EXCHANGE_SOURCE})

--- a/contracts/wawaka/exchange/contracts/asset_type.cpp
+++ b/contracts/wawaka/exchange/contracts/asset_type.cpp
@@ -1,0 +1,212 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "Dispatch.h"
+
+#include "KeyValue.h"
+#include "Environment.h"
+#include "Message.h"
+#include "Response.h"
+#include "StringArray.h"
+#include "Util.h"
+#include "Value.h"
+#include "WasmExtensions.h"
+
+#include "exchange_base.h"
+
+static KeyValueStore asset_type_store("asset_type_store");
+
+const StringArray md_asset_type_id_key("asset_type_identifier");
+const StringArray md_description_key("description");
+const StringArray md_link_key("link");
+const StringArray md_name_key("name");
+
+// -----------------------------------------------------------------
+// METHOD: initialize_contract
+//   contract initialization method
+//
+// JSON PARAMETERS:
+//   none
+//
+// RETURNS:
+//   true if successfully initialized
+// -----------------------------------------------------------------
+bool initialize_contract(const Environment& env, Response& rsp)
+{
+    CONTRACT_SAFE_LOG(4, "initialize_contract");
+
+    if (! ww::exchange::exchange_base::initialize_contract(env, rsp))
+        return false;
+
+    // ---------- save the type identifier ----------
+    const StringArray asset_type_identifier(env.contract_id_);
+    if (! asset_type_store.set(md_asset_type_id_key, asset_type_identifier))
+        return rsp.error("failed to save the asset type identifier");
+
+    // ---------- RETURN ----------
+    return rsp.success(true);
+}
+
+// -----------------------------------------------------------------
+// METHOD: initialize
+//   set the basic information for the asset type
+//
+// JSON PARAMETERS:
+//   description -- string description of the type
+//   link -- URL for more information
+//   name -- short handle for the asset type
+//
+// RETURNS:
+//   true if successfully initialized
+// -----------------------------------------------------------------
+bool initialize(const Message& msg, const Environment& env, Response& rsp)
+{
+    CONTRACT_SAFE_LOG(4, "initialize");
+
+    ASSERT_SENDER_IS_OWNER(env, rsp);
+    ASSERT_UNINITIALIZED(rsp);
+
+    if (! msg.validate_schema("{\"description\":\"\", \"link\":\"\", \"name\":\"\"}"))
+        return rsp.error("invalid request, missing required parameters");
+
+    // save the description
+    const StringArray description(msg.get_string("description"));
+    if (! asset_type_store.set(md_description_key, description))
+        return rsp.error("failed to store the description");
+
+    // save the link
+    const StringArray link(msg.get_string("link"));
+    if (! asset_type_store.set(md_link_key, link))
+        return rsp.error("failed to store the link");
+
+    // save the name
+    const StringArray name(msg.get_string("name"));
+
+    if (! asset_type_store.set(md_name_key, name))
+        return rsp.error("failed to store the name");
+
+    // Mark as initialized
+    if (! ww::exchange::exchange_base::mark_initialized())
+        return rsp.error("failed to store the initialized flag");
+
+    // ---------- RETURN ----------
+    return rsp.success(true);
+}
+
+// -----------------------------------------------------------------
+// METHOD: get_asset_type_identifier
+//   set asset type identifier
+//
+// JSON PARAMETERS:
+//   None
+//
+// RETURNS:
+//   asset type identifier (the contract id)
+// -----------------------------------------------------------------
+bool get_asset_type_identifier(const Message& msg, const Environment& env, Response& rsp)
+{
+    ASSERT_INITIALIZED(rsp);
+    CONTRACT_SAFE_LOG(4, "get_identifier");
+
+    StringArray asset_type_identifier;
+    if (! asset_type_store.get(md_asset_type_id_key, asset_type_identifier))
+        return rsp.error("contract state corrupted, no asset type identifier");
+
+    ww::value::String v((char*)asset_type_identifier.c_data());
+    return rsp.value(v, false);
+}
+
+// -----------------------------------------------------------------
+// METHOD: get_description
+//   set asset type description
+//
+// JSON PARAMETERS:
+//   None
+//
+// RETURNS:
+//   asset type description
+// -----------------------------------------------------------------
+bool get_description(const Message& msg, const Environment& env, Response& rsp)
+{
+    ASSERT_INITIALIZED(rsp);
+    CONTRACT_SAFE_LOG(4, "get_description");
+
+    StringArray description;
+    if (! asset_type_store.get(md_description_key, description))
+        return rsp.error("contract state corrupted, no description");
+
+    ww::value::String v((char*)description.c_data());
+    return rsp.value(v, false);
+}
+
+// -----------------------------------------------------------------
+// METHOD: get_link
+//   set asset type link
+//
+// JSON PARAMETERS:
+//   None
+//
+// RETURNS:
+//   asset type link
+// -----------------------------------------------------------------
+bool get_link(const Message& msg, const Environment& env, Response& rsp)
+{
+    ASSERT_INITIALIZED(rsp);
+    CONTRACT_SAFE_LOG(4, "get_link");
+
+    StringArray link;
+    if (! asset_type_store.get(md_link_key, link))
+        return rsp.error("contract state corrupted, no link");
+
+    ww::value::String v((char*)link.c_data());
+    return rsp.value(v, false);
+}
+
+// -----------------------------------------------------------------
+// METHOD: get_name
+//   set asset type name
+//
+// JSON PARAMETERS:
+//   None
+//
+// RETURNS:
+//   asset type name
+// -----------------------------------------------------------------
+bool get_name(const Message& msg, const Environment& env, Response& rsp)
+{
+    ASSERT_INITIALIZED(rsp);
+    CONTRACT_SAFE_LOG(4, "get_name");
+
+    StringArray name;
+    if (! asset_type_store.get(md_name_key, name))
+        return rsp.error("contract state corrupted, no name");
+
+    ww::value::String v((char*)name.c_data());
+    return rsp.value(v, false);
+}
+
+// -----------------------------------------------------------------
+// -----------------------------------------------------------------
+contract_method_reference_t contract_method_dispatch_table[] = {
+    CONTRACT_METHOD(initialize),
+    CONTRACT_METHOD(get_asset_type_identifier),
+    CONTRACT_METHOD(get_description),
+    CONTRACT_METHOD(get_link),
+    CONTRACT_METHOD(get_name),
+    { NULL, NULL }
+};

--- a/contracts/wawaka/exchange/contracts/common/Asset.cpp
+++ b/contracts/wawaka/exchange/contracts/common/Asset.cpp
@@ -1,0 +1,121 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Asset.h"
+#include "Cryptography.h"
+#include "StateReference.h"
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// Class: ww::exchange::Asset
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+// -----------------------------------------------------------------
+ww::exchange::Asset::Asset(void) :
+    ww::value::Structure(ASSET_SCHEMA)
+{
+    return;
+}
+
+// -----------------------------------------------------------------
+SIMPLE_PROPERTY_GET(Asset, asset_type_identifier, ww::value::String);
+SIMPLE_PROPERTY_GET(Asset, count, ww::value::Number);
+SIMPLE_PROPERTY_GET(Asset, owner_identity, ww::value::String);
+SIMPLE_PROPERTY_GET(Asset, escrow_agent_identity, ww::value::String);
+SIMPLE_PROPERTY_GET(Asset, escrow_identifier, ww::value::String);
+
+SIMPLE_PROPERTY_SET(Asset, asset_type_identifier, ww::value::String);
+SIMPLE_PROPERTY_SET(Asset, count, ww::value::Number);
+SIMPLE_PROPERTY_SET(Asset, owner_identity, ww::value::String);
+SIMPLE_PROPERTY_SET(Asset, escrow_agent_identity, ww::value::String);
+SIMPLE_PROPERTY_SET(Asset, escrow_identifier, ww::value::String);
+
+// -----------------------------------------------------------------
+bool ww::exchange::Asset::serialize_for_escrow_signing(
+    const ww::exchange::StateReference& escrow_agent_state_reference,
+    StringArray& serialized) const
+{
+    ww::value::Array serializer;
+    serializer.append_value(*this);
+    serializer.append_value(escrow_agent_state_reference);
+
+    if (! serializer.serialize(serialized))
+        return false;
+
+    return true;
+}
+
+// -----------------------------------------------------------------
+bool ww::exchange::Asset::sign_for_escrow(
+    const ww::exchange::StateReference& escrow_agent_state_reference,
+    const StringArray& escrow_agent_signing_key,
+    StringArray& encoded_signature) const
+{
+    // serialize the asset
+    StringArray serialized;
+    if (! serialize_for_escrow_signing(escrow_agent_state_reference, serialized))
+        return false;
+
+    // sign the serialized authority
+    StringArray signature;
+    if (! ww::crypto::ecdsa::sign_message(serialized, escrow_agent_signing_key, signature))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to sign serialized authoritative asset");
+        return false;
+    }
+
+    // base64 encode the signature so we can use it in the JSON
+    if (! ww::crypto::b64_encode(signature, encoded_signature))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to encode authoritative asset signature");
+        return false;
+    }
+
+    return true;
+}
+
+// -----------------------------------------------------------------
+bool ww::exchange::Asset::verify_escrow_signature(
+    const ww::exchange::StateReference& escrow_agent_state_reference,
+    const StringArray& encoded_signature) const
+{
+    // get the escrow agent verifying key
+    ww::value::String escrow_agent_identity_string;
+    if (! get_escrow_agent_identity(escrow_agent_identity_string))
+        return false;
+
+    const StringArray escrow_agent_verifying_key(escrow_agent_identity_string.get());
+
+    // serialize the asset
+    StringArray serialized;
+    if (! serialize_for_escrow_signing(escrow_agent_state_reference, serialized))
+        return false;
+
+    // sign the signature from the object
+    StringArray signature;
+
+    if (! ww::crypto::b64_decode(encoded_signature, signature))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to decode issuer authority signature");
+        return false;
+    }
+
+    if (! ww::crypto::ecdsa::verify_signature(serialized, escrow_agent_verifying_key, signature))
+    {
+        CONTRACT_SAFE_LOG(2, "failed to verify issuer authority");
+        return false;
+    }
+
+    return true;
+}

--- a/contracts/wawaka/exchange/contracts/common/Asset.h
+++ b/contracts/wawaka/exchange/contracts/common/Asset.h
@@ -1,0 +1,68 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "Value.h"
+
+#include "Common.h"
+#include "StateReference.h"
+
+#define ASSET_SCHEMA "{"                   \
+    SCHEMA_KW(asset_type_identifier,"") ","     \
+    SCHEMA_KW(count,0) ","                      \
+    SCHEMA_KW(owner_identity,"") ","            \
+    SCHEMA_KW(escrow_agent_identity,"") ","     \
+    SCHEMA_KW(escrow_identifier,"")             \
+    "}"
+
+namespace ww
+{
+namespace exchange
+{
+    class Asset : public ww::value::Structure
+    {
+    private:
+        bool serialize_for_escrow_signing(
+            const ww::exchange::StateReference& escrow_agent_state_reference,
+            StringArray& serialized) const;
+
+    public:
+        bool get_asset_type_identifier(ww::value::String& value) const;
+        bool get_count(ww::value::Number& value) const;
+        bool get_owner_identity(ww::value::String& value) const;
+        bool get_escrow_agent_identity(ww::value::String& value) const;
+        bool get_escrow_identifier(ww::value::String& value) const;
+
+        bool set_asset_type_identifier(const ww::value::String& value);
+        bool set_count(const ww::value::Number& value);
+        bool set_owner_identity(const ww::value::String& value);
+        bool set_escrow_agent_identity(const ww::value::String& value);
+        bool set_escrow_identifier(const ww::value::String& value);
+
+        bool verify_escrow_signature(
+            const ww::exchange::StateReference& escrow_agent_state_reference,
+            const StringArray& encoded_signature) const;
+
+        bool sign_for_escrow(
+            const ww::exchange::StateReference& escrow_agent_state_reference,
+            const StringArray& escrow_agent_signing_key,
+            StringArray& encoded_signature) const;
+
+        Asset(void);
+    };
+
+};  // namespace exchange
+}  // namespace ww

--- a/contracts/wawaka/exchange/contracts/common/AuthoritativeAsset.cpp
+++ b/contracts/wawaka/exchange/contracts/common/AuthoritativeAsset.cpp
@@ -1,0 +1,135 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Value.h"
+
+#include "Asset.h"
+#include "AuthoritativeAsset.h"
+#include "Common.h"
+#include "Cryptography.h"
+#include "IssuerAuthorityChain.h"
+#include "StateReference.h"
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// Class: ww::exchange::AuthoritativeAsset
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+// -----------------------------------------------------------------
+ww::exchange::AuthoritativeAsset::AuthoritativeAsset(void) :
+    ww::value::Structure(AUTHORITATIVE_ASSET_SCHEMA)
+{
+    return;
+}
+
+// -----------------------------------------------------------------
+bool ww::exchange::AuthoritativeAsset::serialize_for_signing(StringArray& serialized) const
+{
+    // we do not serialize the authority chain because it is
+    // bound to the asset through the verifying key that it
+    // establishes. that is, the authority chain establishes
+    // the authority of the key that signs the asset and state
+    // reference so we do not need to include it in the
+    // serialized buffer
+
+    ww::exchange::Asset asset;
+    if (! get_asset(asset))
+        return false;
+
+    ww::exchange::StateReference state_reference;
+    if (! get_issuer_state_reference(state_reference))
+        return false;
+
+    // we serialize in an array to ensure that there is a consistent ordering
+    ww::value::Array serializer;
+    serializer.append_value(asset);
+    serializer.append_value(state_reference);
+
+    // serialize the rest of the structure
+    if (! serializer.serialize(serialized))
+        return false;
+
+    return true;
+}
+
+// -----------------------------------------------------------------
+bool ww::exchange::AuthoritativeAsset::sign(const StringArray& authorizing_signing_key)
+{
+    StringArray serialized;
+    if (! serialize_for_signing(serialized))
+        return false;
+
+    // sign the serialized authority
+    StringArray signature;
+    if (! ww::crypto::ecdsa::sign_message(serialized, authorizing_signing_key, signature))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to sign serialized authoritative asset");
+        return false;
+    }
+
+    // base64 encode the signature so we can use it in the JSON
+    StringArray encoded;
+    if (! ww::crypto::b64_encode(signature, encoded))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to encode authoritative asset signature");
+        return false;
+    }
+
+    // save the encoded array in the signature field
+    ww::value::String signature_value((const char*)encoded.c_data());
+    return set_issuer_signature(signature_value);
+}
+
+// -----------------------------------------------------------------
+bool ww::exchange::AuthoritativeAsset::verify_signature(const StringArray& authorizing_verifying_key) const
+{
+    StringArray serialized;
+    if (! serialize_for_signing(serialized))
+        return false;
+
+    // sign the signature from the object
+    const StringArray encoded(get_string("issuer_signature"));
+    StringArray signature;
+
+    if (! ww::crypto::b64_decode(encoded, signature))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to decode issuer authority signature");
+        return false;
+    }
+
+    if (! ww::crypto::ecdsa::verify_signature(serialized, authorizing_verifying_key, signature))
+    {
+        CONTRACT_SAFE_LOG(2, "failed to verify issuer authority");
+        return false;
+    }
+
+    return true;
+}
+
+// -----------------------------------------------------------------
+bool ww::exchange::AuthoritativeAsset::validate(void) const
+{
+    return true;
+}
+
+// -----------------------------------------------------------------
+SIMPLE_PROPERTY_GET(AuthoritativeAsset, asset, ww::exchange::Asset);
+SIMPLE_PROPERTY_GET(AuthoritativeAsset, issuer_state_reference, ww::exchange::StateReference);
+SIMPLE_PROPERTY_GET(AuthoritativeAsset, issuer_signature, ww::value::String);
+SIMPLE_PROPERTY_GET(AuthoritativeAsset, issuer_authority_chain, ww::exchange::IssuerAuthorityChain)
+
+SIMPLE_PROPERTY_SET(AuthoritativeAsset, asset, ww::exchange::Asset);
+SIMPLE_PROPERTY_SET(AuthoritativeAsset, issuer_state_reference, ww::exchange::StateReference);
+SIMPLE_PROPERTY_SET(AuthoritativeAsset, issuer_signature, ww::value::String);
+SIMPLE_PROPERTY_SET(AuthoritativeAsset, issuer_authority_chain, ww::exchange::IssuerAuthorityChain)

--- a/contracts/wawaka/exchange/contracts/common/AuthoritativeAsset.h
+++ b/contracts/wawaka/exchange/contracts/common/AuthoritativeAsset.h
@@ -1,0 +1,61 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "Value.h"
+
+#include "Asset.h"
+#include "Common.h"
+#include "IssuerAuthorityChain.h"
+#include "StateReference.h"
+
+#define AUTHORITATIVE_ASSET_SCHEMA "{"                             \
+    "\"asset\":" ASSET_SCHEMA ","                                  \
+    "\"issuer_state_reference\":" STATE_REFERENCE_SCHEMA ","            \
+    SCHEMA_KW(issuer_signature,"") ","                                  \
+    "\"issuer_authority_chain\":" ISSUER_AUTHORITY_CHAIN_SCHEMA    \
+    "}"
+
+namespace ww
+{
+namespace exchange
+{
+
+    class AuthoritativeAsset : public ww::value::Structure
+    {
+    private:
+        bool serialize_for_signing(StringArray& serialized) const;
+
+    public:
+        bool get_asset(ww::exchange::Asset& value) const;
+        bool get_issuer_state_reference(ww::exchange::StateReference& value) const;
+        bool get_issuer_signature(ww::value::String& value) const;
+        bool get_issuer_authority_chain(ww::exchange::IssuerAuthorityChain& value) const;
+
+        bool set_asset(const ww::exchange::Asset& value);
+        bool set_issuer_state_reference(const ww::exchange::StateReference& value);
+        bool set_issuer_signature(const ww::value::String& value);
+        bool set_issuer_authority_chain(const ww::exchange::IssuerAuthorityChain& value);
+
+        bool sign(const StringArray& authorizing_signing_key);
+        bool verify_signature(const StringArray& authorizing_verifying_key) const;
+        bool validate(void) const;
+
+        AuthoritativeAsset(void);
+    };
+
+};
+}

--- a/contracts/wawaka/exchange/contracts/common/Common.h
+++ b/contracts/wawaka/exchange/contracts/common/Common.h
@@ -1,0 +1,31 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include "WasmExtensions.h"
+
+#define SIMPLE_PROPERTY_GET(CLASS, KEY, TYPE)                   \
+    bool ww::exchange::CLASS::get_##KEY(TYPE& value) const      \
+    {                                                           \
+        return get_value(#KEY, value);                          \
+    }
+
+#define SIMPLE_PROPERTY_SET(CLASS, KEY, TYPE)                   \
+    bool ww::exchange::CLASS::set_##KEY(const TYPE& value)      \
+    {                                                           \
+        return set_value(#KEY, value);                          \
+    }
+
+#define SCHEMA_KW(kw,v) "\"" #kw "\":" #v

--- a/contracts/wawaka/exchange/contracts/common/EscrowClaim.cpp
+++ b/contracts/wawaka/exchange/contracts/common/EscrowClaim.cpp
@@ -1,0 +1,127 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Cryptography.h"
+#include "Value.h"
+
+#include "EscrowClaim.h"
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// Class: ww::exchange::EscrowClaim
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+// -----------------------------------------------------------------
+ww::exchange::EscrowClaim::EscrowClaim(void) :
+    ww::value::Structure(ESCROW_CLAIM_SCHEMA)
+{
+    return;
+}
+
+// -----------------------------------------------------------------
+SIMPLE_PROPERTY_GET(EscrowClaim, old_owner_identity, ww::value::String);
+SIMPLE_PROPERTY_GET(EscrowClaim, escrow_agent_state_reference, ww::exchange::StateReference);
+SIMPLE_PROPERTY_GET(EscrowClaim, escrow_agent_signature, ww::value::String);
+
+SIMPLE_PROPERTY_SET(EscrowClaim, old_owner_identity, ww::value::String);
+SIMPLE_PROPERTY_SET(EscrowClaim, escrow_agent_state_reference, ww::exchange::StateReference);
+SIMPLE_PROPERTY_SET(EscrowClaim, escrow_agent_signature, ww::value::String);
+
+// -----------------------------------------------------------------
+bool ww::exchange::EscrowClaim::serialize_for_signing(
+    const ww::value::String& escrow_identifier,
+    StringArray& serialized) const
+{
+    ww::value::String old_owner_identity;
+    if (! get_old_owner_identity(old_owner_identity))
+        return false;
+
+    ww::exchange::StateReference state_reference;
+    if (! get_escrow_agent_state_reference(state_reference))
+        return false;
+
+    // we use the array to ensure that the ordering of fields
+    // is consistent
+    ww::value::Array serializer;
+    serializer.append_value(escrow_identifier);
+    serializer.append_value(old_owner_identity);
+    serializer.append_value(state_reference);
+
+    if (! serializer.serialize(serialized))
+        return false;
+
+    return true;
+}
+
+// -----------------------------------------------------------------
+bool ww::exchange::EscrowClaim::sign(
+    const ww::value::String& escrow_identifier,
+    const StringArray& escrow_agent_signing_key)
+{
+    StringArray serialized;
+    if (! serialize_for_signing(escrow_identifier, serialized))
+        return false;
+
+    // sign the serialized claim
+    StringArray signature;
+    if (! ww::crypto::ecdsa::sign_message(serialized, escrow_agent_signing_key, signature))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to sign serialized issuer authority");
+        return false;
+    }
+
+    // base64 encode the signature so we can use it in the JSON
+    StringArray encoded;
+    if (! ww::crypto::b64_encode(signature, encoded))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to encode issuer authority signature");
+        return false;
+    }
+
+    // save the encoded array in the signature field
+    ww::value::String signature_string((const char*)encoded.c_data());
+    return set_escrow_agent_signature(signature_string);
+}
+
+// -----------------------------------------------------------------
+bool ww::exchange::EscrowClaim::verify_signature(
+    const ww::value::String& escrow_identifier,
+    const StringArray& escrow_agent_verifying_key) const
+{
+    StringArray serialized;
+    if (! serialize_for_signing(escrow_identifier, serialized))
+        return false;
+
+    // sign the signature from the object
+    ww::value::String signature_string;
+    if (! get_escrow_agent_signature(signature_string))
+        return false;
+
+    const StringArray encoded(signature_string.get());
+    StringArray signature;
+
+    if (! ww::crypto::b64_decode(encoded, signature))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to decode issuer authority signature");
+        return false;
+    }
+
+    if (! ww::crypto::ecdsa::verify_signature(serialized, escrow_agent_verifying_key, signature))
+    {
+        CONTRACT_SAFE_LOG(2, "failed to verify issuer authority");
+        return false;
+    }
+
+    return true;
+}

--- a/contracts/wawaka/exchange/contracts/common/EscrowClaim.h
+++ b/contracts/wawaka/exchange/contracts/common/EscrowClaim.h
@@ -1,0 +1,63 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "Value.h"
+
+#include "Common.h"
+#include "StateReference.h"
+
+#define ESCROW_CLAIM_SCHEMA "{"                                         \
+    SCHEMA_KW(old_owner_identity,"") ","                              \
+    "\"escrow_agent_state_reference\":" STATE_REFERENCE_SCHEMA ","      \
+    SCHEMA_KW(escrow_agent_signature,"")                                \
+    "}"
+
+namespace ww
+{
+namespace exchange
+{
+
+    class EscrowClaim : public ww::value::Structure
+    {
+    private:
+        bool serialize_for_signing(
+            const ww::value::String& escrow_identifier,
+            StringArray& serialized) const;
+
+        bool get_escrow_agent_signature(ww::value::String& value) const;
+        bool set_escrow_agent_signature(const ww::value::String& value);
+
+    public:
+        bool get_old_owner_identity(ww::value::String& value) const;
+        bool get_escrow_agent_state_reference(ww::exchange::StateReference& value) const;
+
+        bool set_old_owner_identity(const ww::value::String& value);
+        bool set_escrow_agent_state_reference(const ww::exchange::StateReference& value);
+
+        bool verify_signature(
+            const ww::value::String& escrow_identifier,
+            const StringArray& escrow_agent_verifying_key) const;
+
+        bool sign(
+            const ww::value::String& escrow_identifier,
+            const StringArray& escrow_agent_signing_key);
+
+        EscrowClaim(void);
+    };
+
+};
+}

--- a/contracts/wawaka/exchange/contracts/common/IssuerAuthority.cpp
+++ b/contracts/wawaka/exchange/contracts/common/IssuerAuthority.cpp
@@ -1,0 +1,158 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include "Cryptography.h"
+#include "IssuerAuthority.h"
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// Class: ww::exchange::IssuerAuthority
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+static const ww::exchange::IssuerAuthority issuer_authority_schema;
+
+// -----------------------------------------------------------------
+ww::exchange::IssuerAuthority::IssuerAuthority(void) :
+    ww::value::Structure(ISSUER_AUTHORITY_SCHEMA)
+{
+    return;
+}
+
+// -----------------------------------------------------------------
+ww::exchange::IssuerAuthority::IssuerAuthority(
+    const ww::value::String& issuer_verifying_key,
+    const ww::exchange::StateReference& reference) :
+    ww::value::Structure(ISSUER_AUTHORITY_SCHEMA)
+{
+    set_authorized_issuer_verifying_key(issuer_verifying_key);
+    set_issuer_state_reference(reference);
+}
+
+// -----------------------------------------------------------------
+SIMPLE_PROPERTY_GET(IssuerAuthority, authorized_issuer_verifying_key, ww::value::String);
+SIMPLE_PROPERTY_GET(IssuerAuthority, issuer_state_reference, ww::exchange::StateReference);
+SIMPLE_PROPERTY_GET(IssuerAuthority, authorizing_signature, ww::value::String);
+
+SIMPLE_PROPERTY_SET(IssuerAuthority, authorized_issuer_verifying_key, ww::value::String);
+SIMPLE_PROPERTY_SET(IssuerAuthority, issuer_state_reference, ww::exchange::StateReference);
+SIMPLE_PROPERTY_SET(IssuerAuthority, authorizing_signature, ww::value::String);
+
+// -----------------------------------------------------------------
+bool ww::exchange::IssuerAuthority::serialize_for_signing(
+    const StringArray& asset_type_identifier,
+    StringArray& serialized
+    ) const
+{
+    ww::value::String ati_value((const char*)asset_type_identifier.c_data());
+
+    ww::value::String ivk_value("");
+    if (! get_authorized_issuer_verifying_key(ivk_value))
+        return false;
+
+    ww::exchange::StateReference isr_value;
+    if (! get_issuer_state_reference(isr_value))
+        return false;
+
+    // we serialize in an array to ensure that there is a consistent ordering
+    ww::value::Array serializer;
+    serializer.append_value(ati_value);
+    serializer.append_value(ivk_value);
+    serializer.append_value(isr_value);
+
+    // serialize the rest of the structure
+    if (! serializer.serialize(serialized))
+        return false;
+
+    return true;
+}
+
+// -----------------------------------------------------------------
+bool ww::exchange::IssuerAuthority::sign(
+    const StringArray& authorizing_signing_key,
+    const StringArray& asset_type_identifier
+    )
+{
+    // serialize the authority for signing
+    StringArray serialized;
+    if (! serialize_for_signing(asset_type_identifier, serialized))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to serialize issuer authority");
+        return false;
+    }
+
+    // sign the serialized authority
+    StringArray signature;
+    if (! ww::crypto::ecdsa::sign_message(serialized, authorizing_signing_key, signature))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to sign serialized issuer authority");
+        return false;
+    }
+
+    // base64 encode the signature so we can use it in the JSON
+    StringArray encoded;
+    if (! ww::crypto::b64_encode(signature, encoded))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to encode issuer authority signature");
+        return false;
+    }
+
+    // save the encoded array in the signature field
+    ww::value::String signature_value((const char*)encoded.c_data());
+    return set_authorizing_signature(signature_value);
+}
+
+// -----------------------------------------------------------------
+bool ww::exchange::IssuerAuthority::verify_signature(
+    const StringArray& authorizing_verifying_key,
+    const StringArray& asset_type_identifier
+    ) const
+{
+    // serialize the authority for signing
+    StringArray serialized;
+    if (! serialize_for_signing(asset_type_identifier, serialized))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to serialize issuer authority");
+        return false;
+    }
+
+    // sign the signature from the object
+    const StringArray encoded(get_string("authorizing_signature"));
+    StringArray signature;
+
+    if (! ww::crypto::b64_decode(encoded, signature))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to decode issuer authority signature");
+        return false;
+    }
+
+    if (! ww::crypto::ecdsa::verify_signature(serialized, authorizing_verifying_key, signature))
+    {
+        CONTRACT_SAFE_LOG(2, "failed to verify issuer authority");
+        return false;
+    }
+
+    return true;
+}
+
+// -----------------------------------------------------------------
+bool ww::exchange::IssuerAuthority::validate(
+    const StringArray& authorizing_verifying_key,
+    const StringArray& asset_type_identifier
+    ) const
+{
+    if (! validate_schema(issuer_authority_schema))
+        return false;
+
+    return verify_signature(authorizing_verifying_key, asset_type_identifier);
+}

--- a/contracts/wawaka/exchange/contracts/common/IssuerAuthority.h
+++ b/contracts/wawaka/exchange/contracts/common/IssuerAuthority.h
@@ -1,0 +1,73 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "StringArray.h"
+#include "Value.h"
+
+#include "Common.h"
+#include "StateReference.h"
+
+#define ISSUER_AUTHORITY_SCHEMA "{"                        \
+    SCHEMA_KW(authorized_issuer_verifying_key,"") ","           \
+    "\"issuer_state_reference\":" STATE_REFERENCE_SCHEMA ","    \
+    SCHEMA_KW(authorizing_signature,"")                         \
+    "}"
+
+namespace ww
+{
+namespace exchange
+{
+
+    class IssuerAuthority : public ww::value::Structure
+    {
+    private:
+        bool serialize_for_signing(
+            const StringArray& asset_type_identifier,
+            StringArray& serialized) const;
+
+    public:
+        bool get_authorized_issuer_verifying_key(ww::value::String& value) const;
+        bool get_issuer_state_reference(ww::exchange::StateReference& value) const;
+        bool get_authorizing_signature(ww::value::String& value) const;
+
+        bool set_authorized_issuer_verifying_key(const ww::value::String& value);
+        bool set_issuer_state_reference(const ww::exchange::StateReference& value);
+        bool set_authorizing_signature(const ww::value::String& value);
+
+        bool sign(
+            const StringArray& authorizing_signing_key,
+            const StringArray& asset_type_identifier);
+
+        bool verify_signature(
+            const StringArray& authorizing_verifying_key,
+            const StringArray& asset_type_identifier) const;
+
+        bool validate(
+            const StringArray& authorizing_verifying_key,
+            const StringArray& asset_type_identifier
+            ) const;
+
+        IssuerAuthority(void);
+
+        IssuerAuthority(
+            const ww::value::String& issuer_verifying_key,
+            const ww::exchange::StateReference& reference);
+
+    };
+
+};
+}

--- a/contracts/wawaka/exchange/contracts/common/IssuerAuthorityChain.cpp
+++ b/contracts/wawaka/exchange/contracts/common/IssuerAuthorityChain.cpp
@@ -1,0 +1,138 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "WasmExtensions.h"
+#include "IssuerAuthorityChain.h"
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// Class: ww::exchange::IssuerAuthorityChain
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+static const ww::exchange::IssuerAuthorityChain issuer_authority_chain_schema;
+
+// -----------------------------------------------------------------
+ww::exchange::IssuerAuthorityChain::IssuerAuthorityChain(void) :
+    ww::value::Structure(ISSUER_AUTHORITY_CHAIN_SCHEMA)
+{
+    return;
+}
+
+// -----------------------------------------------------------------
+ww::exchange::IssuerAuthorityChain::IssuerAuthorityChain(
+    const ww::value::String& asset_type_identifier,
+    const ww::value::String& vetting_organization_verifying_key) :
+    ww::value::Structure(ISSUER_AUTHORITY_CHAIN_SCHEMA)
+{
+    if (! set_asset_type_identifier(asset_type_identifier))
+    {
+        CONTRACT_SAFE_LOG(1, "issuer authority chain; failed to set asset type identifier");
+        return;
+    }
+
+    if (! set_vetting_organization_verifying_key(vetting_organization_verifying_key))
+    {
+        CONTRACT_SAFE_LOG(1, "issuer authority chain; failed to set verifying key");
+        return;
+    }
+
+    return;
+}
+
+// -----------------------------------------------------------------
+SIMPLE_PROPERTY_GET(IssuerAuthorityChain, asset_type_identifier, ww::value::String);
+SIMPLE_PROPERTY_GET(IssuerAuthorityChain, vetting_organization_verifying_key, ww::value::String);
+SIMPLE_PROPERTY_GET(IssuerAuthorityChain, authority_chain, ww::value::Array);
+
+SIMPLE_PROPERTY_SET(IssuerAuthorityChain, asset_type_identifier, ww::value::String);
+SIMPLE_PROPERTY_SET(IssuerAuthorityChain, vetting_organization_verifying_key, ww::value::String);
+SIMPLE_PROPERTY_SET(IssuerAuthorityChain, authority_chain, ww::value::Array);
+
+// -----------------------------------------------------------------
+bool ww::exchange::IssuerAuthorityChain::add_issuer_authority(const ww::exchange::IssuerAuthority& value)
+{
+    // there are a lot of copies in here, definitely not the
+    // most efficient way to add an authority, but this is safe
+    // and is unlikely to be in the middle of a long loop
+    ww::value::Array authority_chain;
+
+    if (! get_value("authority_chain", authority_chain))
+        return false;
+
+    if (! authority_chain.append_value(value))
+        return false;
+
+    if (! set_value("authority_chain", authority_chain))
+        return false;
+
+    return true;
+}
+
+// -----------------------------------------------------------------
+// validate -- verify that the chain establishes the authority of the
+// provided issuer verifying key
+// -----------------------------------------------------------------
+bool ww::exchange::IssuerAuthorityChain::validate(const StringArray& issuer_verifying_key) const
+{
+    if (! validate_schema(issuer_authority_chain_schema))
+        return false;
+
+    ww::value::Array authorities;
+    if (! get_authority_chain(authorities))
+        return false;
+
+    StringArray type_identifier(get_string("asset_type_identifier"));
+    StringArray verifying_key(get_string("vetting_organization_verifying_key"));
+
+    size_t count = authorities.get_count();
+    for (size_t index = 0; index < count; index++)
+    {
+        ww::exchange::IssuerAuthority authority;
+        if (! authorities.get_value(index, authority))
+            return false;
+
+        if (! authority.validate(verifying_key, type_identifier))
+            return false;
+
+        // the key in this authority is used to verify the next authority
+        verifying_key.assign(authority.get_string("authorized_issuer_verifying_key"));
+    }
+
+    return verifying_key.equal(issuer_verifying_key);
+}
+
+// -----------------------------------------------------------------
+bool ww::exchange::IssuerAuthorityChain::add_dependencies_to_response(Response& rsp) const
+{
+    ww::value::Array authorities;
+    if (! get_authority_chain(authorities))
+        return false;
+
+    size_t count = authorities.get_count();
+    for (size_t index = 0; index < count; index++)
+    {
+        ww::exchange::IssuerAuthority authority;
+        if (! authorities.get_value(index, authority))
+            return false;
+
+        ww::exchange::StateReference ref;
+        if (! authority.get_issuer_state_reference(ref))
+            return false;
+
+        if (! rsp.add_dependency(ref.get_string("contract_id"), ref.get_string("state_hash")))
+            return false;
+    }
+
+    return true;
+}

--- a/contracts/wawaka/exchange/contracts/common/IssuerAuthorityChain.h
+++ b/contracts/wawaka/exchange/contracts/common/IssuerAuthorityChain.h
@@ -1,0 +1,58 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "Response.h"
+#include "Value.h"
+
+#include "IssuerAuthority.h"
+
+#define ISSUER_AUTHORITY_CHAIN_SCHEMA "{"                       \
+    SCHEMA_KW(asset_type_identifier,"") ","                     \
+    SCHEMA_KW(vetting_organization_verifying_key,"") ","        \
+    "\"authority_chain\": []"                                   \
+    "}"
+
+namespace ww
+{
+namespace exchange
+{
+
+    class IssuerAuthorityChain : public ww::value::Structure
+    {
+    public:
+        bool get_asset_type_identifier(ww::value::String& value) const;
+        bool get_vetting_organization_verifying_key(ww::value::String& value) const;
+        bool get_authority_chain(ww::value::Array& value) const;
+        bool get_dependencies(ww::value::Array& dependencies) const;
+
+        bool set_asset_type_identifier(const ww::value::String& value);
+        bool set_vetting_organization_verifying_key(const ww::value::String& value);
+        bool set_authority_chain(const ww::value::Array& value);
+
+        bool add_issuer_authority(const ww::exchange::IssuerAuthority& value);
+
+        bool validate(const StringArray& issuer_verifying_key) const;
+        bool add_dependencies_to_response(Response& rsp) const;
+
+        IssuerAuthorityChain(void);
+        IssuerAuthorityChain(
+            const ww::value::String& asset_type_identifier,
+            const ww::value::String& vetting_organization_verifying_key);
+    };
+
+};
+}

--- a/contracts/wawaka/exchange/contracts/common/LedgerEntry.cpp
+++ b/contracts/wawaka/exchange/contracts/common/LedgerEntry.cpp
@@ -1,0 +1,165 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "LedgerEntry.h"
+
+#include "Cryptography.h"
+#include "StringArray.h"
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// Class: ww::exchange::LedgerEntry
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+// -----------------------------------------------------------------
+ww::exchange::LedgerEntry::LedgerEntry(void) :
+    ww::value::Structure(LEDGER_ENTRY_SCHEMA)
+{}
+
+// -----------------------------------------------------------------
+ww::exchange::LedgerEntry::LedgerEntry(const StringArray& serialized) :
+    ww::value::Structure(LEDGER_ENTRY_SCHEMA)
+{
+    if (! serialized.null_terminated())
+    {
+        CONTRACT_SAFE_LOG(1, "JSON string is not null terminated");
+        return;
+    }
+
+    deserialize((const char*)serialized.c_data());
+}
+
+// -----------------------------------------------------------------
+bool ww::exchange::LedgerEntry::is_active(void) const
+{
+    ww::value::Boolean flag(true);
+    if (! get_value("active", flag))
+        return false;
+
+    return flag.get();
+}
+
+// -----------------------------------------------------------------
+bool ww::exchange::LedgerEntry::set_active(void)
+{
+    const ww::value::String null_string("");
+    if (! set_escrow_identifier(null_string))
+        return false;
+
+    if (! set_escrow_agent_identity(null_string))
+        return false;
+
+    ww::value::Boolean flag(true);
+    return set_value("active", flag);
+}
+
+// -----------------------------------------------------------------
+bool ww::exchange::LedgerEntry::set_inactive(const ww::value::String& escrow_agent_identity)
+{
+    if (! set_escrow_agent_identity(escrow_agent_identity))
+        return false;
+
+    if (! initialize_escrow_identifier())
+        return false;
+
+    ww::value::Boolean flag(false);
+    return set_value("active", flag);
+}
+
+// -----------------------------------------------------------------
+uint32_t ww::exchange::LedgerEntry::get_count(void) const
+{
+    ww::value::Number value;
+    if (! get_value("asset.count", value))
+        return 0;
+
+    return (uint32_t)value.get();
+}
+
+// -----------------------------------------------------------------
+bool ww::exchange::LedgerEntry::set_count(uint32_t count)
+{
+    ww::value::Number value(count);
+    return set_value("asset.count", value);
+}
+
+// -----------------------------------------------------------------
+const char* ww::exchange::LedgerEntry::get_owner_identity(void) const
+{
+    return get_string("asset.owner_identity");
+}
+
+bool ww::exchange::LedgerEntry::get_owner_identity(ww::value::String& value) const
+{
+    return get_value("asset.owner_identity", value);
+}
+
+bool ww::exchange::LedgerEntry::set_owner_identity(const ww::value::String& value)
+{
+    return set_value("asset.owner_identity", value);
+}
+
+// -----------------------------------------------------------------
+const char* ww::exchange::LedgerEntry::get_escrow_agent_identity(void) const
+{
+    return get_string("asset.escrow_agent_identity");
+}
+
+bool ww::exchange::LedgerEntry::get_escrow_agent_identity(ww::value::String& value) const
+{
+    return get_value("asset.escrow_agent_identity", value);
+}
+
+bool ww::exchange::LedgerEntry::set_escrow_agent_identity(const ww::value::String& value)
+{
+    return set_value("asset.escrow_agent_identity", value);
+}
+
+// -----------------------------------------------------------------
+const char* ww::exchange::LedgerEntry::get_escrow_identifier(void) const
+{
+    return get_string("asset.escrow_identifier");
+}
+
+bool ww::exchange::LedgerEntry::get_escrow_identifier(ww::value::String& value) const
+{
+    return get_value("asset.escrow_identifier", value);
+}
+
+bool ww::exchange::LedgerEntry::set_escrow_identifier(const ww::value::String& value)
+{
+    return set_value("asset.escrow_identifier", value);
+}
+
+// -----------------------------------------------------------------
+bool ww::exchange::LedgerEntry::initialize_escrow_identifier(void)
+{
+    // create a random identifier
+    StringArray id_array(32);
+    if (! random_identifier(id_array.size(), id_array.data()))
+        return false;
+
+    // base64 encode the random identifier
+    StringArray encoded;
+    if (! ww::crypto::b64_encode(id_array, encoded))
+        return false;
+
+    // and save it in the ledger entry
+    ww::value::String id_string((const char*)encoded.c_data());
+    return set_escrow_identifier(id_string);
+}
+
+// -----------------------------------------------------------------
+SIMPLE_PROPERTY_GET(LedgerEntry, asset, ww::exchange::Asset);
+SIMPLE_PROPERTY_SET(LedgerEntry, asset, ww::exchange::Asset);

--- a/contracts/wawaka/exchange/contracts/common/LedgerEntry.h
+++ b/contracts/wawaka/exchange/contracts/common/LedgerEntry.h
@@ -1,0 +1,64 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "Value.h"
+
+#include "Asset.h"
+#include "Common.h"
+
+#define LEDGER_ENTRY_SCHEMA "{"                 \
+    SCHEMA_KW(active, true) ","                 \
+    "\"asset\":" ASSET_SCHEMA                   \
+    "}"
+
+namespace ww
+{
+namespace exchange
+{
+
+    class LedgerEntry : public ww::value::Structure
+    {
+    public:
+        bool is_active(void) const;
+        bool set_active();
+        bool set_inactive(const ww::value::String& escrow_agent_identity);
+
+        bool get_asset(ww::exchange::Asset& value) const;
+        bool set_asset(const ww::exchange::Asset& value);
+
+        uint32_t get_count(void) const;
+        bool set_count(const uint32_t count);
+
+        const char* get_owner_identity(void) const;
+        bool get_owner_identity(ww::value::String& value) const;
+        bool set_owner_identity(const ww::value::String& value);
+
+        const char* get_escrow_agent_identity(void) const;
+        bool get_escrow_agent_identity(ww::value::String& value) const;
+        bool set_escrow_agent_identity(const ww::value::String& value);
+
+        const char* get_escrow_identifier(void) const;
+        bool get_escrow_identifier(ww::value::String& value) const;
+        bool set_escrow_identifier(const ww::value::String& value);
+        bool initialize_escrow_identifier(void);
+
+        LedgerEntry(const StringArray& serialized);
+        LedgerEntry(void);
+    };
+
+};
+}

--- a/contracts/wawaka/exchange/contracts/common/LedgerStore.cpp
+++ b/contracts/wawaka/exchange/contracts/common/LedgerStore.cpp
@@ -1,0 +1,104 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "LedgerStore.h"
+#include "WasmExtensions.h"
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// CLASS: LedgerStore
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+bool ww::exchange::LedgerStore::exists(const StringArray& owner_identity) const
+{
+    StringArray serialized_entry;
+    return get(owner_identity, serialized_entry);
+}
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+bool ww::exchange::LedgerStore::get_entry(
+    const StringArray& owner_identity,
+    ww::exchange::LedgerEntry& value) const
+{
+    StringArray serialized_entry;
+    if (! get(owner_identity, serialized_entry))
+        return false;
+
+    if (! serialized_entry.null_terminated())
+    {
+        CONTRACT_SAFE_LOG(1, "stored ledger entry is not null terminated; %zu", serialized_entry.size());
+        return false;
+    }
+
+    if (! value.deserialize((const char*)serialized_entry.c_data()))
+    {
+        CONTRACT_SAFE_LOG(1, "stored ledger entry is not formatted correctly");
+        return false;
+    }
+
+    return true;
+}
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+bool ww::exchange::LedgerStore::set_entry(
+    const StringArray& owner_identity,
+    const ww::exchange::LedgerEntry& value) const
+{
+    StringArray serialized_entry;
+    if (! value.serialize(serialized_entry))
+    {
+        CONTRACT_SAFE_LOG(1, "ledger entry failed to serialize");
+        return false;
+    }
+
+    return set(owner_identity, serialized_entry);
+}
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+bool ww::exchange::LedgerStore::add_entry(
+    const StringArray& owner_identity,
+    const StringArray& asset_type_identifier,
+    uint32_t count) const
+{
+    const ww::value::String owner_string((const char*)owner_identity.c_data());
+    const ww::value::String asset_type_identifier_string((char*)asset_type_identifier.c_data());
+
+    ww::exchange::Asset asset;
+
+    if (! asset.set_asset_type_identifier(asset_type_identifier_string))
+        return false;
+
+    if (! asset.set_count(count))
+        return false;
+
+    if (! asset.set_owner_identity(owner_string))
+        return false;
+
+    if (! asset.set_escrow_agent_identity(owner_string))
+        return false;
+
+    ww::exchange::LedgerEntry entry;
+
+    if (! entry.set_asset(asset))
+        return false;
+
+    if (! entry.set_active())
+        return false;
+
+    if (! entry.initialize_escrow_identifier())
+        return false;
+
+    return set_entry(owner_identity, entry);
+}

--- a/contracts/wawaka/exchange/contracts/common/LedgerStore.h
+++ b/contracts/wawaka/exchange/contracts/common/LedgerStore.h
@@ -1,0 +1,41 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include "KeyValue.h"
+#include "StringArray.h"
+
+#include "LedgerEntry.h"
+
+namespace ww
+{
+namespace exchange
+{
+    class LedgerStore : public KeyValueStore
+    {
+    public:
+        bool add_entry(const StringArray& identity, const StringArray& asset_type_identifier, uint32_t count) const;
+        bool get_entry(const StringArray& identity, ww::exchange::LedgerEntry& value) const;
+        bool set_entry(const StringArray& identity, const ww::exchange::LedgerEntry& value) const;
+        bool exists(const StringArray& identity) const;
+
+        LedgerStore(const char* prefix) : KeyValueStore(prefix) {};
+    };
+
+}; // namespace: exchange
+} // namespace: ww

--- a/contracts/wawaka/exchange/contracts/common/StateReference.cpp
+++ b/contracts/wawaka/exchange/contracts/common/StateReference.cpp
@@ -1,0 +1,66 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "StateReference.h"
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// Class: ww::exchange::StateReference
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+static const ww::exchange::StateReference state_reference_schema;
+
+// -----------------------------------------------------------------
+ww::exchange::StateReference::StateReference(void) :
+    ww::value::Structure(STATE_REFERENCE_SCHEMA)
+{
+    return;
+}
+
+ww::exchange::StateReference::StateReference(const Environment& env) :
+    ww::value::Structure(STATE_REFERENCE_SCHEMA)
+{
+    const ww::value::String contract_id(env.contract_id_);
+    set_contract_id(contract_id);
+
+    const ww::value::String state_hash(env.state_hash_);
+    set_state_hash(state_hash);
+}
+
+// -----------------------------------------------------------------
+SIMPLE_PROPERTY_GET(StateReference, contract_id, ww::value::String);
+SIMPLE_PROPERTY_GET(StateReference, state_hash, ww::value::String);
+
+SIMPLE_PROPERTY_SET(StateReference, contract_id, ww::value::String);
+SIMPLE_PROPERTY_SET(StateReference, state_hash, ww::value::String);
+
+// -----------------------------------------------------------------
+bool ww::exchange::StateReference::validate(void) const
+{
+    // should add a check to make sure that the contract_id and state_hash
+    // have the correct format
+
+    return validate_schema(state_reference_schema);
+}
+
+// -----------------------------------------------------------------
+bool ww::exchange::StateReference::add_to_response(Response& rsp) const
+{
+    if (! validate())
+        return false;
+
+    const char* contract_id = get_string("contract_id");
+    const char* state_hash = get_string("state_hash");
+
+    return rsp.add_dependency(contract_id, state_hash);
+}

--- a/contracts/wawaka/exchange/contracts/common/StateReference.h
+++ b/contracts/wawaka/exchange/contracts/common/StateReference.h
@@ -1,0 +1,52 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "Environment.h"
+#include "Response.h"
+#include "Value.h"
+
+#include "Common.h"
+
+#define STATE_REFERENCE_SCHEMA "{"              \
+    SCHEMA_KW(contract_id,"") ","             \
+    SCHEMA_KW(state_hash,"")                  \
+    "}"
+
+namespace ww
+{
+namespace exchange
+{
+
+    class StateReference : public ww::value::Structure
+    {
+    public:
+        bool get_contract_id(ww::value::String& value) const;
+        bool get_state_hash(ww::value::String& value) const;
+
+        bool set_contract_id(const ww::value::String& value);
+        bool set_state_hash(const ww::value::String& value);
+
+        bool validate(void) const;
+
+        bool add_to_response(Response& rsp) const;
+
+        StateReference(void);
+        StateReference(const Environment& env);
+    };
+
+};
+}

--- a/contracts/wawaka/exchange/contracts/exchange_base.cpp
+++ b/contracts/wawaka/exchange/contracts/exchange_base.cpp
@@ -1,0 +1,160 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "Dispatch.h"
+
+#include "Cryptography.h"
+#include "Environment.h"
+#include "KeyValue.h"
+#include "Message.h"
+#include "Response.h"
+#include "StringArray.h"
+#include "Util.h"
+#include "Value.h"
+
+#include "exchange_base.h"
+
+static KeyValueStore exchange_base_store("exchange_base");
+
+static const StringArray md_owner_key("owner");
+static const StringArray md_initialized_key("initialized");
+
+static const StringArray md_signing_key("ecdsa_private_key");
+static const StringArray md_verifying_key("ecdsa_public_key");
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// CONTRACT METHODS
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+// -----------------------------------------------------------------
+// METHOD: initialize_contract
+//   contract initialization function, this is not a method but rather
+//   the function called when the contract object is first initialized,
+//   creates an ecdsa key pair that can be used to sign messages from
+//   the contract
+//
+// JSON PARAMETERS:
+//   none
+//
+// ENVIRONMENT:
+//   creator_id_
+//
+// RETURNS:
+//   true if successfully initialized
+// -----------------------------------------------------------------
+bool ww::exchange::exchange_base::initialize_contract(
+    const Environment& env,
+    Response& rsp)
+{
+    // ---------- Mark as uninitialized ----------
+    const int initialized = 0;
+    if (! exchange_base_store.set(md_initialized_key, initialized))
+        return rsp.error("failed to save initialization state");
+
+    // ---------- Save owner information ----------
+    const StringArray owner_val(env.creator_id_);
+    if (! exchange_base_store.set(md_owner_key, owner_val))
+        return rsp.error("failed to save creator metadata");
+
+    // ---------- Create and save the ECDSA key pair ----------
+    StringArray public_key;
+    StringArray private_key;
+
+    if (! ww::crypto::ecdsa::generate_keys(private_key, public_key))
+        return rsp.error("failed to create contract ecdsa keys");
+
+    if (! exchange_base_store.set(md_verifying_key, public_key))
+        return rsp.error("failed to save ecdsa public key");
+
+    if (! exchange_base_store.set(md_signing_key, private_key))
+        return rsp.error("failed to save ecdsa private key");
+
+    // ---------- RETURN ----------
+    return rsp.success(true);
+}
+
+// -----------------------------------------------------------------
+// METHOD: get_verifying_key
+//   contract method to retrieve the ecdsa verifying key that was
+//   created during initialization
+//
+// JSON PARAMETERS:
+//   none
+//
+// RETURNS:
+//   ecdsa verifying key
+// -----------------------------------------------------------------
+bool ww::exchange::exchange_base::get_verifying_key(
+    const Message& msg,
+    const Environment& env,
+    Response& rsp)
+{
+    // NOTE: this method does not require initialization of the authority
+    // object, that is "initialize_contract" must be called (but we couldn't
+    // get here without that) but "initialize" method need not be called
+
+    StringArray verifying_key;
+    if (! ww::exchange::exchange_base::get_verifying_key(verifying_key))
+        return rsp.error("corrupted state; verifying key not found");
+
+    ww::value::String v((char*)verifying_key.c_data());
+    return rsp.value(v, false);
+}
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// UTILITY FUNCTIONS
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+// -----------------------------------------------------------------
+bool ww::exchange::exchange_base::get_verifying_key(StringArray& verifying_key)
+{
+    if (! exchange_base_store.get(md_verifying_key, verifying_key))
+        return false;
+
+    return true;
+}
+
+// -----------------------------------------------------------------
+bool ww::exchange::exchange_base::get_signing_key(StringArray& signing_key)
+{
+    if (! exchange_base_store.get(md_signing_key, signing_key))
+        return false;
+
+    return true;
+}
+
+// -----------------------------------------------------------------
+bool ww::exchange::exchange_base::mark_initialized(void)
+{
+    // Mark as initialized
+    const uint32_t initialized = 1;
+    if (! exchange_base_store.set(md_initialized_key, initialized))
+        return false;
+
+    return true;
+}
+
+// -----------------------------------------------------------------
+bool ww::exchange::exchange_base::is_initialized(void)
+{
+    uint32_t initialized = 0;
+    if (! exchange_base_store.get(md_initialized_key, initialized))
+        return false;
+
+    return (initialized == 1);
+}

--- a/contracts/wawaka/exchange/contracts/exchange_base.h
+++ b/contracts/wawaka/exchange/contracts/exchange_base.h
@@ -1,0 +1,58 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "Environment.h"
+#include "Message.h"
+#include "Response.h"
+#include "StringArray.h"
+
+#define ASSERT_INITIALIZED(_rsp)                                \
+    do {                                                        \
+        if (! ww::exchange::exchange_base::is_initialized())    \
+            return _rsp.error("contract is not initialized");   \
+    } while (0)
+
+#define ASSERT_UNINITIALIZED(_rsp)                                      \
+    do {                                                                \
+        if (ww::exchange::exchange_base::is_initialized())              \
+            return _rsp.error("contract is already initialized");       \
+    } while (0)
+
+namespace ww
+{
+namespace exchange
+{
+namespace exchange_base
+{
+    // this module defines several contract methods and associated utility functions
+    // that are shared between exchange contracts, specifically, the methods create
+    // an ecdsa key pair
+
+    // common function to initialize state for issuer authority use
+    bool initialize_contract(const Environment& env, Response& rsp);
+    bool get_verifying_key(const Message& msg, const Environment& env, Response& rsp);
+
+    // utility functions
+    bool mark_initialized(void);
+    bool is_initialized(void);
+
+    bool get_verifying_key(StringArray& verifying_key);
+    bool get_signing_key(StringArray& signing_key);
+
+}; // exchange_base
+}; // exchange
+}; // ww

--- a/contracts/wawaka/exchange/contracts/issuer.cpp
+++ b/contracts/wawaka/exchange/contracts/issuer.cpp
@@ -1,0 +1,535 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "Dispatch.h"
+
+#include "KeyValue.h"
+#include "Environment.h"
+#include "Message.h"
+#include "Response.h"
+#include "StringArray.h"
+#include "Util.h"
+#include "Value.h"
+#include "WasmExtensions.h"
+
+#include "exchange_base.h"
+#include "issuer_authority_base.h"
+
+#include "common/AuthoritativeAsset.h"
+#include "common/EscrowClaim.h"
+#include "common/LedgerEntry.h"
+#include "common/LedgerStore.h"
+
+static ww::exchange::LedgerStore ledger_store("ledger");
+
+// -----------------------------------------------------------------
+// METHOD: initialize_contract
+//   contract initialization method
+//
+// JSON PARAMETERS:
+//   none
+//
+// RETURNS:
+//   true if successfully initialized
+// -----------------------------------------------------------------
+bool initialize_contract(const Environment& env, Response& rsp)
+{
+    return ww::exchange::exchange_base::initialize_contract(env, rsp);
+}
+
+// -----------------------------------------------------------------
+// METHOD: initialize
+//
+// JSON PARAMETERS:
+//  asset_authority_chain -- the object that grants issuance
+//    authority to this contract
+//
+// RETURNS:
+//   true if asset type id successfully saved
+// -----------------------------------------------------------------
+bool initialize(const Message& msg, const Environment& env, Response& rsp)
+{
+    return ww::exchange::issuer_authority_base::initialize_derived_authority(msg, env, rsp);
+}
+
+// -----------------------------------------------------------------
+// METHOD: get_verifying_key
+//
+// JSON PARAMETERS:
+//   none
+//
+// RETURNS:
+//   ecdsa verifying key
+// -----------------------------------------------------------------
+bool get_verifying_key(const Message& msg, const Environment& env, Response& rsp)
+{
+    return ww::exchange::exchange_base::get_verifying_key(msg, env, rsp);
+}
+
+// -----------------------------------------------------------------
+// METHOD: get_asset_type_identifier
+//
+// JSON PARAMETERS:
+//   none
+//
+// RETURNS:
+//   asset type id as a string
+// -----------------------------------------------------------------
+bool get_asset_type_identifier(const Message& msg, const Environment& env, Response& rsp)
+{
+    return ww::exchange::issuer_authority_base::get_asset_type_identifier(msg, env, rsp);
+}
+
+// -----------------------------------------------------------------
+// METHOD: add_approved_issuer
+//
+// JSON PARAMETERS:
+//   issuer-verifying-key -- verifying key of the asset issuer
+//
+// RETURNS:
+//   true if key is successfully stored
+// -----------------------------------------------------------------
+bool add_approved_issuer(const Message& msg, const Environment& env, Response& rsp)
+{
+    return ww::exchange::issuer_authority_base::add_approved_issuer(msg, env, rsp);
+}
+
+// -----------------------------------------------------------------
+// METHOD: get_issuer_authority
+//
+// JSON PARAMETERS:
+//   issuer-verifying-key -- verifying key of the asset issuer
+//
+// RETURNS:
+//   serialized authority object
+// -----------------------------------------------------------------
+bool get_issuer_authority(const Message& msg, const Environment& env, Response& rsp)
+{
+    return ww::exchange::issuer_authority_base::get_issuer_authority(msg, env, rsp);
+}
+
+// -----------------------------------------------------------------
+// METHOD: get_authority
+//
+// JSON PARAMETERS:
+//   none
+//
+// RETURNS:
+//   serialized authority object for this issuer
+// -----------------------------------------------------------------
+bool get_authority(const Message& msg, const Environment& env, Response& rsp)
+{
+    return ww::exchange::issuer_authority_base::get_authority(msg, env, rsp);
+}
+
+// -----------------------------------------------------------------
+// METHOD: issue
+//
+// JSON PARAMETERS:
+//   owner_identity
+//   count
+//
+// RETURNS:
+//   boolean
+// -----------------------------------------------------------------
+#define ISSUE_PARAMETER_SCHEMA "{\"owner_identity\":\"\", \"count\":0}"
+
+bool issue(const Message& msg, const Environment& env, Response& rsp)
+{
+    ASSERT_SENDER_IS_OWNER(env, rsp);
+    ASSERT_INITIALIZED(rsp);
+
+    if (! msg.validate_schema(ISSUE_PARAMETER_SCHEMA))
+        return rsp.error("invalid request, missing required parameters");
+
+    // in theory, owner is an escda key, in practice it could be anything
+    // but only an ecdsa key can be used meaningfully
+    const StringArray owner(msg.get_string("owner_identity"));
+    if (owner.size() == 0)
+        return rsp.error("invalid request, invalid owner identity parameter");
+
+    if (ledger_store.exists(owner))
+        return rsp.error("invalid request, duplicate issuance");
+
+    const int count = (int) msg.get_number("count");
+    if (count <= 0)
+        return rsp.error("invalid request, invalid asset count");
+
+    StringArray asset_type_identifier;
+    if (! ww::exchange::issuer_authority_base::get_asset_type_identifier(asset_type_identifier))
+        return rsp.error("contract state corrupted, no asset type identifier");
+
+    if (! ledger_store.add_entry(owner, asset_type_identifier, (uint32_t)count))
+        return rsp.error("ledger operation failed, unable to save issuance");
+
+    return rsp.success(true);
+}
+
+// -----------------------------------------------------------------
+// METHOD: get_balance
+//
+// JSON PARAMETERS:
+//   none
+//
+// RETURNS:
+//   current number of assets assigned to the requestor
+// -----------------------------------------------------------------
+bool get_balance(const Message& msg, const Environment& env, Response& rsp)
+{
+    ASSERT_INITIALIZED(rsp);
+
+    const StringArray owner(env.originator_id_);
+
+    uint32_t balance = 0;
+
+    ww::exchange::LedgerEntry entry;
+    if (ledger_store.get_entry(owner, entry))
+        balance = entry.get_count();
+
+    ww::value::Number balance_value(balance);
+    return rsp.value(balance_value, false);
+}
+
+// -----------------------------------------------------------------
+// METHOD: transfer
+//
+// JSON PARAMETERS:
+//   new_owner_identity
+//   count
+//
+// RETURNS:
+//   boolean
+// -----------------------------------------------------------------
+#define TRANSFER_PARAMETER_SCHEMA "{\"new_owner_identity\":\"\", \"count\":0}"
+
+bool transfer(const Message& msg, const Environment& env, Response& rsp)
+{
+    ASSERT_INITIALIZED(rsp);
+
+    if (! msg.validate_schema(TRANSFER_PARAMETER_SCHEMA))
+        return rsp.error("invalid request, missing required parameters");
+
+    const int count = (int) msg.get_number("count");
+    if (count <= 0)
+        return rsp.error("invalid transfer request, invalid asset count");
+
+    const StringArray new_owner(msg.get_string("new_owner_identity"));
+    if (new_owner.size() == 0)
+        return rsp.error("invalid transfer request, invalid owner identity parameter");
+
+    const StringArray old_owner(env.originator_id_);
+
+    // if there is no issuance for this identity, we treat it as a 0 balance
+    ww::exchange::LedgerEntry old_entry;
+
+    if (! ledger_store.get_entry(old_owner, old_entry))
+        return rsp.error("transfer failed, insufficient balance for transfer");
+
+    if (old_entry.get_count() < count)
+        return rsp.error("transfer failed, insufficient balance for transfer");
+
+    if (! old_entry.is_active())
+        return rsp.error("transfer failed, old assets are escrowed");
+
+    // in theory, owner is an escda key, in practice it could be anything
+    // but only an ecdsa key can be used meaningfully
+    if (! ledger_store.exists(new_owner))
+    {
+        StringArray asset_type_identifier;
+        if (! ww::exchange::issuer_authority_base::get_asset_type_identifier(asset_type_identifier))
+            return rsp.error("contract state corrupted, no asset type identifier");
+
+        if (! ledger_store.add_entry(new_owner, asset_type_identifier, 0))
+            return rsp.error("transfer failed, failed to add new owner");
+    }
+
+    ww::exchange::LedgerEntry new_entry;
+    if (! ledger_store.get_entry(new_owner, new_entry))
+        return rsp.error("transfer failed, failed to find new owner");
+
+    if (! new_entry.is_active())
+        return rsp.error("invalid transfer request, new assets are escrowed");
+
+    // after all the set up, finally transfer the assets
+    old_entry.set_count(old_entry.get_count() - (uint32_t)count);
+    if (! ledger_store.set_entry(old_owner, old_entry))
+        return rsp.error("transfer failed, unable to update old entry");
+
+    new_entry.set_count(new_entry.get_count() + (uint32_t)count);
+    if (! ledger_store.set_entry(new_owner, new_entry))
+        return rsp.error("transfer failed, unable to update new entry");
+
+    return rsp.success(true);
+}
+
+// -----------------------------------------------------------------
+// METHOD: escrow
+//
+// JSON PARAMETERS:
+//   escrow_agent_identity
+//
+// RETURNS:
+//   boolean
+// -----------------------------------------------------------------
+#define ESCROW_PARAMETER_SCHEMA "{\"escrow_agent_identity\":\"\"}"
+
+bool escrow(const Message& msg, const Environment& env, Response& rsp)
+{
+    CONTRACT_SAFE_LOG(4, "escrow");
+
+    ASSERT_INITIALIZED(rsp);
+
+    if (! msg.validate_schema(ESCROW_PARAMETER_SCHEMA))
+        return rsp.error("invalid escrow request, missing required parameters");
+
+    const ww::value::String escrow_agent(msg.get_string("escrow_agent_identity"));
+
+    const StringArray owner(env.originator_id_);
+
+    // if there is no issuance for this identity, we treat it as a 0 balance
+    ww::exchange::LedgerEntry entry;
+
+    if (! ledger_store.get_entry(owner, entry))
+        return rsp.error("escrow failed, no entry for requestor");
+
+    if (! entry.is_active())
+        return rsp.error("escrow failed, assets are already escrowed");
+
+    entry.set_inactive(escrow_agent);
+
+    if (! ledger_store.set_entry(owner, entry))
+        return rsp.error("escrow failed, unable to update entry");
+
+    return rsp.success(true);
+}
+
+// -----------------------------------------------------------------
+// METHOD: escrow_attestation
+//
+// JSON PARAMETERS:
+//   none
+//
+// RETURNS:
+//   authoritative_asset_type
+// -----------------------------------------------------------------
+bool escrow_attestation(const Message& msg, const Environment& env, Response& rsp)
+{
+    ASSERT_INITIALIZED(rsp);
+
+    const StringArray owner(env.originator_id_);
+
+    // if there is no issuance for this identity, we treat it as a 0 balance
+    ww::exchange::LedgerEntry entry;
+    if (! ledger_store.get_entry(owner, entry))
+        return rsp.error("invalid escrow attestation request; no entry for requestor");
+
+    if (entry.is_active())
+        return rsp.error("invalid escrow attestation request, asset is not in escrow");
+
+    const ww::exchange::StateReference state_reference(env);
+
+    ww::exchange::Asset asset;
+    if (! entry.get_asset(asset))
+        return rsp.error("corrupted state, invalid asset in ledger");
+
+    ww::exchange::IssuerAuthorityChain authority_chain;
+    if (! ww::exchange::issuer_authority_base::get_authority(authority_chain))
+        return rsp.error("failed to retrieve issuer authority");
+
+    ww::exchange::AuthoritativeAsset authoritative_asset;
+    if (! authoritative_asset.set_issuer_state_reference(state_reference))
+        return rsp.error("failed to create escrow attestation; state_reference");
+
+    if (! authoritative_asset.set_asset(asset))
+        return rsp.error("failed to create escrow attestation; authoritative_asset");
+
+    if (! authoritative_asset.set_issuer_authority_chain(authority_chain))
+        return rsp.error("failed to create escrow attestation; issuer_authority_chain");
+
+    StringArray signing_key;
+    if (! ww::exchange::exchange_base::get_signing_key(signing_key))
+        return rsp.error("corrupted state; signing key not found");
+
+    if (! authoritative_asset.sign(signing_key))
+        return rsp.error("corrupted state; signature failed");
+
+    return rsp.value(authoritative_asset, false);
+}
+
+// -----------------------------------------------------------------
+// METHOD: disburse
+//
+// JSON PARAMETERS:
+//   escrow_agent_state_reference
+//   escrow_agent_signature
+//
+// RETURNS:
+//   boolean
+// -----------------------------------------------------------------
+#define DISBURSE_PARAMETER_SCHEMA "{"                                   \
+    "\"escrow_agent_state_reference\":" STATE_REFERENCE_SCHEMA ","      \
+    SCHEMA_KW(escrow_agent_signature,"")                                \
+    "}"
+
+bool disburse(const Message& msg, const Environment& env, Response& rsp)
+{
+    ASSERT_INITIALIZED(rsp);
+
+    if (! msg.validate_schema(DISBURSE_PARAMETER_SCHEMA))
+        return rsp.error("invalid request, missing required parameters");
+
+    const StringArray owner(env.originator_id_);
+
+    ww::exchange::LedgerEntry entry;
+    if (! ledger_store.get_entry(owner, entry))
+        return rsp.error("invalid disburse request, no entry for requestor");
+
+    if (entry.is_active())
+        return rsp.error("invalid disburse request, assets are not escrowed");
+
+    // verify that escrow agent signature
+    const StringArray signature(msg.get_string("escrow_agent_signature"));
+    const StringArray escrow_agent(entry.get_escrow_agent_identity());
+
+    ww::exchange::StateReference escrow_agent_state_reference;
+    if (! msg.get_value("escrow_agent_state_reference", escrow_agent_state_reference))
+        return rsp.error("invalid request, malformed parameter, escrow_agent_state_reference");
+
+    ww::exchange::Asset asset;
+    if (! entry.get_asset(asset))
+        return rsp.error("unexpected error; failed to serialize asset");
+
+    if (! asset.verify_escrow_signature(escrow_agent_state_reference, signature))
+        return rsp.error("escrow signature verification failed");
+
+    // now modify the entry to mark it as active
+    entry.set_active();
+    if (! ledger_store.set_entry(owner, entry))
+        return rsp.error("escrow failed, unable to update entry");
+
+    // add the dependency to the response
+    if (! escrow_agent_state_reference.add_to_response(rsp))
+        return rsp.error("disburse request failed, unable to save state reference");
+
+    return rsp.success(true);
+}
+
+// -----------------------------------------------------------------
+// METHOD: claim
+//
+// JSON PARAMETERS:
+//   escrow_claim
+//
+// RETURNS:
+//   boolean
+// -----------------------------------------------------------------
+#define CLAIM_PARAMETER_SCHEMA "{"              \
+    "\"escrow_claim\":" ESCROW_CLAIM_SCHEMA     \
+    "}"
+
+bool claim(const Message& msg, const Environment& env, Response& rsp)
+{
+    ASSERT_INITIALIZED(rsp);
+
+    if (! msg.validate_schema(CLAIM_PARAMETER_SCHEMA))
+        return rsp.error("invalid request, missing required parameters");
+
+    ww::exchange::EscrowClaim escrow_claim;
+    if (! msg.get_value("escrow_claim", escrow_claim))
+        return rsp.error("invalid request, malformed parameter, escrow_claim");
+
+    // get the old owner's entry from the ledger
+    ww::value::String old_owner_identity_string;
+    if (! escrow_claim.get_old_owner_identity(old_owner_identity_string))
+        return rsp.error("invalid claim request, malformed parameter, escrow_claim");
+    const StringArray old_owner_identity(old_owner_identity_string.get());
+
+    ww::exchange::LedgerEntry old_owner_entry;
+    if (! ledger_store.get_entry(old_owner_identity, old_owner_entry))
+        return rsp.error("invalid claim request, no such asset");
+
+    // make sure the old entry is actually escrowed
+    if (! old_owner_entry.is_active())
+        return rsp.error("invalid claim request, state mismatch");
+
+    // check the signature from the escrow agent
+    ww::value::String escrow_agent_identity_string;
+    if (! old_owner_entry.get_escrow_agent_identity(escrow_agent_identity_string))
+        return rsp.error("contract state corrupted, no escrow agent identity");
+
+    ww::value::String escrow_identifier;
+    if (! old_owner_entry.get_escrow_identifier(escrow_identifier))
+        return rsp.error("contract state corrupted, no escrow identifier");
+
+    const StringArray escrow_agent_identity(escrow_agent_identity_string.get());
+    if (! escrow_claim.verify_signature(escrow_identifier, escrow_agent_identity))
+        return rsp.error("invalid claim request, signature verification failed");
+
+    // get the new owner's entry from the ledger, create an empty
+    // entry if one does not already exist
+    const StringArray new_owner_identity(env.originator_id_);
+    ww::exchange::LedgerEntry new_owner_entry;
+    if (! ledger_store.exists(new_owner_identity))
+    {
+        const int count = 0;
+
+        StringArray asset_type_identifier;
+        if (! ww::exchange::issuer_authority_base::get_asset_type_identifier(asset_type_identifier))
+            return rsp.error("contract state corrupted, no asset type identifier");
+
+        if (! ledger_store.add_entry(new_owner_identity, asset_type_identifier, (uint32_t)count))
+            return rsp.error("ledger operation failed, unable to save issuance");
+    }
+
+    if (! ledger_store.get_entry(new_owner_identity, new_owner_entry))
+        return rsp.error("contract state corrupted, no issuance located");
+
+    // move the balance from the old owner to the new owner
+    uint32_t old_owner_balance = old_owner_entry.get_count();
+    uint32_t new_owner_balance = new_owner_entry.get_count();
+
+    old_owner_entry.set_count(0);
+    if (! ledger_store.set_entry(old_owner_identity, old_owner_entry))
+        return rsp.error("failed to save updated balance");
+
+    new_owner_entry.set_count(old_owner_balance + new_owner_balance);
+    if (! ledger_store.set_entry(new_owner_identity, new_owner_entry))
+        return rsp.error("failed to save updated balance");
+
+    return rsp.success(true);
+}
+
+// -----------------------------------------------------------------
+// -----------------------------------------------------------------
+contract_method_reference_t contract_method_dispatch_table[] = {
+    CONTRACT_METHOD(initialize),
+    CONTRACT_METHOD(get_verifying_key),
+    CONTRACT_METHOD(get_asset_type_identifier),
+    CONTRACT_METHOD(add_approved_issuer),
+    CONTRACT_METHOD(get_issuer_authority),
+    CONTRACT_METHOD(get_authority),
+
+    CONTRACT_METHOD(issue),
+    CONTRACT_METHOD(get_balance),
+    CONTRACT_METHOD(transfer),
+    CONTRACT_METHOD(escrow),
+    CONTRACT_METHOD(escrow_attestation),
+    CONTRACT_METHOD(disburse),
+    CONTRACT_METHOD(claim),
+    { NULL, NULL }
+};

--- a/contracts/wawaka/exchange/contracts/issuer_authority_base.cpp
+++ b/contracts/wawaka/exchange/contracts/issuer_authority_base.cpp
@@ -1,0 +1,330 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "Dispatch.h"
+
+#include "KeyValue.h"
+#include "Environment.h"
+#include "Message.h"
+#include "Response.h"
+#include "StringArray.h"
+#include "Util.h"
+#include "Value.h"
+#include "WasmExtensions.h"
+
+#include "exchange_base.h"
+#include "issuer_authority_base.h"
+
+#include "common/IssuerAuthority.h"
+#include "common/IssuerAuthorityChain.h"
+#include "common/StateReference.h"
+
+static KeyValueStore issuer_authority_common_store("issuer_authority_common_store");
+static KeyValueStore issuer_authority_approved_keys("issuer_authority_approved_keys");
+
+static const StringArray md_asset_type_id_key("asset_type_identifier");
+static const StringArray md_authority_chain_key("authority_chain");
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// CONTRACT METHODS
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+// -----------------------------------------------------------------
+// METHOD: initialize_root_authority
+//   initialize key value store for a vetting organization that is
+//   the root of trust; that is, there is no associated authority
+//   object that needs to be added to the store.
+//
+// JSON PARAMETERS:
+//   asset-type-id -- ecdsa public key for the asset type
+//
+// RETURNS:
+//   true if asset type id successfully saved
+// -----------------------------------------------------------------
+#define INITIALIZE_ROOT_AUTHORITY_SCHEMA "{\"asset_type_identifier\":\"\"}"
+bool ww::exchange::issuer_authority_base::initialize_root_authority(
+    const Message& msg,
+    const Environment& env,
+    Response& rsp)
+{
+    CONTRACT_SAFE_LOG(4, "initialize_root_authority");
+
+    ASSERT_SENDER_IS_OWNER(env, rsp);
+    ASSERT_UNINITIALIZED(rsp);
+
+    if (! msg.validate_schema(INITIALIZE_ROOT_AUTHORITY_SCHEMA))
+        return rsp.error("invalid request, missing required parameters");
+
+    // Build the root authority chain and save it in the metadata
+    StringArray verifying_key;
+    if (! ww::exchange::exchange_base::get_verifying_key(verifying_key))
+        return rsp.error("corrupted state; verifying key not found");
+
+    if (! verifying_key.null_terminated())
+        return rsp.error("corrupted state; verifying key is not null terminated");
+
+    ww::value::String verifying_key_string((const char*)verifying_key.c_data());
+
+    // Set the asset type
+    const ww::value::String asset_type_identifier_string(msg.get_string("asset_type_identifier"));
+    if (asset_type_identifier_string.is_null())
+        return rsp.error("missing required parameter; asset_type_identifier");
+
+    const StringArray asset_type_identifier(asset_type_identifier_string.get());
+    if (! issuer_authority_common_store.set(md_asset_type_id_key, asset_type_identifier))
+        return rsp.error("failed to store the asset type id");
+
+    if (! asset_type_identifier.null_terminated())
+        return rsp.error("corrupted request; asset type identifier is not null terminated");
+
+    // Save the serialized authority object
+    ww::exchange::IssuerAuthorityChain authority_chain(asset_type_identifier_string, verifying_key_string);
+
+    StringArray serialized_authority_chain;
+    if (! authority_chain.serialize(serialized_authority_chain))
+        return rsp.error("failed to save authority chain; serialization failed");
+
+    if (! issuer_authority_common_store.set(md_authority_chain_key, serialized_authority_chain))
+        return rsp.error("failed to save authority chain; failed to store data");
+
+    CONTRACT_SAFE_LOG(3, "AUTHORITY: %s", (const char*)serialized_authority_chain.c_data());
+
+    // Mark as initialized
+    ww::exchange::exchange_base::mark_initialized();
+
+    // ---------- RETURN ----------
+    return rsp.success(true);
+}
+
+// -----------------------------------------------------------------
+// METHOD: initialize_derived_authority
+//   initialize the key value store for an issuer that derives authority
+//   from another object such as a vetting organization or another issuer
+//
+// JSON PARAMETERS:
+//  asset_authority_chain -- the object that grants issuance
+//    authority to this contract
+//
+// RETURNS:
+//   true
+// -----------------------------------------------------------------
+bool ww::exchange::issuer_authority_base::initialize_derived_authority(
+    const Message& msg,
+    const Environment& env,
+    Response& rsp)
+{
+    ASSERT_SENDER_IS_OWNER(env, rsp);
+    ASSERT_UNINITIALIZED(rsp);
+
+    // Validate the authority given to the contract object
+    ww::exchange::IssuerAuthorityChain authority_chain;
+    if (! msg.get_value("asset_authority_chain", authority_chain))
+        return rsp.error("missing required parameter; asset_authority_chain");
+
+    StringArray verifying_key;
+    if (! ww::exchange::exchange_base::get_verifying_key(verifying_key))
+        return rsp.error("corrupted state; verifying key not found");
+
+    if (! authority_chain.validate(verifying_key))
+        return rsp.error("invalid parameter; authority chain validation failed");
+
+    // Save the serialized authority chain object
+    StringArray serialized_authority_chain;
+    if (! authority_chain.serialize(serialized_authority_chain))
+        return rsp.error("failed to save authority chain; serialization failed");
+
+    if (! issuer_authority_common_store.set(md_authority_chain_key, serialized_authority_chain))
+        return rsp.error("failed to save authority chain; failed to store data");
+
+    // Save the asset type identifier
+    const StringArray asset_type_id(authority_chain.get_string("asset_type_identifier"));
+    if (! issuer_authority_common_store.set(md_asset_type_id_key, asset_type_id))
+        return rsp.error("failed to store the asset type id");
+
+    // Mark as initialized
+    ww::exchange::exchange_base::mark_initialized();
+
+    // ---------- RETURN ----------
+
+    // the authority given to the issuer is only valid if all of the
+    // dependencies have been committed to the ledger
+    if (! authority_chain.add_dependencies_to_response(rsp))
+        return rsp.error("failed to add dependencies to the response");
+
+    return rsp.success(true);
+}
+
+// -----------------------------------------------------------------
+// METHOD: get_asset_type_identifier
+//
+// JSON PARAMETERS:
+//   none
+//
+// RETURNS:
+//   asset type id as a string
+// -----------------------------------------------------------------
+bool ww::exchange::issuer_authority_base::get_asset_type_identifier(
+    const Message& msg,
+    const Environment& env,
+    Response& rsp)
+{
+    ASSERT_INITIALIZED(rsp);
+
+    StringArray asset_type_identifier;
+    if (! ww::exchange::issuer_authority_base::get_asset_type_identifier(asset_type_identifier))
+        return rsp.error("contract state corrupted, no asset type identifier");
+
+    ww::value::String v((char*)asset_type_identifier.c_data());
+    return rsp.value(v, false);
+}
+
+// -----------------------------------------------------------------
+// METHOD: add_approved_issuer
+//
+// JSON PARAMETERS:
+//   issuer-verifying-key -- verifying key of the asset issuer
+//
+// RETURNS:
+//   true if key is successfully stored
+// -----------------------------------------------------------------
+bool ww::exchange::issuer_authority_base::add_approved_issuer(
+    const Message& msg,
+    const Environment& env,
+    Response& rsp)
+{
+    ASSERT_SENDER_IS_OWNER(env, rsp);
+    ASSERT_INITIALIZED(rsp);
+
+    // Save the issuer's key, would be good to make sure that this is a valid ECDSA key
+    StringArray issuer_verifying_key(msg.get_string("issuer_verifying_key"));
+    if (! issuer_authority_approved_keys.set(issuer_verifying_key, 1))
+        return rsp.error("failed to save the issuer verifying key");
+
+    // ---------- RETURN ----------
+    return rsp.success(true);
+}
+
+// -----------------------------------------------------------------
+// METHOD: get_authority
+//
+// JSON PARAMETERS:
+//   none
+//
+// RETURNS:
+//   serialized authority object for this contract
+// -----------------------------------------------------------------
+bool ww::exchange::issuer_authority_base::get_authority(
+    const Message& msg,
+    const Environment& env,
+    Response& rsp)
+{
+    ASSERT_INITIALIZED(rsp);
+
+    ww::exchange::IssuerAuthorityChain authority_chain;
+    if (! get_authority(authority_chain))
+        return rsp.error("failed to retrieve authority chain");
+
+    return rsp.value(authority_chain, false);
+}
+
+// -----------------------------------------------------------------
+// METHOD: get_issuer_authority
+//
+// JSON PARAMETERS:
+//   issuer-verifying-key -- verifying key of the asset issuer
+//
+// RETURNS:
+//   serialized authority object
+// -----------------------------------------------------------------
+bool ww::exchange::issuer_authority_base::get_issuer_authority(
+    const Message& msg,
+    const Environment& env,
+    Response& rsp)
+{
+    ASSERT_INITIALIZED(rsp);
+
+    // Retrieve the issuer's key from the parameter list
+    const StringArray issuer_verifying_key(msg.get_string("issuer_verifying_key"));
+
+    uint32_t flag;
+    if (! issuer_authority_approved_keys.get(issuer_verifying_key, flag))
+        return rsp.error("not an approved authority");
+
+    // Retrieve information from the current state of the contract
+    StringArray asset_type_identifier;
+    if (! issuer_authority_common_store.get(md_asset_type_id_key, asset_type_identifier))
+        return rsp.error("corrupted state; asset type identifier not found");
+
+    StringArray verifying_key;
+    if (! ww::exchange::exchange_base::get_verifying_key(verifying_key))
+        return rsp.error("corrupted state; verifying key not found");
+
+    StringArray signing_key;
+    if (! ww::exchange::exchange_base::get_signing_key(signing_key))
+        return rsp.error("corrupted state; signing key not found");
+
+    // --------------- Build the authority chain ---------------
+    StringArray serialized_authority_chain;
+    if (! issuer_authority_common_store.get(md_authority_chain_key, serialized_authority_chain))
+        return rsp.error("corrupted state; serialized authority chain not found");
+
+    ww::exchange::IssuerAuthorityChain authority_chain;
+    if (! authority_chain.deserialize((const char*)serialized_authority_chain.c_data()))
+        return rsp.error("failed to save authority chain; serialization failed");
+
+    const ww::exchange::StateReference state_reference(env);
+    const ww::value::String string_issuer_verifying_key((const char*)issuer_verifying_key.c_data());
+
+    ww::exchange::IssuerAuthority authority(string_issuer_verifying_key, state_reference);
+    if (! authority.sign(signing_key, asset_type_identifier))
+        return rsp.error("failed to compute signature");
+
+    if (! authority_chain.add_issuer_authority(authority))
+        return rsp.error("failed to create issuer authority chain");
+
+    return rsp.value(authority_chain, false);
+}
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// UTILITY FUNCTIONS
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+// -----------------------------------------------------------------
+bool ww::exchange::issuer_authority_base::get_asset_type_identifier(
+    StringArray& asset_type_identifier)
+{
+    if (! issuer_authority_common_store.get(md_asset_type_id_key, asset_type_identifier))
+        return false;
+
+    return true;
+}
+
+// -----------------------------------------------------------------
+bool ww::exchange::issuer_authority_base::get_authority(
+    ww::exchange::IssuerAuthorityChain& authority_chain)
+{
+    // Retrieve the authority chain from state
+    StringArray serialized_authority_chain;
+    if (! issuer_authority_common_store.get(md_authority_chain_key, serialized_authority_chain))
+        return false;
+
+    if (! authority_chain.deserialize((const char*)serialized_authority_chain.c_data()))
+        return false;
+
+    return true;
+}

--- a/contracts/wawaka/exchange/contracts/issuer_authority_base.h
+++ b/contracts/wawaka/exchange/contracts/issuer_authority_base.h
@@ -1,0 +1,49 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "Environment.h"
+#include "Message.h"
+#include "Response.h"
+#include "StringArray.h"
+
+#include "common/IssuerAuthorityChain.h"
+
+namespace ww
+{
+namespace exchange
+{
+namespace issuer_authority_base
+{
+    // this module defines several contract methods that are shared between the issuer
+    // authorities which include issuers and vetting organizations
+
+    // contract methods
+    bool initialize_root_authority(const Message& msg, const Environment& env, Response& rsp);
+    bool initialize_derived_authority(const Message& msg, const Environment& env, Response& rsp);
+
+    bool get_asset_type_identifier(const Message& msg, const Environment& env, Response& rsp);
+    bool get_authority(const Message& msg, const Environment& env, Response& rsp);
+    bool add_approved_issuer(const Message& msg, const Environment& env, Response& rsp);
+    bool get_issuer_authority(const Message& msg, const Environment& env, Response& rsp);
+
+    // utility functions
+    bool get_asset_type_identifier(StringArray& asset_type_identifier);
+    bool get_authority(ww::exchange::IssuerAuthorityChain& authority_chain);
+
+}; // issuer_authority
+}; // exchange
+}; // ww

--- a/contracts/wawaka/exchange/contracts/vetting_organization.cpp
+++ b/contracts/wawaka/exchange/contracts/vetting_organization.cpp
@@ -1,0 +1,127 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "Dispatch.h"
+
+#include "KeyValue.h"
+#include "Environment.h"
+#include "Message.h"
+#include "Response.h"
+#include "StringArray.h"
+#include "Util.h"
+#include "Value.h"
+#include "WasmExtensions.h"
+
+#include "exchange_base.h"
+#include "issuer_authority_base.h"
+
+// -----------------------------------------------------------------
+// METHOD: initialize_contract
+//   contract initialization method
+//
+// JSON PARAMETERS:
+//   none
+//
+// RETURNS:
+//   true if successfully initialized
+// -----------------------------------------------------------------
+bool initialize_contract(const Environment& env, Response& rsp)
+{
+    return ww::exchange::exchange_base::initialize_contract(env, rsp);
+}
+
+// -----------------------------------------------------------------
+// METHOD: initialize
+//
+// JSON PARAMETERS:
+//   asset-type-id -- ecdsa public key for the asset type
+//
+// RETURNS:
+//   true if asset type id successfully saved
+// -----------------------------------------------------------------
+bool initialize(const Message& msg, const Environment& env, Response& rsp)
+{
+    return ww::exchange::issuer_authority_base::initialize_root_authority(msg, env, rsp);
+}
+
+// -----------------------------------------------------------------
+// METHOD: get_asset_type_identifier
+//
+// JSON PARAMETERS:
+//   none
+//
+// RETURNS:
+//   asset type id as a string
+// -----------------------------------------------------------------
+bool get_asset_type_identifier(const Message& msg, const Environment& env, Response& rsp)
+{
+    return ww::exchange::issuer_authority_base::get_asset_type_identifier(msg, env, rsp);
+}
+
+// -----------------------------------------------------------------
+// METHOD: get_verifying_key
+//
+// JSON PARAMETERS:
+//   none
+//
+// RETURNS:
+//   ecdsa verifying key
+// -----------------------------------------------------------------
+bool get_verifying_key(const Message& msg, const Environment& env, Response& rsp)
+{
+    return ww::exchange::exchange_base::get_verifying_key(msg, env, rsp);
+}
+
+// -----------------------------------------------------------------
+// METHOD: add_approved_issuer
+//
+// JSON PARAMETERS:
+//   issuer-verifying-key -- verifying key of the asset issuer
+//
+// RETURNS:
+//   true if key is successfully stored
+// -----------------------------------------------------------------
+bool add_approved_issuer(const Message& msg, const Environment& env, Response& rsp)
+{
+    return ww::exchange::issuer_authority_base::add_approved_issuer(msg, env, rsp);
+}
+
+// -----------------------------------------------------------------
+// METHOD: get_issuer_authority
+//
+// JSON PARAMETERS:
+//   issuer-verifying-key -- verifying key of the asset issuer
+//
+// RETURNS:
+//   serialized authority object
+// -----------------------------------------------------------------
+bool get_issuer_authority(const Message& msg, const Environment& env, Response& rsp)
+{
+    return ww::exchange::issuer_authority_base::get_issuer_authority(msg, env, rsp);
+}
+
+// -----------------------------------------------------------------
+// -----------------------------------------------------------------
+contract_method_reference_t contract_method_dispatch_table[] = {
+    CONTRACT_METHOD(initialize),
+    CONTRACT_METHOD(get_verifying_key),
+    CONTRACT_METHOD(get_asset_type_identifier),
+    CONTRACT_METHOD(add_approved_issuer),
+    CONTRACT_METHOD(get_issuer_authority),
+    { NULL, NULL }
+};

--- a/contracts/wawaka/exchange/doc/asset_type.json
+++ b/contracts/wawaka/exchange/doc/asset_type.json
@@ -1,0 +1,97 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "title": "interface for asset type contract object",
+    "id": "http://tradenet.org/pdo/wawaka/exchange/asset_type#",
+
+    "description": [
+        "an object that serves as a common reference for assets of a particular type",
+        "the object must be initialized by invoking the initialize method"
+    ],
+
+    "interface": {
+        "initialize": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "sets the basic information associated with the asset type",
+                "must be invoked by the creator",
+                "may only be invoked one time and must be invoked before any other operation"
+            ],
+            "type": "method",
+            "modifies_state": true,
+            "returns": "boolean",
+            "PositionalParameters": [],
+            "KeywordParameters": {
+                "description": {
+                    "description": "textual description of the asset type"
+                    "type": "string",
+                    "required": true
+                },
+                "link": {
+                    "description": "URL for further information about the asset type",
+                    "type": "string",
+                    "required": true
+                },
+                "name": {
+                    "description": "human understandable name of the asset type",
+                    "type": "string",
+                    "required": true
+                }
+            }
+        },
+
+        "get_asset_type_identifier": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "returns the unique identifier for the asset type",
+                "the unique identifier is the contract id for the object"
+            ],
+            "type": "method",
+            "modifies_state": false,
+            "returns": {
+                "$ref": "#/pdo/basetypes/contract-id"
+            },
+            "PositionalParameters": [],
+            "KeywordParameters": {}
+        },
+
+        "get_description": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "returns the description associated with the asset type"
+            ],
+            "type": "method",
+            "modifies_state": false,
+            "returns": "string",
+            "PositionalParameters": [],
+            "KeywordParameters": {}
+        },
+
+        "get_link": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "returns the link associated with the asset type"
+            ],
+            "type": "method",
+            "modifies_state": false,
+            "returns": "string",
+            "PositionalParameters": [],
+            "KeywordParameters": {}
+        },
+
+        "get_name": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "returns the name associated with the asset type"
+            ],
+            "type": "method",
+            "modifies_state": false,
+            "returns": "string",
+            "PositionalParameters": [],
+            "KeywordParameters": {}
+        }
+    }
+}
+
+// Local Variables:
+// mode: hs-minor
+// End:

--- a/contracts/wawaka/exchange/doc/auction.json
+++ b/contracts/wawaka/exchange/doc/auction.json
@@ -1,0 +1,330 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "title": "Exchange Interface",
+    "id": "http://tradenet.org/pdo/contract/wawaka/exchange#",
+    "definitions": {
+        "issuer_authority_type": {
+            "//": "-----------------------------------------------------------------",
+            "id": "#authority_type",
+            "description": [
+                "attestation of the authority given to an issuer by an organization authorized",
+                "to vet issuers of a specific asset type, this may be a vetting organization",
+                "or an authorized issuer of the the asset type",
+                "the holder of the issuer_signing_key associated with the issuer_verifying_key is",
+                "authorized to issue assets of a particular asset type"
+            ],
+            "type": "object",
+            "properties": {
+                "authorized_issuer_verifying_key": {
+                    "description": [
+                        "public key for the issuer"
+                    ],
+                    "$ref": "#/pdo/basetypes/ecdsa-public-key",
+                    "required": true
+                },
+                "authorizing_issuer_state_reference": {
+                    "description": [
+                        "state reference for the authorized issuer object",
+                        "ensures that the issuer object state is committed on the ledger"
+                    ],
+                    "$ref": "#/pdo/basetypes/state-reference",
+                    "required": true
+                },
+                "authorizing_signature": {
+                    "description": [
+                        "signature of the entity that authorizes the use of the verifying key",
+                        "signature is computed over the asset type identifier, authorized_issuer_verifying_key,"
+                        "and the authorizing_issuer_state_reference"
+
+                    ],
+                    "$ref": "#/pdo/basetypes/escda-signature",
+                    "required": true
+                }
+            }
+        },
+        "issuer_authority_chain_type": {
+            "//": "-----------------------------------------------------------------",
+            "id": "#authority_chain_type",
+            "description": [
+                "authority chain that captures the authorization chain from a vetting organization",
+                "to the verifying key of an asset issuer"
+            ],
+            "type": "object",
+            "properties": {
+                "asset_type_identifier": {
+                    "description": [
+                        "the asset type identifier"
+                    ],
+                    "$ref": "#/pdo/basetypes/contract-id",
+                    "required": true
+                },
+                "vetting_organization_verifying_key": {
+                    "description": [
+                        "verifying key associated with the vetting organization",
+                        "this is the root of trust for issuance"
+                    ],
+                    "$ref": "#/pdo/basetypes/ecdsa-public-key",
+                    "required": true
+                },
+                "authority_chain": {
+                    "description": [],
+                    "type": "array",
+                    "items": {
+                        "$ref": "#issuer_authority_type",
+                        "minItems" : 1,
+                        "uniqueItems": true
+                    },
+                    "required": true
+                },
+            }
+        },
+        "asset_type_object": {
+            "description": [
+                "an object that serves as a common reference for assets of a particular type",
+                "the object must be initialized by invoking the initialize method"
+            ],
+            "interface": {
+                "initialize": {
+                    "description": [
+                        "sets the basic information associated with the asset type",
+                        "must be invoked by the creator",
+                        "may only be invoked one time and must be invoked before any other operation"
+                    ],
+                    "type": "method",
+                    "modifies_state": true,
+                    "returns": "boolean",
+                    "PositionalParameters": [],
+                    "KeywordParameters": {
+                        "description": {
+                            "description": "textual description of the asset type"
+                            "type": "string",
+                            "required": true
+                        },
+                        "link": {
+                            "description": "URL for further information about the asset type",
+                            "type": "string",
+                            "required": true
+                        },
+                        "name": {
+                            "description": "human understandable name of the asset type",
+                            "type": "string",
+                            "required": true
+                        }
+                    }
+                },
+                "get_identifier": {
+                    "description": [
+                        "returns the unique identifier for the asset type",
+                        "the unique identifier is the contract id for the object"
+                    ],
+                    "type": "method",
+                    "modifies_state": false,
+                    "returns": {
+                        "$ref": "#/pdo/basetypes/contract-id"
+                    },
+                    "PositionalParameters": [],
+                    "KeywordParameters": {}
+                },
+                "get_description": {
+                    "description": [
+                        "returns the description associated with the asset type"
+                    ],
+                    "type": "method",
+                    "modifies_state": false,
+                    "returns": "string",
+                    "PositionalParameters": [],
+                    "KeywordParameters": {}
+                },
+                "get_link": {
+                    "description": [
+                        "returns the link associated with the asset type"
+                    ],
+                    "type": "method",
+                    "modifies_state": false,
+                    "returns": "string",
+                    "PositionalParameters": [],
+                    "KeywordParameters": {}
+                },
+                "get_name": {
+                    "description": [
+                        "returns the name associated with the asset type"
+                    ],
+                    "type": "method",
+                    "modifies_state": false,
+                    "returns": "string",
+                    "PositionalParameters": [],
+                    "KeywordParameters": {}
+                }
+            }
+        },
+        "vetting_organization_object": {
+            "description": [
+                "an object that serves as the signing authority for an organization",
+                "that vets issuers of a specific asset type",
+                "the vetting organization object represents a root of trust for issuers"
+            ],
+            "interface": {
+                "initialize": {
+                    "description": [
+                        "set the basic information associated with the vetting organization",
+                        "must be invoked before any other operations"
+                    ],
+                    "type": "method",
+                    "modifies_state": true,
+                    "returns": "boolean",
+                    "PositionalParameters": [],
+                    "KeywordParameters":  {
+                        "asset_type_identifier": {
+                            "description": "the identity of the asset type that may be issued",
+                            "$ref": "#/pdo/basetypes/contract-id",
+                            "required": true
+                        }
+                    }
+                },
+                "get_asset_type_identifier": {
+                    "description": [
+                        "returns the asset type id associated with the vetting organization"
+                    ],
+                    "type": "method",
+                    "modifies_state": false,
+                    "returns": {
+                        "$ref": "#/pdo/basetypes/contract-id",
+                    }
+                    "PositionalParameters": [],
+                    "KeywordParameters":  {},
+                },
+                "add_approved_issuer": {
+                    "description": [
+                        "register the verifying key of an issuer of assets of the type associated",
+                        "with the vetting organization",
+                        "the vetting organization attests that the verifying key may be used to sign",
+                        "asset issuances"
+                    ],
+                    "type": "method",
+                    "modifies_state": true,
+                    "returns": "boolean",
+                    "PositionalParameters": [],
+                    "KeywordParameters":  {
+                        "issuer_verifying_key": {
+                            "description": "the ECDSA verifying key associated with an issuer object",
+                            "type": {
+                                "$ref": "#/pod/basetypes/ecdsa-public-key"
+                            },
+                            "required": true
+                        }
+                    }
+                },
+                "get_issuer_authority": {
+                    "description": [
+                        "return a verifiable authority object",
+                        "dependency will include the current state hash of the vetting organization object"
+                    ],
+                    "type": "method",
+                    "modifies_state": false,
+                    "returns": {
+                        "$ref": "#pdo/contract/wawaka/exchange/issuer_authority_chain_type"
+                    },
+                    "PositionalParameters": [],
+                    "KeywordParameters":  {
+                        "issuer_verifying_key": {
+                            "description": "the ECDSA verifying key associated with an issuer object, must be authorized",
+                            "type": {
+                                "$ref": "#/pod/basetypes/ecdsa-public-key"
+                            },
+                            "required": true
+                        }
+                    }
+                }
+            }
+        },
+        "issuer_object": {
+            "description": [
+                ""
+            ],
+            "interface": {
+                "initialize": {
+                    "description": [
+                        ""
+                    ],
+                    "type": "method",
+                    "returns": "boolean",
+                    "PositionalParameters": [],
+                    "KeywordParameters":  {
+                        "asset_type_identifier": {
+                            "description": "",
+                            "type": "",
+                            "required": true
+                        }
+                    }
+                }
+                "method1": {
+                    "description": [
+                        ""
+                    ],
+                    "type": "method",
+                    "returns": "boolean",
+                    "PositionalParameters": [],
+                    "KeywordParameters":  {
+                        "parameter1": {
+                            "description": "",
+                            "type": "",
+                            "required": true
+                        }
+                    }
+                }
+                "method1": {
+                    "description": [
+                        ""
+                    ],
+                    "type": "method",
+                    "returns": "boolean",
+                    "PositionalParameters": [],
+                    "KeywordParameters":  {
+                        "parameter1": {
+                            "description": "",
+                            "type": "",
+                            "required": true
+                        }
+                    }
+                }
+                "method1": {
+                    "description": [
+                        ""
+                    ],
+                    "type": "method",
+                    "returns": "boolean",
+                    "PositionalParameters": [],
+                    "KeywordParameters":  {
+                        "parameter1": {
+                            "description": "",
+                            "type": "",
+                            "required": true
+                        }
+                    }
+                }
+            }
+        },
+        "template_contract": {
+            "description": [
+                ""
+            ],
+            "interface": {
+                "method1": {
+                    "description": [
+                        ""
+                    ],
+                    "type": "method",
+                    "returns": "boolean",
+                    "PositionalParameters": [],
+                    "KeywordParameters":  {
+                        "parameter1": {
+                            "description": "",
+                            "type": "",
+                            "required": true
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/contracts/wawaka/exchange/doc/basetypes.json
+++ b/contracts/wawaka/exchange/doc/basetypes.json
@@ -1,0 +1,272 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "title": "Exchange Interface",
+    "id": "http://tradenet.org/pdo/wawaka/exchange/basetypes#",
+
+    "definitions": {
+        "issuer_authority_type": {
+            "//": "-----------------------------------------------------------------",
+            "id": "#authority_type",
+            "description": [
+                "attestation of the authority given to an issuer by an organization authorized",
+                "to vet issuers of a specific asset type, this may be a vetting organization",
+                "or an authorized issuer of the the asset type",
+                "the holder of the issuer_signing_key associated with the issuer_verifying_key is",
+                "authorized to issue assets of a particular asset type"
+            ],
+            "type": "object",
+            "properties": {
+                "authorized_issuer_verifying_key": {
+                    "description": [
+                        "public key for the issuer"
+                    ],
+                    "$ref": "#/pdo/basetypes/ecdsa-public-key",
+                    "required": true
+                },
+
+                "authorizing_issuer_state_reference": {
+                    "description": [
+                        "state reference for the authorized issuer object",
+                        "ensures that the issuer object state is committed on the ledger"
+                    ],
+                    "$ref": "#/pdo/basetypes/state-reference",
+                    "required": true
+                },
+
+                "authorizing_signature": {
+                    "description": [
+                        "signature of the entity that authorizes the use of the verifying key",
+                        "signature is computed over the asset type identifier, authorized_issuer_verifying_key,"
+                        "and the authorizing_issuer_state_reference"
+
+                    ],
+                    "$ref": "#/pdo/basetypes/escda-signature",
+                    "required": true
+                }
+            }
+        },
+
+        "issuer_authority_chain_type": {
+            "//": "-----------------------------------------------------------------",
+            "id": "#authority_chain_type",
+            "description": [
+                "authority chain that captures the authorization chain from a vetting organization",
+                "to the verifying key of an asset issuer"
+            ],
+            "type": "object",
+            "properties": {
+                "asset_type_identifier": {
+                    "description": [
+                        "the asset type identifier"
+                    ],
+                    "type": {
+                        "$ref": "#/pdo/basetypes/contract-id"
+                    },
+                    "required": true
+                },
+
+                "vetting_organization_verifying_key": {
+                    "description": [
+                        "verifying key associated with the vetting organization",
+                        "this is the root of trust for issuance"
+                    ],
+                    "type": {
+                        "$ref": "#/pdo/basetypes/ecdsa-public-key"
+                    },
+                    "required": true
+                },
+
+                "authority_chain": {
+                    "description": [],
+                    "type": "array",
+                    "items": {
+                        "$ref": "#issuer_authority_type",
+                        "minItems" : 1,
+                        "uniqueItems": true
+                    },
+                    "required": true
+                }
+            }
+        },
+
+        "asset_type": {
+            "//": "-----------------------------------------------------------------",
+            "id": "#asset_type",
+            "description": [
+                ""
+            ],
+            "type": "object",
+            "properties": {
+                "asset_type_identifier": {
+                    "description": [
+                        "the asset type identifier"
+                    ],
+                    "$ref": "#/pdo/basetypes/contract-id",
+                    "required": true
+                },
+
+                "count": {
+                    "description": "number of assets to be assigned to the new owner",
+                    "type": "integer",
+                    "required": true
+                },
+
+                "owner_identity": {
+                    "description": "ECDSA key for the new owner of the assets",
+                    "type": {
+                        "$ref": "#/pdo/basetypes/ecdsa-public-key"
+                    },
+                    "required": true
+                },
+
+                "escrow_agent_identity": {
+                    "description": "ECDSA key for the escrow agent",
+                    "type": {
+                        "$ref": "#/pdo/basetypes/ecdsa-public-key"
+                    },
+                    "required": false
+                },
+
+                "escrow_identifier": {
+                    "description": [
+                        "unique random identifier for an escrow transaction",
+                        "the identifier ensures that stale disburse claims do not apply",
+                        "to the current escrow transaction"
+                    ],
+                    "type": "string",
+                    "required": false
+                }
+            }
+        },
+
+        "authoritative_asset_type": {
+            "//": "-----------------------------------------------------------------",
+            "id": "#authoritative_asset_type",
+            "description": [
+                ""
+            ],
+            "type": "object",
+            "properties": {
+                "asset": {
+                    "description": "the asset",
+                    "type": {
+                        "$ref": "#asset_type"
+                    },
+                    "required": true
+                },
+
+                "issuer_state_reference": {
+                    "description": [
+                        "state reference for the issuer object",
+                        "that is, the state of the asset is valid at this state reference"
+                    ],
+                    "type": {
+                        "$ref": "#/pdo/basetypes/state-reference"
+                    },
+                    "required": true
+                },
+
+                "issuer_signature": {
+                    "description": [
+                        "signature of the issuer that verifies the state of the asset",
+                        "signature is computed over the serialized asset and state reference of the issuer,"
+                        "and the authorizing_issuer_state_reference"
+
+                    ],
+                    "type": {
+                        "$ref": "#/pdo/basetypes/escda-signature"
+                    },
+                    "required": true
+                },
+
+                "issuer_authority_chain": {
+                    "description": [
+                        "the authority chain that attests to the the validity of the issuer"
+                    ],
+                    "type": {
+                        "$ref": "#authority_chain_type"
+                    },
+                    "required": true
+                }
+            }
+        },
+
+        "escrow_claim_type": {
+            "//": "-----------------------------------------------------------------",
+            "id": "#escrow_claim_type",
+            "description": [
+                "information necessary to claim an asset from escrow and change ownership"
+            ],
+            "type": "object",
+            "properties": {
+                "old_owner_identity": {
+                    "description": "ECDSA key for the new owner of the assets",
+                    "type": {
+                        "$ref": "#/pdo/basetypes/ecdsa-public-key"
+                    },
+                    "required": true
+                },
+
+                "escrow_agent_state_reference": {
+                    "description": [
+                        "state reference for the escrow object",
+                        "release from escrow is only valid if this state is committed to the ledger"
+                    ],
+                    "type": {
+                        "$ref": "#/pdo/basetypes/state-reference"
+                    },
+                    "required": true
+                },
+
+                "escrow_agent_signature": {
+                    "description": [
+                        "signature of the escrow that verifies that the asset should be release from escrow",
+                        "signature is computed over the serialized asset, state reference of the escrow agent,",
+                        "and the invokers identity"
+                    ],
+                    "type": {
+                        "$ref": "#/pdo/basetypes/escda-signature"
+                    },
+                    "required": true
+                }
+            }
+        },
+
+        "asset_request_type": {
+            "//": "-----------------------------------------------------------------",
+            "id": "#asset_request_type",
+            "description": [
+                "request for exchange that specifies type, count or owner that will be accepted",
+                "in exchange for the offered asset"
+            ],
+            "type": "object",
+            "properties": {
+                "asset_type_identifier": {
+                    "description": [
+                        "the asset type identifier"
+                    ],
+                    "$ref": "#/pdo/basetypes/contract-id",
+                    "required": true
+                },
+
+                "count": {
+                    "description": "number of assets to be assigned to the new owner",
+                    "type": "integer",
+                    "required": true
+                },
+
+                "owner_identity": {
+                    "description": "ECDSA key for the new owner of the assets",
+                    "type": {
+                        "$ref": "#/pdo/basetypes/ecdsa-public-key"
+                    },
+                    "required": true
+                }
+            }
+        }
+    }
+}
+
+// Local Variables:
+// mode: hs-minor
+// End:

--- a/contracts/wawaka/exchange/doc/exchange.json
+++ b/contracts/wawaka/exchange/doc/exchange.json
@@ -1,0 +1,183 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "title": "Exchange Interface",
+    "id": "http://tradenet.org/pdo/contract/wawaka/exchange#",
+
+    "description": [
+        ""
+    ],
+
+    "interface": {
+        "initialize": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "initialize the details of the requested exchange",
+                "this operation must be invoked before any other operation",
+                "it must be invoked by creator"
+            ],
+            "type": "method",
+            "modifies_state": true,
+            "returns": "boolean",
+            "PositionalParameters": [],
+            "KeywordParameters":  {
+                "asset_request": {
+                    "description": "",
+                    "type": {
+                        "$ref": "#/pdo/wawaka/exchange/basetypes/asset_request_type"
+                    },
+                    "required": true
+                },
+
+                "authority_verifying_key": {
+                    "description": [
+                        "verifying key associated with a vetting organization or issuer",
+                        "this is the root of trust for issuance, exchanged assets must be",
+                        "authorized by the specified key"
+                    ],
+                    "type": {
+                        "$ref": "#/pdo/basetypes/ecdsa-public-key"
+                    },
+                    "required": true
+                }
+            }
+        },
+
+        "offer_asset": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "offer an asset through the exchange contract",
+                "the offered asset must be escrowed to the exchange contract object",
+                "it must be invoked by creator"
+            ],
+            "type": "method",
+            "modifies_state": true,
+            "returns": "boolean",
+            "PositionalParameters": [],
+            "KeywordParameters":  {
+                "offered_authoritative_asset": {
+                    "description": "",
+                    "type": {
+                        "$ref": "#/pdo/wawaka/exchange/basetypes/authoritative_asset_type"
+                    },
+                    "required": true
+                }
+            }
+        },
+
+        "cancel_offer": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                ""
+            ],
+            "type": "method",
+            "modifies_state": true,
+            "returns": "boolean",
+            "PositionalParameters": [],
+            "KeywordParameters":  {
+                "parameter1": {
+                    "description": "",
+                    "type": "",
+                    "required": true
+                }
+            }
+        },
+
+        "cancel_offer_attestation": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                ""
+            ],
+            "type": "method",
+            "modifies_state": false,
+            "returns": "boolean",
+            "PositionalParameters": [],
+            "KeywordParameters":  {
+                "parameter1": {
+                    "description": "",
+                    "type": "",
+                    "required": true
+                }
+            }
+        },
+
+        "examine_offered_asset": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "return the offered authoritative asset"
+            ],
+            "type": "method",
+            "modifies_state": false,
+            "returns": {
+                "$ref": "#/pdo/wawaka/exchange/basetypes/escrow_claim_type"
+            }
+            "PositionalParameters": [],
+            "KeywordParameters":  {}
+        },
+
+        "examine_requested_asset": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "return the asset request object"
+            ],
+            "type": "method",
+            "modifies_state": false,
+            "returns": {
+                "$ref": "#/pdo/wawaka/exchange/basetypes/asset_request_type"
+            },
+            "PositionalParameters": [],
+            "KeywordParameters":  {}
+        },
+
+        "exchange_asset": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "submit an asset in response to the asset request",
+                "the submitted asset must be escrowed to the exchange object",
+                "the submitted asset must match the request"
+            ],
+            "type": "method",
+            "modifies_state": true,
+            "returns": "boolean",
+            "PositionalParameters": [],
+            "KeywordParameters":  {
+                "offered_authoritative_asset": {
+                    "description": "",
+                    "type": {
+                        "$ref": "#/pdo/wawaka/exchange/basetypes/authoritative_asset_type"
+                    },
+                    "required": true
+                }
+            }
+        },
+
+        "claim_exchange": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "create a claim object that can be used to redeem the exchange asset",
+                "must be invoked by the creator"
+            ],
+            "type": "method",
+            "modifies_state": false,
+            "returns": {
+                "$ref": "#/pdo/wawaka/exchange/basetypes/escrow_claim_type"
+            }
+            "PositionalParameters": [],
+            "KeywordParameters":  {}
+        },
+
+        "claim_offer": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "create a claim object that can be used to redeem the offered asset",
+                "must be invoked by the identity that submitted the exchange asset"
+            ],
+            "type": "method",
+            "modifies_state": false,
+            "returns": {
+                "$ref": "#/pdo/wawaka/exchange/basetypes/escrow_claim_type"
+            }
+            "PositionalParameters": [],
+            "KeywordParameters":  {}
+        }
+    }
+}

--- a/contracts/wawaka/exchange/doc/issuer.json
+++ b/contracts/wawaka/exchange/doc/issuer.json
@@ -1,0 +1,295 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "title": "Exchange Interface",
+    "id": "http://tradenet.org/pdo/wawaka/exchange/issuer#",
+
+    "description": [
+        ""
+    ],
+
+    "interface": {
+        "initialize": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "initialize the issuer with the authority granted to issue assets",
+                "this operation must be invoked before any other operation",
+                "it must be invoked by creator"
+            ],
+            "type": "method",
+            "modifies_state": true,
+            "returns": "boolean",
+            "PositionalParameters": [],
+            "KeywordParameters":  {
+                "asset_authority_chain": {
+                    "description": "",
+                    "type": {
+                        "$ref": "#pdo/wawaka/exchange/basetypes/issuer_authority_chain_type"
+                    },
+                    "required": true
+                }
+            }
+        },
+
+        "get_asset_type_identifier": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "returns the asset type id associated with the vetting organization"
+            ],
+            "type": "method",
+            "modifies_state": false,
+            "returns": {
+                "$ref": "#/pdo/basetypes/contract-id",
+            }
+            "PositionalParameters": [],
+            "KeywordParameters":  {},
+        },
+
+        "get_verifying_key": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "returns the asset type id associated with the vetting organization"
+            ],
+            "type": "method",
+            "modifies_state": false,
+            "returns": {
+                "$ref": "#/pdo/basetypes/ecdsa-public-key",
+            }
+            "PositionalParameters": [],
+            "KeywordParameters":  {},
+        },
+
+        "add_approved_issuer": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "register the verifying key of an issuer of assets of the type associated",
+                "with the vetting organization",
+                "the vetting organization attests that the verifying key may be used to sign",
+                "asset issuances"
+            ],
+            "type": "method",
+            "modifies_state": true,
+            "returns": "boolean",
+            "PositionalParameters": [],
+            "KeywordParameters":  {
+                "issuer_verifying_key": {
+                    "description": "the ECDSA verifying key associated with an issuer object",
+                    "type": {
+                        "$ref": "#/pdo/basetypes/ecdsa-public-key"
+                    },
+                    "required": true
+                }
+            }
+        },
+
+        "get_issuer_authority": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "return a verifiable authority object",
+                "dependency will include the current state hash of the vetting organization object"
+            ],
+            "type": "method",
+            "modifies_state": false,
+            "returns": {
+                "$ref": "#pdo/wawaka/exchange/basetypes/issuer_authority_chain_type"
+            },
+            "PositionalParameters": [],
+            "KeywordParameters":  {
+                "issuer_verifying_key": {
+                    "description": "the ECDSA verifying key associated with an issuer object, must be authorized",
+                    "type": {
+                        "$ref": "#/pod/basetypes/ecdsa-public-key"
+                    },
+                    "required": true
+                }
+            }
+        },
+
+        "get_authority": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "return a verifiable authority object",
+                "this is the object that establishes this issuers authority"
+            ],
+            "type": "method",
+            "modifies_state": false,
+            "returns": {
+                "$ref": "#pdo/wawaka/exchange/basetypes/issuer_authority_chain_type"
+            },
+            "PositionalParameters": [],
+            "KeywordParameters":  {
+                "issuer_verifying_key": {
+                    "description": "the ECDSA verifying key associated with an issuer object, must be authorized",
+                    "type": {
+                        "$ref": "#/pod/basetypes/ecdsa-public-key"
+                    },
+                    "required": true
+                }
+            }
+        },
+
+        "issue": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "issue assets to an identity",
+                "assigns ownership of assets in the issuers ledger",
+                "must be invoked by the creator of the issuer object"
+            ],
+            "type": "method",
+            "modifies_state": true,
+            "returns": "boolean",
+            "PositionalParameters": [],
+            "KeywordParameters":  {
+                "owner_identity": {
+                    "description": "ECDSA key for the new owner of the assets",
+                    "type": {
+                        "$ref": "#/pdo/basetypes/ecdsa-public-key"
+                    },
+                    "required": true
+                },
+                "count": {
+                    "description": "number of assets to be assigned to the new owner",
+                    "type": "integer",
+                    "required": true
+                }
+            }
+        },
+
+        "get_balance": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "get the current number of assets assigned to the invoker",
+                "if the identity is unknown to the issuer, then the balance is 0"
+            ],
+            "type": "method",
+            "modifies_state": false,
+            "returns": "integer",
+            "PositionalParameters": [],
+            "KeywordParameters":  {}
+        },
+
+        "transfer": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "transfer ownership of some number of assets from the invoker to",
+                "the specified identity"
+            ],
+            "type": "method",
+            "modifies_state": true,
+            "returns": "boolean",
+            "PositionalParameters": [],
+            "KeywordParameters":  {
+                "new_owner_identity": {
+                    "description": "ECDSA key for the new owner of the assets",
+                    "type": {
+                        "$ref": "#/pdo/basetypes/ecdsa-public-key"
+                    },
+                    "required": true
+                },
+                "count": {
+                    "description": "number of assets to be assigned to the new owner",
+                    "type": "integer",
+                    "required": true
+                }
+            }
+        },
+
+        "escrow": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "place the assets assigned to the invoker in escrow to a given identity;",
+                "the asset balance will be marked inactive.",
+                "note that this method changes the state of the asset balance, but does",
+                "not return an escrow attestion since the state change in this function",
+                "must be committed first."
+            ],
+            "type": "method",
+            "modifies_state": true,
+            "returns": "boolean",
+            "PositionalParameters": [],
+            "KeywordParameters":  {
+                "escrow_agent_identity": {
+                    "description": "ECDSA key for the new owner of the assets",
+                    "type": {
+                        "$ref": "#/pdo/basetypes/ecdsa-public-key"
+                    },
+                    "required": true
+                }
+            }
+        },
+
+        "escrow_attestation": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "create an attestation that assets owned by the invoker",
+                "have been escrowed to a particular escrow agent"
+            ],
+            "type": "method",
+            "modifies_state": false,
+            "returns": {
+                "$ref": "#/pdo/wawaka/exchange/basetypes/authoritative_asset_type"
+            },
+            "PositionalParameters": [],
+            "KeywordParameters":  {}
+        },
+
+        "disburse": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "release from escrow the assets owned by the invoker",
+                "sets transaction dependencies based on the input"
+            ],
+            "type": "method",
+            "modifies_state": true,
+            "returns": "boolean",
+            "PositionalParameters": [],
+            "KeywordParameters":  {
+                "escrow_agent_state_reference": {
+                    "description": [
+                        "state reference for the escrow object",
+                        "release from escrow is only valid if this state is committed to the ledger"
+                    ],
+                    "type": {
+                        "$ref": "#/pdo/basetypes/state-reference"
+                    },
+                    "required": true
+                },
+
+                "escrow_agent_signature": {
+                    "description": [
+                        "signature of the escrow that verifies that the asset should be release from escrow",
+                        "signature is computed over the serialized asset and state reference of the escrow agent"
+                    ],
+                    "type": {
+                        "$ref": "#/pdo/basetypes/escda-signature"
+                    },
+                    "required": true
+                }
+            }
+        },
+
+        "claim": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "claim ownership of assets based on the signature of an escrow agent",
+                "sets transaction dependencies based on the input"
+            ],
+            "type": "method",
+            "modifies_state": true,
+            "returns": "boolean",
+            "PositionalParameters": [],
+            "KeywordParameters":  {
+                "escrow_claim": {
+                    "description": "a claim of ownership change from an escrow agent",
+                    "type": {
+                        "$ref": "#/pdo/wawaka/exchange/basetypes/escrow_claim_type"
+                    },
+                    "required": true
+                }
+            }
+        }
+    }
+}
+
+// Local Variables:
+// mode: hs-minor
+// End:

--- a/contracts/wawaka/exchange/doc/vetting_organization.json
+++ b/contracts/wawaka/exchange/doc/vetting_organization.json
@@ -1,0 +1,113 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "title": "interface for vetting organization contract object",
+    "id": "http://tradenet.org/pdo/wawaka/exchange/vetting_organization#",
+
+    "description": [
+        "an object that serves as the signing authority for an organization",
+        "that vets issuers of a specific asset type",
+        "the vetting organization object represents a root of trust for issuers"
+    ],
+
+    "interface": {
+
+        "initialize": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "set the basic information associated with the vetting organization",
+                "must be invoked before any other operations"
+            ],
+            "type": "method",
+            "modifies_state": true,
+            "returns": "boolean",
+            "PositionalParameters": [],
+            "KeywordParameters":  {
+                "asset_type_identifier": {
+                    "description": "the identity of the asset type that may be issued",
+                    "type": {
+                        "$ref": "#/pdo/basetypes/contract-id"
+                    },
+                    "required": true
+                }
+            }
+        },
+
+        "get_asset_type_identifier": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "returns the asset type id associated with the vetting organization"
+            ],
+            "type": "method",
+            "modifies_state": false,
+            "returns": {
+                "$ref": "#/pdo/basetypes/contract-id",
+            }
+            "PositionalParameters": [],
+            "KeywordParameters":  {},
+        },
+
+        "get_verifying_key": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "returns the asset type id associated with the vetting organization"
+            ],
+            "type": "method",
+            "modifies_state": false,
+            "returns": {
+                "$ref": "#/pdo/basetypes/ecdsa-public-key",
+            }
+            "PositionalParameters": [],
+            "KeywordParameters":  {},
+        },
+
+        "add_approved_issuer": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "register the verifying key of an issuer of assets of the type associated",
+                "with the vetting organization",
+                "the vetting organization attests that the verifying key may be used to sign",
+                "asset issuances"
+            ],
+            "type": "method",
+            "modifies_state": true,
+            "returns": "boolean",
+            "PositionalParameters": [],
+            "KeywordParameters":  {
+                "issuer_verifying_key": {
+                    "description": "the ECDSA verifying key associated with an issuer object",
+                    "type": {
+                        "$ref": "#/pdo/basetypes/ecdsa-public-key"
+                    },
+                    "required": true
+                }
+            }
+        },
+
+        "get_issuer_authority": {
+            "//": "-----------------------------------------------------------------",
+            "description": [
+                "return a verifiable authority object",
+                "dependency will include the current state hash of the vetting organization object"
+            ],
+            "type": "method",
+            "modifies_state": false,
+            "returns": {
+                "$ref": "#pdo/wawaka/exchange/basetypes/issuer_authority_chain_type"
+            },
+            "PositionalParameters": [],
+            "KeywordParameters":  {
+                "issuer_verifying_key": {
+                    "description": "the ECDSA verifying key associated with an issuer object, must be authorized",
+                    "type": {
+                        "$ref": "#/pod/basetypes/ecdsa-public-key"
+                    },
+                    "required": true
+                }
+            }
+        }
+    }
+}
+
+// Local Variables:
+// mode: hs-minor
+// End:

--- a/contracts/wawaka/exchange/plugins/asset_type.py
+++ b/contracts/wawaka/exchange/plugins/asset_type.py
@@ -1,0 +1,105 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import shlex
+import logging
+
+logger = logging.getLogger(__name__)
+
+from pdo.client.controller.commands.send import send_to_contract
+from pdo.client.controller.util import *
+from pdo.contract import invocation_request
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def __command_asset_type__(state, bindings, pargs) :
+    """controller command to interact with an asset_type contract
+    """
+
+    parser = argparse.ArgumentParser(prog='asset_type')
+    parser.add_argument('-e', '--enclave', help='URL of the enclave service to use', type=str)
+    parser.add_argument('-f', '--save_file', help='File where contract data is stored', type=str)
+    parser.add_argument('-q', '--quiet', help='Suppress printing the result', action='store_true')
+    parser.add_argument('-w', '--wait', help='Wait for the transaction to commit', action='store_true')
+
+    subparsers = parser.add_subparsers(dest='command')
+
+    subparser = subparsers.add_parser('initialize')
+    subparser.add_argument('-d', '--description', help='human readable description', type=str, default='')
+    subparser.add_argument('-n', '--name', help='human readable name', type=str, default='')
+    subparser.add_argument('-l', '--link', help='URL where more information is located', type=str, default='')
+
+    subparser = subparsers.add_parser('get_asset_type_identifier')
+    subparser.add_argument('-s', '--symbol', help='binding symbol for result', type=str)
+
+    subparser = subparsers.add_parser('describe')
+    options = parser.parse_args(pargs)
+
+    extraparams={'quiet' : options.quiet, 'wait' : options.wait}
+
+    # -------------------------------------------------------
+    if options.command == 'initialize' :
+        message = invocation_request('initialize', name=options.name, description=options.description, link=options.link)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+        return
+
+    # -------------------------------------------------------
+    if options.command == 'get_asset_type_identifier' :
+        extraparams['commit'] = False
+        message = invocation_request('get_asset_type_identifier')
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+        if result and options.symbol :
+            bindings.bind(options.symbol, result)
+        print("IDENTIFIER: {0}".format(result))
+        return
+
+    # -------------------------------------------------------
+    if options.command == 'describe' :
+        extraparams['quiet'] = True
+        extraparams['commit'] = False
+        message = invocation_request('get_name')
+        name = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+        message = invocation_request('get_description')
+        description = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+        message = invocation_request('get_link')
+        link = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+        print("NAME: {0}".format(name))
+        print("DESC: {0}".format(description))
+        print("LINK: {0}".format(link))
+
+        return
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def do_asset_type(self, args) :
+    """
+    asset_type -- invoke methods from the asset_type contract
+    """
+
+    try :
+        pargs = self.__arg_parse__(args)
+        __command_asset_type__(self.state, self.bindings, pargs)
+
+    except SystemExit as se :
+        return self.__arg_error__('asset_type', args, se.code)
+    except Exception as e :
+        return self.__error__('asset_type', args, str(e))
+
+    return False
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def load_commands(cmdclass) :
+    setattr(cmdclass, 'do_asset_type', do_asset_type)

--- a/contracts/wawaka/exchange/plugins/issuer.py
+++ b/contracts/wawaka/exchange/plugins/issuer.py
@@ -1,0 +1,258 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import shlex
+import logging
+
+logger = logging.getLogger(__name__)
+
+from pdo.client.controller.commands.send import send_to_contract
+from pdo.client.controller.util import *
+from pdo.contract import invocation_request
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def __command_issuer__(state, bindings, pargs) :
+    """controller command to interact with an issuer contract
+    """
+
+    parser = argparse.ArgumentParser(prog='issuer')
+    parser.add_argument('-e', '--enclave', help='URL of the enclave service to use', type=str)
+    parser.add_argument('-f', '--save_file', help='File where contract data is stored', type=str)
+    parser.add_argument('-q', '--quiet', help='Suppress printing the result', action='store_true')
+    parser.add_argument('-w', '--wait', help='Wait for the transaction to commit', action='store_true')
+
+    subparsers = parser.add_subparsers(dest='command')
+
+    # common contract commands
+    subparser = subparsers.add_parser('initialize')
+    subparser.add_argument(
+        '-a', '--authority',
+        help='serialized authority from the vetting organization',
+        type=invocation_parameter, required=True)
+
+    subparser = subparsers.add_parser('get_verifying_key')
+    subparser.add_argument(
+        '-s', '--symbol',
+        help='binding symbol for result',
+        type=str)
+
+    # issuer authority commands
+    subparser = subparsers.add_parser('get_asset_type_identifier')
+    subparser.add_argument(
+        '-s', '--symbol',
+        help='binding symbol for result',
+        type=str)
+
+    subparser = subparsers.add_parser('approve_issuer')
+    subparser.add_argument(
+        '-i', '--issuer',
+        help='identity of the issuer; ECDSA key',
+        type=invocation_parameter, required=True)
+
+    subparser = subparsers.add_parser('get_issuer_authority')
+    subparser.add_argument(
+        '-s', '--symbol',
+        help='binding symbol for result',
+        type=str)
+    subparser.add_argument(
+        '-i', '--issuer',
+        help='identity of the issuer; ECDSA key',
+        type=invocation_parameter, required=True)
+
+    subparser = subparsers.add_parser('get_authority')
+    subparser.add_argument(
+        '-s', '--symbol',
+        help='binding symbol for result',
+        type=str)
+
+    # ledger management commands
+    subparser = subparsers.add_parser('get_balance')
+    subparser.add_argument(
+        '-s', '--symbol',
+        help='binding symbol for result',
+        type=str)
+
+    subparser = subparsers.add_parser('issue')
+    subparser.add_argument(
+        '-o', '--owner',
+        help='identity of the issuance owner; ECDSA key',
+        type=str, required=True)
+    subparser.add_argument(
+        '-c', '--count',
+        help='amount of the issuance',
+        type=int, required=True)
+
+    subparser = subparsers.add_parser('transfer')
+    subparser.add_argument(
+        '-n', '--new_owner',
+        help='identity of the new owner; ECDSA key',
+        type=str, required=True)
+    subparser.add_argument(
+        '-c', '--count',
+        help='amount to transfer',
+        type=int, required=True)
+
+    # escrow and exchange commands
+    subparser = subparsers.add_parser('escrow')   # combine escrow & attestation
+    subparser.add_argument(
+        '-a', '--agent',
+        help='identity of the escrow agent',
+        type=str, required=True)
+    subparser.add_argument(
+        '-s', '--symbol',
+        help='binding symbol for result',
+        type=str)
+
+    subparser = subparsers.add_parser('disburse')
+    subparser.add_argument(
+        '-a', '--attestation',
+        help='Disburse attestation from the escrow agent',
+        type=invocation_parameter, required=True)
+
+    subparser = subparsers.add_parser('claim')
+    subparser.add_argument(
+        '-a', '--attestation',
+        help='Disburse attestation from the escrow agent',
+        type=invocation_parameter, required=True)
+
+    options = parser.parse_args(pargs)
+
+    extraparams={'quiet' : options.quiet, 'wait' : options.wait}
+
+    # -------------------------------------------------------
+    if options.command == 'initialize' :
+        message = invocation_request('initialize', asset_authority_chain=options.authority)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+        return
+
+    # -------------------------------------------------------
+    if options.command == 'get_verifying_key' :
+        extraparams['commit'] = False
+        message = invocation_request('get_verifying_key')
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+        if options.symbol :
+            bindings.bind(options.symbol, result)
+        return
+
+    # -------------------------------------------------------
+    if options.command == 'get_asset_type_identifier' :
+        extraparams['commit'] = False
+        message = invocation_request('get_asset_type_identifier')
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+        if options.symbol :
+            bindings.bind(options.symbol, result)
+        return
+
+    # -------------------------------------------------------
+    if options.command == 'approve_issuer' :
+        message = invocation_request('add_approved_issuer', issuer_verifying_key=options.issuer)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+        return
+
+   # -------------------------------------------------------
+    if options.command == 'get_issuer_authority' :
+        extraparams['commit'] = False
+        message = invocation_request('get_issuer_authority', issuer_verifying_key=options.issuer)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+        if options.symbol :
+            bindings.bind(options.symbol, result)
+        return
+
+   # -------------------------------------------------------
+    if options.command == 'get_authority' :
+        extraparams['commit'] = False
+        message = invocation_request('get_authority')
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+        if options.symbol :
+            bindings.bind(options.symbol, result)
+        return
+
+    # -------------------------------------------------------
+    if options.command == 'get_balance' :
+        extraparams['commit'] = False
+        message = invocation_request('get_balance')
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+        if options.symbol :
+            bindings.bind(options.symbol, result)
+        return
+
+    # -------------------------------------------------------
+    if options.command == 'issue' :
+        message = invocation_request('issue', owner_identity=options.owner, count=options.count)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+        return
+
+    # -------------------------------------------------------
+    if options.command == 'transfer' :
+        message = invocation_request('transfer', new_owner_identity=options.new_owner, count=options.count)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+        return
+
+    # -------------------------------------------------------
+    if options.command == 'escrow' :
+        extraparams['commit'] = True
+        extraparams['wait'] = True
+        message = invocation_request('escrow', escrow_agent_identity=options.agent)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+
+        extraparams['commit'] = False
+        extraparams['wait'] = False
+        message = invocation_request('escrow_attestation')
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+        if options.symbol :
+            bindings.bind(options.symbol, result)
+        return
+
+    # -------------------------------------------------------
+    if options.command == 'disburse' :
+        assert type(options.attestation) is list
+        dependencies = options.attestation[0]
+        signature = options.attestation[1]
+        message = invocation_request('disburse', dependencies, signature)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+        return
+
+    # -------------------------------------------------------
+    if options.command == 'claim' :
+        assert type(options.attestation) is list
+        old_owner_identity = options.attestation[0]
+        dependencies = options.attestation[1]
+        signature = options.attestation[2]
+        message = invocation_request('claim', old_owner_identity, dependencies, signature)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+        return
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def do_issuer(self, args) :
+    """
+    issuer -- invoke methods from the issuer contract
+    """
+
+    try :
+        pargs = self.__arg_parse__(args)
+        __command_issuer__(self.state, self.bindings, pargs)
+    except SystemExit as se :
+        return self.__arg_error__('issuer', args, se.code)
+    except Exception as e :
+        return self.__error__('issuer', args, str(e))
+
+    return False
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def load_commands(cmdclass) :
+    setattr(cmdclass, 'do_issuer', do_issuer)

--- a/contracts/wawaka/exchange/plugins/vetting.py
+++ b/contracts/wawaka/exchange/plugins/vetting.py
@@ -1,0 +1,139 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import shlex
+import logging
+
+logger = logging.getLogger(__name__)
+
+from pdo.client.controller.commands.send import send_to_contract
+from pdo.client.controller.util import *
+from pdo.contract import invocation_request
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def __command_vetting__(state, bindings, pargs) :
+    """controller command to interact with an vetting contract
+    """
+
+    parser = argparse.ArgumentParser(prog='vetting')
+    parser.add_argument('-e', '--enclave', help='URL of the enclave service to use', type=str)
+    parser.add_argument('-f', '--save_file', help='File where contract data is stored', type=str)
+    parser.add_argument('-q', '--quiet', help='Suppress printing the result', action='store_true')
+    parser.add_argument('-w', '--wait', help='Wait for the transaction to commit', action='store_true')
+
+    subparsers = parser.add_subparsers(dest='command')
+
+    # common contract commands
+    subparser = subparsers.add_parser('initialize')
+    subparser.add_argument(
+        '-t', '--type_id',
+        help='contract identifier for the issuer asset type',
+        type=invocation_parameter, required=True)
+
+    subparser = subparsers.add_parser('get_verifying_key')
+    subparser.add_argument(
+        '-s', '--symbol',
+        help='binding symbol for result',
+        type=str)
+
+    # issuer authority commands
+    subparser = subparsers.add_parser('get_asset_type_identifier')
+    subparser.add_argument(
+        '-s', '--symbol',
+        help='binding symbol for result',
+        type=str)
+
+    subparser = subparsers.add_parser('approve_issuer')
+    subparser.add_argument(
+        '-i', '--issuer',
+        help='identity of the issuer; ECDSA key',
+        type=invocation_parameter, required=True)
+
+    subparser = subparsers.add_parser('get_issuer_authority')
+    subparser.add_argument(
+        '-s', '--symbol',
+        help='binding symbol for result',
+        type=str)
+    subparser.add_argument(
+        '-i', '--issuer',
+        help='identity of the issuer; ECDSA key',
+        type=invocation_parameter, required=True)
+
+    options = parser.parse_args(pargs)
+
+    extraparams={'quiet' : options.quiet, 'wait' : options.wait}
+
+    # -------------------------------------------------------
+    if options.command == 'initialize' :
+        message = invocation_request('initialize', asset_type_identifier=options.type_id)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+        return
+
+    # -------------------------------------------------------
+    if options.command == 'get_verifying_key' :
+        extraparams['commit'] = False
+        message = invocation_request('get_verifying_key')
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+        if options.symbol :
+            bindings.bind(options.symbol, result)
+        return
+
+    # -------------------------------------------------------
+    if options.command == 'get_asset_type_identifier' :
+        extraparams['commit'] = False
+        message = invocation_request('get_asset_type_identifier')
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+        if options.symbol :
+            bindings.bind(options.symbol, result)
+        return
+
+    # -------------------------------------------------------
+    if options.command == 'approve_issuer' :
+        message = invocation_request('add_approved_issuer', issuer_verifying_key=options.issuer)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+        return
+
+   # -------------------------------------------------------
+    if options.command == 'get_issuer_authority' :
+        extraparams['commit'] = False
+        message = invocation_request('get_issuer_authority', issuer_verifying_key=options.issuer)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+        if options.symbol :
+            bindings.bind(options.symbol, result)
+        return
+
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def do_vetting(self, args) :
+    """
+    vetting -- invoke methods from the vetting contract
+    """
+
+    try :
+        pargs = self.__arg_parse__(args)
+        __command_vetting__(self.state, self.bindings, pargs)
+    except SystemExit as se :
+        return self.__arg_error__('vetting', args, se.code)
+    except Exception as e :
+        return self.__error__('vetting', args, str(e))
+
+    return False
+
+## -----------------------------------------------------------------
+## -----------------------------------------------------------------
+def load_commands(cmdclass) :
+    setattr(cmdclass, 'do_vetting', do_vetting)

--- a/contracts/wawaka/exchange/scripts/README.md
+++ b/contracts/wawaka/exchange/scripts/README.md
@@ -1,0 +1,111 @@
+<!---
+Licensed under Creative Commons Attribution 4.0 International License
+https://creativecommons.org/licenses/by/4.0/
+--->
+# Exchange Scripts
+
+This directory contains a number of pdo-shell scripts to test the
+exchange contract family. The scripts assume that a complete
+installation of the PDO client is complete.
+
+The scripts use pdo-shell variables that can be set from the pdo-shell
+invocation using the `-m` switch: `-m <variable> <value>`.
+
+## Test Scripts
+
+### `run-tests.sh`
+
+This script sets up and runs the functional test suite for the exchange
+contract family. The actual tests will be found in the pdo-shell script
+`functional_test.psh`
+
+### `setup.sh`
+
+This script creates the keys and assets in preparation for the exchange
+and auction tests. It will invoke many of the contract invocation
+scripts in order to setup and execute the exchange and auction tests.
+
+## Contract Invoctaion Scripts
+
+Contract invocation scripts provide wrappers for basic interactions
+with the exchange contract family.
+
+The following pdo-shell variables are used:
+* color -- the color to use for the marble
+* data -- the directory where eservice database is stored
+* save -- the directory where the contract objects are stored
+* path -- the directory where the PSH scripts are stored
+
+The script assumes that there are three keys available for each colorad
+marble type:
+* `${color}_type` -- keys used for the asset type object
+* `${color}_vetting` -- keys used for the vetting rganization
+* `${color}_issuer` -- keys used for the issuer
+
+For the most part, the scripts will be invoke like this:
+
+```bash
+pdo-shell -s <command>.psh -m color <color> -m path <contract path>
+```
+
+### `approve_issuer.psh`
+
+This script will allow a vetting organization to approve an issuer. The
+vetting organization and issuer must be created first.
+
+### `create_issuer.psh`
+
+This script will create an issuer. The vetting organization and asset
+type must be created first.
+
+### `create_type.psh`
+
+This script will create an asset type. This is the first script that
+will generally be invoked.
+
+### `create_vetting.psh`
+
+This script will create a vetting organization. A vetting organization
+is the root of a trust hierarchy of issuers for an particular asset
+type.  The asset type must be created first.
+
+### `initialize_issuer.psh`
+
+This script will initialize an issuer that has been approved by
+a vetting organization. The script copies the authority chain
+from the vetting organization into the issuer.
+
+## `issue.psh`
+
+This script will issue assets for a particular issuee. The issuee must
+have keys available. The script takes two additional parameter beyond
+the common paramters.
+
+* `issuee` -- the name of the invidual who will be issued assets, there
+must be a public key in the key directory for the issuee Keys must be
+available for the issuee.
+* `count` -- the number of assets to be issued to the issuee
+
+This script can be invoked as follows:
+
+`$ pdo-shell -s issue.psh -m color <color> -m path <contract path> -m issuee <identity> -m count <count>`
+
+## Support Scripts
+
+### `create_eservice_db.psh`
+
+Script to set up the eservice database. Should be removed later
+in favor of a commonly available version of the script.
+
+### `functional_test.psh`
+
+This script provides a functional test of the various contract
+types in the exchange contract family. In general, this should
+not be invoked directly but should be called through `run-tests.sh`.
+
+### `init.psh`
+
+Simple initialization script that loads the plugins for the exchange
+suite of contracts. This script also creates some enclave service
+and provisioning service groups that are useful for creating contract
+objects.

--- a/contracts/wawaka/exchange/scripts/approve_issuer.psh
+++ b/contracts/wawaka/exchange/scripts/approve_issuer.psh
@@ -1,0 +1,39 @@
+#! /usr/bin/env pdo-shell
+
+## Copyright 2018 Intel Corporation
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+set -q --conditional -s data -v .
+set -q --conditional -s save -v .
+
+script -f ${path}/init.psh
+
+if --null ${color}
+   echo must specify color: '-m color <color>'
+   exit
+fi
+
+set -q --conditional -s vetter -v ${color}_vetting
+set -q --conditional -s issuer_contract -v ${save}/${color}_issuer.pdo
+set -q --conditional -s vetting_contract -v ${save}/${color}_vetting.pdo
+
+## =================================================================
+echo approve ${color} marble issuer
+## =================================================================
+identity -n ${vetter}
+
+issuer -q -f ${issuer_contract} get_verifying_key -s _issuer_contract_key
+vetting -q -w -f ${vetting_contract} approve_issuer -i ${_issuer_contract_key}
+
+exit

--- a/contracts/wawaka/exchange/scripts/create_eservice_db.psh
+++ b/contracts/wawaka/exchange/scripts/create_eservice_db.psh
@@ -1,0 +1,28 @@
+#! /usr/bin/env pdo-shell
+
+## Copyright 2018 Intel Corporation
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+set -q --conditional -s dbfile -v ${data}/eservice-db.json
+
+eservice_db clear
+eservice_db add --url http://localhost:7101 --name es7101
+eservice_db add --url http://localhost:7102 --name es7102
+eservice_db add --url http://localhost:7103 --name es7103
+eservice_db add --url http://localhost:7104 --name es7104
+eservice_db add --url http://localhost:7105 --name es7105
+
+eservice_db save --database ${dbfile}
+
+exit

--- a/contracts/wawaka/exchange/scripts/create_issuer.psh
+++ b/contracts/wawaka/exchange/scripts/create_issuer.psh
@@ -1,0 +1,35 @@
+#! /usr/bin/env pdo-shell
+
+## Copyright 2018 Intel Corporation
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+set -q --conditional -s data -v .
+set -q --conditional -s save -v .
+script -f ${path}/init.psh
+
+if --null ${color}
+   echo must specify color: '-m color <color>'
+   exit
+fi
+
+set -q --conditional -s issuer -v ${color}_issuer
+set -q --conditional -s issuer_contract -v ${save}/${color}_issuer.pdo
+
+## =================================================================
+echo create ${color} marble issuer
+## =================================================================
+identity -n ${issuer}
+create -c issuer_contract -s _issuer -f ${issuer_contract}
+
+exit

--- a/contracts/wawaka/exchange/scripts/create_type.psh
+++ b/contracts/wawaka/exchange/scripts/create_type.psh
@@ -1,0 +1,33 @@
+#! /usr/bin/env pdo-shell
+
+## Copyright 2018 Intel Corporation
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+set -q --conditional -s data -v .
+set -q --conditional -s save -v .
+script -f ${path}/init.psh
+
+if --null ${color}
+   echo must specify color: '-m color <color>'
+   exit
+fi
+
+## =================================================================
+echo create the asset type for ${color} marbles
+## =================================================================
+identity -n ${color}_type
+create -c asset_type -s _asset_type -f ${save}/${color}_type.pdo
+asset_type -q -w -f ${save}/${color}_type.pdo initialize -n "${color} marbles" -d "${color} marble description" -l "http://"
+
+exit

--- a/contracts/wawaka/exchange/scripts/create_vetting.psh
+++ b/contracts/wawaka/exchange/scripts/create_vetting.psh
@@ -1,0 +1,34 @@
+#! /usr/bin/env pdo-shell
+
+## Copyright 2018 Intel Corporation
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+set -q --conditional -s data -v .
+set -q --conditional -s save -v .
+script -f ${path}/init.psh
+
+if --null ${color}
+   echo must specify color: '-m color <color>'
+   exit
+fi
+
+## =================================================================
+echo create the ${color} marble vetting organization
+## =================================================================
+identity -n ${color}_vetting
+asset_type -q -f ${save}/${color}_type.pdo get_asset_type_identifier -s _type_id
+create -c vetting_organization_contract -s _vetting_organization -f ${save}/${color}_vetting.pdo
+vetting -q -w -f ${save}/${color}_vetting.pdo initialize -t ${_type_id}
+
+exit

--- a/contracts/wawaka/exchange/scripts/functional_test.psh
+++ b/contracts/wawaka/exchange/scripts/functional_test.psh
@@ -1,0 +1,235 @@
+#! /usr/bin/env pdo-shell
+
+## Copyright 2018 Intel Corporation
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+## Two shell variables are used:
+##    data -- the directory where the contract objects are stored
+##    path -- the directory where the PSH scripts are stored
+##
+## $ pdo-shell -s create.psh -m path <contract path>
+
+set -q --conditional -s data -v .
+set -q --conditional -s save -v .
+script -f ${path}/init.psh
+
+set -q -s _user1_key -i user1
+set -q -s _user2_key -i user2
+set -q -s _user3_key -i user3
+set -q -s _user4_key -i user4
+set -q -s _user5_key -i user5
+
+## =================================================================
+echo create the asset type for green marbles
+## =================================================================
+identity -n green_type
+create -c asset_type -s _asset_type -f ${save}/green_type.pdo
+asset_type -q -w -f ${save}/green_type.pdo initialize -n "green marbles" -d "green marble description" -l "http://"
+
+## -----------------------------------------------------------------
+echo basic asset type tests
+## -----------------------------------------------------------------
+asset_type -q -f ${save}/green_type.pdo describe
+asset_type -q -f ${save}/green_type.pdo get_asset_type_identifier -s _green_type_id_
+echo green marble type identifier is ${_green_type_id_}
+
+## =================================================================
+echo create and initialize the vetting organization for green marbles
+## =================================================================
+identity -n green_vetting
+create -c vetting-organization-contract -s _vetting_organization -f ${save}/green_vetting.pdo
+vetting -q -w -f ${save}/green_vetting.pdo initialize -t ${_green_type_id_}
+
+## -----------------------------------------------------------------
+echo basic vetting organization tests
+## -----------------------------------------------------------------
+vetting -q -f ${save}/green_vetting.pdo get_verifying_key -s _green_vetting_id_
+vetting -q -f ${save}/green_vetting.pdo get_asset_type_identifier -s _tmp_
+if --not -e ${_green_type_id_} ${_tmp_}
+   echo type identifier mismatch
+   exit -v -1
+fi
+
+## =================================================================
+echo create and initialize the green marble issuer
+## =================================================================
+identity -n green_issuer
+create -c issuer-contract -s _issuer -f ${save}/green_issuer.pdo
+issuer -q -f ${save}/green_issuer.pdo get_verifying_key -s _green_issuer_id_
+
+identity -n green_vetting
+vetting -q -f ${save}/green_vetting.pdo approve_issuer -i ${_green_issuer_id_}
+
+identity -n green_issuer
+vetting -q -f ${save}/green_vetting.pdo get_issuer_authority -i ${_green_issuer_id_} -s _authority_
+echo ISSUER AUTHORITY: ${_authority_}
+
+issuer -q -f ${save}/green_issuer.pdo initialize -a ${_authority_}
+
+## -----------------------------------------------------------------
+echo basic issuer tests
+## -----------------------------------------------------------------
+identity -n green_issuer
+issuer -q -f ${save}/green_issuer.pdo get_asset_type_identifier -s _tmp_
+if --not -e ${_green_type_id_} ${_tmp_}
+   echo type identifier mismatch
+   exit -v -1
+fi
+
+issuer -q -f ${save}/green_issuer.pdo get_authority -s _tmp_
+if --not -e ${_authority_} ${_tmp_}
+   echo authority does not match
+   exit -v -1
+fi
+
+issuer -q -w -f ${save}/green_issuer.pdo issue -o ${_user1_key} -c 51
+issuer -q -w -f ${save}/green_issuer.pdo issue -o ${_user2_key} -c 52
+issuer -q -w -f ${save}/green_issuer.pdo issue -o ${_user3_key} -c 53
+issuer -q -w -f ${save}/green_issuer.pdo issue -o ${_user4_key} -c 54
+issuer -q -w -f ${save}/green_issuer.pdo issue -o ${_user5_key} -c 55
+
+identity -n user1
+issuer -q -f ${save}/green_issuer.pdo get_balance -s _balance
+if --not -e ${_balance} 51
+   echo balance does not match, ${_balance}
+   exit -v -1
+fi
+echo user1 balance matched
+
+identity -n user2
+issuer -q -f ${save}/green_issuer.pdo get_balance -s _balance
+if --not -e ${_balance} 52
+   echo balance does not match, ${_balance}
+   exit -v -1
+fi
+echo user2 balance matched
+
+identity -n user3
+issuer -q -f ${save}/green_issuer.pdo get_balance -s _balance
+if --not -e ${_balance} 53
+   echo balance does not match, ${_balance}
+   exit -v -1
+fi
+echo user3 balance matched
+
+identity -n user4
+issuer -q -f ${save}/green_issuer.pdo get_balance -s _balance
+if --not -e ${_balance} 54
+   echo balance does not match, ${_balance}
+   exit -v -1
+fi
+echo user4 balance matched
+
+identity -n user5
+issuer -q -f ${save}/green_issuer.pdo get_balance -s _balance
+if --not -e ${_balance} 55
+   echo balance does not match, ${_balance}
+   exit -v -1
+fi
+echo user5 balance matched
+
+identity -n user1
+issuer -q -w -f ${save}/green_issuer.pdo transfer -n ${_user2_key} -c 50
+issuer -q -f ${save}/green_issuer.pdo get_balance -s _balance
+if --not -e ${_balance} 1
+   echo transfer source balance does not match, ${_balance} not 1
+   exit -v -1
+fi
+
+identity -n user2
+issuer -q -f ${save}/green_issuer.pdo get_balance -s _balance
+if --not -e ${_balance} 102
+   echo transfer destination balance does not match, ${_balance} not 102
+   exit -v -1
+fi
+
+echo transfer balance matched
+
+## =================================================================
+echo check escrow
+## =================================================================
+identity -n user1
+issuer -q -w -f ${save}/green_issuer.pdo escrow -a user2 -s attestation
+echo ESCROW ATTESTATION ${attestation}
+
+## still to test:
+## disburse
+## claim
+
+## =================================================================
+echo check cascading issuer authority
+## =================================================================
+
+## This test cascades issuing authority through several levels
+## of authority. The authority and attestation should chain from
+## the green vetting type through green, green1, green2 and ultimately
+## green3 issuers
+
+## ---------- Green 1 ----------
+
+identity -n green1_issuer
+create -c issuer-contract -s _issuer -f ${save}/green1_issuer.pdo
+issuer -q -f ${save}/green1_issuer.pdo get_verifying_key -s _green1_issuer_id_
+
+identity -n green_issuer
+vetting -q -f ${save}/green_issuer.pdo approve_issuer -i ${_green1_issuer_id_}
+
+identity -n green1_issuer
+issuer -q -f ${save}/green_issuer.pdo get_issuer_authority -i ${_green1_issuer_id_} -s _green1_authority_
+echo GREEN1 ISSUER AUTHORITY: ${_green1_authority_}
+
+issuer -q -f ${save}/green1_issuer.pdo initialize -a ${_green1_authority_}
+
+## ---------- Green 2 ----------
+
+identity -n green2_issuer
+create -c issuer-contract -s _issuer -f ${save}/green2_issuer.pdo
+issuer -q -f ${save}/green2_issuer.pdo get_verifying_key -s _green2_issuer_id_
+
+identity -n green1_issuer
+vetting -q -f ${save}/green1_issuer.pdo approve_issuer -i ${_green2_issuer_id_}
+
+identity -n green2_issuer
+issuer -q -f ${save}/green1_issuer.pdo get_issuer_authority -i ${_green2_issuer_id_} -s _green2_authority_
+echo GREEN2 ISSUER AUTHORITY: ${_green2_authority_}
+
+issuer -q -f ${save}/green2_issuer.pdo initialize -a ${_green2_authority_}
+
+## ---------- Green 3 ----------
+
+identity -n green3_issuer
+create -c issuer-contract -s _issuer -f ${save}/green3_issuer.pdo
+issuer -q -f ${save}/green3_issuer.pdo get_verifying_key -s _green3_issuer_id_
+
+identity -n green2_issuer
+vetting -q -f ${save}/green2_issuer.pdo approve_issuer -i ${_green3_issuer_id_}
+
+identity -n green3_issuer
+issuer -q -f ${save}/green2_issuer.pdo get_issuer_authority -i ${_green3_issuer_id_} -s _green3_authority_
+echo GREEN3 ISSUER AUTHORITY: ${_green3_authority_}
+
+issuer -q -f ${save}/green3_issuer.pdo initialize -a ${_green3_authority_}
+
+## ---------- make sure we can issue assets ----------
+issuer -q -w -f ${save}/green3_issuer.pdo issue -o ${_user1_key} -c 51
+issuer -q -w -f ${save}/green3_issuer.pdo issue -o ${_user2_key} -c 52
+issuer -q -w -f ${save}/green3_issuer.pdo issue -o ${_user3_key} -c 53
+issuer -q -w -f ${save}/green3_issuer.pdo issue -o ${_user4_key} -c 54
+issuer -q -w -f ${save}/green3_issuer.pdo issue -o ${_user5_key} -c 55
+
+identity -n user1
+issuer -q -w -f ${save}/green3_issuer.pdo escrow -a user2 -s attestation
+echo escrow attestation for green3 issuer ${attestation}
+
+exit

--- a/contracts/wawaka/exchange/scripts/init.psh
+++ b/contracts/wawaka/exchange/scripts/init.psh
@@ -1,0 +1,28 @@
+#! /usr/bin/env pdo-shell
+
+## Copyright 2018 Intel Corporation
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+load_plugin -f plugins/asset_type.py
+load_plugin -f plugins/vetting.py
+load_plugin -f plugins/issuer.py
+## load_plugin -c exchange
+## load_plugin -c auction
+
+## load the eservice database
+set -q --conditional -s dbfile -v ${data}/eservice-db.json
+eservice_db load --database ${dbfile}
+
+## load the eservice and pservice groups for the site
+script -f ${home}/etc/site.psh

--- a/contracts/wawaka/exchange/scripts/initialize_issuer.psh
+++ b/contracts/wawaka/exchange/scripts/initialize_issuer.psh
@@ -1,0 +1,44 @@
+#! /usr/bin/env pdo-shell
+
+## Copyright 2018 Intel Corporation
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+set -q --conditional -s data -v .
+set -q --conditional -s save -v .
+script -f ${path}/init.psh
+
+if --null ${color}
+   echo must specify color: '-m color <color>'
+   exit
+fi
+
+set -q --conditional -s issuer -v ${color}_issuer
+set -q --conditional -s issuer_contract -v ${save}/${color}_issuer.pdo
+set -q --conditional -s type_contract -v ${save}/${color}_type.pdo
+set -q --conditional -s vetting_contract -v ${save}/${color}_vetting.pdo
+
+## =================================================================
+echo initialize ${color} marble issuer with vetting authority
+## =================================================================
+identity -n ${issuer}
+
+## get all of the necessary values used to construct the authorization
+asset_type -q -f ${type_contract} get_asset_type_identifier -s _type_id
+issuer -q -f ${issuer_contract} get_verifying_key -s _issuer_contract_key
+vetting -q -f ${vetting_contract} get_issuer_authority -i ${_issuer_contract_key} -s _auth
+
+## record the authorization provided by the vetting organization
+issuer -q -w -f ${issuer_contract} initialize -a ${_auth}
+
+exit

--- a/contracts/wawaka/exchange/scripts/issue.psh
+++ b/contracts/wawaka/exchange/scripts/issue.psh
@@ -1,0 +1,45 @@
+#! /usr/bin/env pdo-shell
+
+## Copyright 2018 Intel Corporation
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+set -q --conditional -s data -v .
+set -q --conditional -s save -v .
+script -f ${path}/init.psh
+
+if --null ${color}
+   echo must specify color: '-m color <color>'
+   exit
+fi
+
+if --null ${count}
+   echo must specify count: '-m count <count>'
+   exit
+fi
+
+if --null ${issuee}
+   echo must specify identity for issuance: '-m issuee <identity>'
+   exit
+fi
+
+set -q --conditional -s issuer -v ${color}_issuer
+
+## =================================================================
+echo issue ${count} ${color} marbles to ${issuee}
+## =================================================================
+identity -n ${issuer}
+set -q -s _issuee_key -i ${issuee}
+issuer -q -w -f ${save}/${color}_issuer.pdo issue -o ${_issuee_key} -c ${count}
+
+exit

--- a/contracts/wawaka/exchange/scripts/run-tests.sh
+++ b/contracts/wawaka/exchange/scripts/run-tests.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+SCRIPTDIR="$(dirname $(readlink --canonicalize ${BASH_SOURCE}))"
+SRCDIR="${PDO_SOURCE_ROOT:-$(realpath ${SCRIPTDIR}/../../../..)}"
+EXCHANGE_ROOT="$(realpath ${SCRIPTDIR}/..)"
+
+source ${SRCDIR}/bin/lib/common.sh
+
+PY3_VERSION=$(python --version | sed 's/Python 3\.\([0-9]\).*/\1/')
+if [[ $PY3_VERSION -lt 5 ]]; then
+    die activate python3 first
+fi
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+KEYGEN=${SRCDIR}/build/__tools__/make-keys
+if [ ! -f ${PDO_HOME}/keys/red_type_private.pem ]; then
+    yell create keys for the contracts
+    for color in red green blue white; do
+        ${KEYGEN} --keyfile ${PDO_HOME}/keys/${color}_type --format pem
+        ${KEYGEN} --keyfile ${PDO_HOME}/keys/${color}_vetting --format pem
+        ${KEYGEN} --keyfile ${PDO_HOME}/keys/${color}_issuer --format pem
+    done
+
+    for color in green1 green2 green3; do
+        ${KEYGEN} --keyfile ${PDO_HOME}/keys/${color}_issuer --format pem
+    done
+
+fi
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+: "${PDO_LEDGER_URL?Missing environment variable PDO_LEDGER_URL}"
+
+if [ ! -f ${PDO_HOME}/data/eservice-db.json ]; then
+    ${SCRIPTDIR}/create_eservice_db.psh
+fi
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+cd "${EXCHANGE_ROOT}"
+
+try scripts/functional_test.psh --loglevel info --ledger ${PDO_LEDGER_URL}

--- a/contracts/wawaka/exchange/scripts/setup.sh
+++ b/contracts/wawaka/exchange/scripts/setup.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SCRIPTDIR="$(dirname $(readlink --canonicalize ${BASH_SOURCE}))"
+SRCDIR="${PDO_SOURCE_ROOT:-$(realpath ${SCRIPTDIR}/../../../..)}"
+EXCHANGE_ROOT="$(realpath ${SCRIPTDIR}/..)"
+
+source ${SRCDIR}/bin/lib/common.sh
+
+PY3_VERSION=$(python --version | sed 's/Python 3\.\([0-9]\).*/\1/')
+if [[ $PY3_VERSION -lt 5 ]]; then
+    die activate python3 first
+fi
+
+KEYGEN=${SRCDIR}/build/__tools__/make-keys
+if [ ! -f ${PDO_HOME}/keys/red_type_private.pem ]; then
+    yell create keys for the contracts
+    for color in red green blue ; do
+        ${KEYGEN} --keyfile ${PDO_HOME}/keys/${color}_type --format pem
+        ${KEYGEN} --keyfile ${PDO_HOME}/keys/${color}_vetting --format pem
+        ${KEYGEN} --keyfile ${PDO_HOME}/keys/${color}_issuer --format pem
+    done
+fi
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+: "${PDO_LEDGER_URL?Missing environment variable PDO_LEDGER_URL}"
+
+if [ ! -f ${PDO_HOME}/data/eservice-db.json ]; then
+    scripts/create_eservice_db.psh
+fi
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
+cd "${EXCHANGE_ROOT}"
+
+yell create the green issuer contracts
+try scripts/create_type.psh --loglevel warn --ledger $PDO_LEDGER_URL -m color green
+try scripts/create_vetting.psh --loglevel warn --ledger $PDO_LEDGER_URL -m color green
+try scripts/create_issuer.psh --loglevel warn --ledger $PDO_LEDGER_URL -m color green
+try scripts/approve_issuer.psh --loglevel warn --ledger $PDO_LEDGER_URL -m color green
+try scripts/initialize_issuer.psh --loglevel warn --ledger $PDO_LEDGER_URL -m color green
+
+yell create the red issuer contracts
+try scripts/create_type.psh --loglevel warn --ledger $PDO_LEDGER_URL -m color red
+try scripts/create_vetting.psh --loglevel warn --ledger $PDO_LEDGER_URL -m color red
+try scripts/create_issuer.psh --loglevel warn --ledger $PDO_LEDGER_URL -m color red
+try scripts/approve_issuer.psh --loglevel warn --ledger $PDO_LEDGER_URL -m color red
+try scripts/initialize_issuer.psh --loglevel warn --ledger $PDO_LEDGER_URL -m color red
+
+yell issue green marbles
+for p in $(seq 1 5); do
+    scripts/issue.psh --loglevel warn --ledger $PDO_LEDGER_URL \
+                      -m color green -m issuee user$p -m count $(($p * 10))
+done
+
+yell issue red marbles
+for p in $(seq 6 10); do
+    scripts/issue.psh --loglevel warn --ledger $PDO_LEDGER_URL \
+                      -m color red -m issuee user$p -m count $(($p * 10))
+done


### PR DESCRIPTION
This commit adds the first set of contracts
for the exchange family of contracts. While there are
some changes, the documentation for the exchange contract
family for gypsy is still fundamentally correct. The specific
apis, however, have changed and are documented in the doc
directory.

A test script is available in the scripts directory. Run
"run-tests.sh" after you have installed the contracts.

Although the issuer method claim and disburse are fully
implemented, they have not be tested. Testing will wait
until the exchange and auction contracts are complete.

Signed-off-by: Mic Bowman <mic.bowman@intel.com>