### PR TITLE
Upgrade to WAMR release WAMR-09-29-2020

### DIFF
--- a/common/interpreter/wawaka_wasm/README.md
+++ b/common/interpreter/wawaka_wasm/README.md
@@ -48,14 +48,14 @@ source ./emsdk_env.sh
 If wawaka is configured as the contract interpreter, the libraries implementing the WASM interpreter
 will be built for use with Intel SGX. The source for the WAMR interpreter is
 included as a submodule in the interpreters/ folder, and will
-always point to the latest tagged commit that we have validated: `WAMR-07-10-2020`.
+always point to the latest tagged commit that we have validated: `WAMR-09-29-2020`.
 If the PDO parent repo was not cloned with the `--recurse-submodules` flag,
 you will have to explictly pull the submodule source.
 
 ```
 cd ${PDO_SOURCE_ROOT}/interpreters/wasm-micro-runtime
 git submodule update --init
-git checkout WAMR-07-10-2020 # optional
+git checkout WAMR-09-29-2020 # optional
 ```
 
 The WAMR API is built during the Wawaka build, so no additional

--- a/common/interpreter/wawaka_wasm/WawakaInterpreter.cpp
+++ b/common/interpreter/wawaka_wasm/WawakaInterpreter.cpp
@@ -93,7 +93,7 @@ void WawakaInterpreter::parse_response_string(
 {
     // Convert the wasm address for the result string into an
     // address in the native code
-    int32 response_app_beg, response_app_end;
+    uint32 response_app_beg, response_app_end;
 
     pe::ThrowIf<pe::RuntimeError>(
         response_app == 0,

--- a/docker/Dockerfile.pdo-build
+++ b/docker/Dockerfile.pdo-build
@@ -24,7 +24,7 @@
 #  - pdo repo branch to use:			PDO_REPO_BRANCH (default: master)
 #  - build in debug mode:			PDO_DEBUG_BUILD (default: 0)
 #  - contract interpreter (gipsy or wawaka):	PDO_INTERPRETER (default: gipsy)
-#  - wamr version:		                WAMR    (default: WAMR-07-10-2020)
+#  - wamr version:		                WAMR    (default: WAMR-09-29-2020)
 
 # Build:
 #   $ docker build -f docker/Dockerfile.pdo-build -t pdo-build docker
@@ -100,7 +100,7 @@ ENV PDO_INTERPRETER=${PDO_INTERPRETER}
 
 # - web-assembly/wasm/wawaka
 #   - Configure WAMR source
-ARG WAMR=WAMR-07-10-2020
+ARG WAMR=WAMR-09-29-2020
 RUN cd /project/pdo/src/private-data-objects/interpreters/wasm-micro-runtime \
  && git checkout ${WAMR}\
  && echo "export WASM_SRC=$(pwd)" >> /etc/profile.d/pdo.sh

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -118,7 +118,7 @@ the contract enclave.
 `WASM_SRC` points to the installation of the wasm-micro-runtime. This
 is used to build the WASM interpreter for the wawaka contract interpreter.
 The git submodule points to the latest tagged commit of [WAMR](https://github.com/bytecodealliance/wasm-micro-runtime) we have validated:
-`WAMR-07-10-2020`.
+`WAMR-09-29-2020`.
 
 <!-- -------------------------------------------------- -->
 ### `WASM_MEM_CONFIG`


### PR DESCRIPTION
This PR brings Wawaka to the latest WAMR-09-29-2020 release, covering the previous WAMR-09-08-2020 tagged release as well. In these two releases, the WAMR team implemented additional post-MVP WASM features including support for libpthread and WASI (WebAssembly System Interface) in SGX, as well as several bugfixes. 

**Notes:**
- The `wasm_runtime_get_app_addr_range` API was changed since our last WAMR upgrade to use `uint32` instead of `int32` for the WASM address ranges.
- This PR still uses the latest-fastcomp emscripten backend.