### PR TITLE
Fix VerifySecrets ecall where we accidentally zero-padd short signatures

### DIFF
--- a/eservice/lib/libpdo_enclave/contract.edl
+++ b/eservice/lib/libpdo_enclave/contract.edl
@@ -43,8 +43,9 @@ enclave {
             [in, string] const char* inSerializedSecretList,
             [out, size=inEncryptedContractKeyLength] uint8_t* outEncryptedContractKey,
             size_t inEncryptedContractKeyLength,
-            [out, size=inEncryptedContractKeySignatureLength] uint8_t* outEncryptedContractKeySignature,
-            size_t inEncryptedContractKeySignatureLength
+            [out, size=inEncryptedContractKeySignatureMaxLength] uint8_t* outEncryptedContractKeySignature,
+            size_t inEncryptedContractKeySignatureMaxLength,
+            [out] size_t* outEncryptedContractKeySignatureActualLength
             );
 
         // inEncryptedSessionKey is binary encoding of the encrypted session key

--- a/eservice/lib/libpdo_enclave/contract_enclave.cpp
+++ b/eservice/lib/libpdo_enclave/contract_enclave.cpp
@@ -146,7 +146,8 @@ pdo_err_t ecall_VerifySecrets(const uint8_t* inSealedSignupData,
     uint8_t* outEncryptedContractKey,
     size_t inEncryptedContractKeyLength,
     uint8_t* outEncryptedContractKeySignature,
-    size_t inEncryptedContractKeySignatureLength)
+    size_t inEncryptedContractKeySignatureMaxLength,
+    size_t* outEncryptedContractKeySignatureActualLength)
 {
     pdo_err_t result = PDO_SUCCESS;
 
@@ -157,7 +158,8 @@ pdo_err_t ecall_VerifySecrets(const uint8_t* inSealedSignupData,
         pdo::error::ThrowIfNull(inContractCreatorId, "Contract creator ID pointer is NULL");
         pdo::error::ThrowIfNull(inSerializedSecretList, "Secret list pointer is NULL");
         pdo::error::ThrowIfNull(outEncryptedContractKey, "Contract key pointer is NULL");
-        pdo::error::ThrowIfNull(outEncryptedContractKeySignature, "Contract key signature is NULL");
+        pdo::error::ThrowIfNull(outEncryptedContractKeySignature, "Contract key signature pointer is NULL");
+        pdo::error::ThrowIfNull(outEncryptedContractKeySignatureActualLength, "Contract key signature length pointer is NULL");
 
         pdo_err_t presult;
 
@@ -198,12 +200,13 @@ pdo_err_t ecall_VerifySecrets(const uint8_t* inSealedSignupData,
 
         const ByteArray signature = enclaveData.sign_message(message);
         pdo::error::ThrowIf<pdo::error::ValueError>(
-            inEncryptedContractKeySignatureLength < signature.size(),
+            inEncryptedContractKeySignatureMaxLength < signature.size(),
             "Contract key signature is too short");
 
-        Zero(outEncryptedContractKeySignature, inEncryptedContractKeySignatureLength);
-        memcpy_s(outEncryptedContractKeySignature, inEncryptedContractKeySignatureLength,
+        Zero(outEncryptedContractKeySignature, inEncryptedContractKeySignatureMaxLength);
+        memcpy_s(outEncryptedContractKeySignature, inEncryptedContractKeySignatureMaxLength,
             signature.data(), signature.size());
+        *outEncryptedContractKeySignatureActualLength=signature.size();
     }
     catch (pdo::error::Error& e)
     {

--- a/eservice/lib/libpdo_enclave/contract_enclave.h
+++ b/eservice/lib/libpdo_enclave/contract_enclave.h
@@ -41,7 +41,8 @@ extern pdo_err_t ecall_VerifySecrets(const uint8_t* inSealedSignupData,
     char* outEncryptedContractKey,
     size_t inEncryptedContractKeyLength,
     char* outEncryptedContractKeySignature,
-    size_t inEncryptedContractKeySignatureLength);
+    size_t inEncryptedContractKeySignatureMaxLength,
+    size_t* outEncryptedContractKeySignatureActualLength);
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 extern pdo_err_t ecall_InitializeContract(const uint8_t* inSealedSignupData,

--- a/eservice/pdo/eservice/enclave/enclave/base.cpp
+++ b/eservice/pdo/eservice/enclave/enclave/base.cpp
@@ -180,7 +180,7 @@ size_t pdo::enclave_api::base::GetEnclaveQuoteSize()
 } // pdo::enclave_api::base::GetEnclaveQuoteSize
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-size_t pdo::enclave_api::base::GetSignatureSize()
+size_t pdo::enclave_api::base::GetSignatureMaxSize()
 {
     // this is the size of the byte array required for the signature
     // fixed constant for now until there is one we can get from the

--- a/eservice/pdo/eservice/enclave/enclave/base.h
+++ b/eservice/pdo/eservice/enclave/enclave/base.h
@@ -83,7 +83,7 @@ namespace pdo
               in by enclave.
             */
 
-            size_t GetSignatureSize();
+            size_t GetSignatureMaxSize();
             size_t GetEnclaveQuoteSize();
 
             /*

--- a/pservice/pdo/pservice/enclave/enclave/base.cpp
+++ b/pservice/pdo/pservice/enclave/enclave/base.cpp
@@ -122,7 +122,7 @@ size_t pdo::enclave_api::base::GetEnclaveQuoteSize()
 } // pdo::enclave_api::base::GetEnclaveQuoteSize
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-size_t pdo::enclave_api::base::GetSignatureSize()
+size_t pdo::enclave_api::base::GetSignatureMaxSize()
 {
     // this is the size of the byte array required for the signature
     // fixed constant for now until there is one we can get from the

--- a/pservice/pdo/pservice/enclave/enclave/base.h
+++ b/pservice/pdo/pservice/enclave/enclave/base.h
@@ -68,7 +68,7 @@ namespace pdo
               in by enclave.
             */
 
-            size_t GetSignatureSize();
+            size_t GetSignatureMaxSize();
             size_t GetEnclaveQuoteSize();
 
             /*


### PR DESCRIPTION
Subject should say it all.  Hopefully that fixes the random problems Prakash sees with the CCF PR ....