### PR TITLE
Bump sgx to 2.12 for docker & enable pdo-dev ubuntu 20.04

### DIFF
--- a/docker/Dockerfile.pdo-dev
+++ b/docker/Dockerfile.pdo-dev
@@ -19,9 +19,9 @@
 #  Configuration (build) paramaters
 #  - ubuntu version to use: 	  UBUNTU_VERSION (default: 18.04)
 #  - ubuntu name to use: 	  UBUNTU_NAME (default: bionic)
-#  - sgx sdk/psw version: 	  SGX (default: 2.10)
+#  - sgx sdk/psw version: 	  SGX (default: 2.12)
 #  - openssl version: 		  OPENSSL (default: 1.1.1g)
-#  - sgxssl version: 		  SGXSSL  (default: 2.10_1.1.1g)
+#  - sgxssl version: 		  SGXSSL  (default: 2.11_1.1.1g)
 #  - additional apt packages:	  ADD_APT_PKGS (default: )
 
 # Build:
@@ -63,7 +63,7 @@ FROM ubuntu:${UBUNTU_VERSION}
 ARG UBUNTU_VERSION
 ARG UBUNTU_NAME
 
-ARG SGX=2.10
+ARG SGX=2.12
 ARG OPENSSL=1.1.1g
 ARG SGXSSL=2.10_1.1.1g
 
@@ -73,7 +73,7 @@ ARG ADD_APT_PKGS=
 # TODO(xenial): we need to manually install protobuf 3 as xenial has v2
 # Note: ocamlbuild is required by PREREQ but does not exist for xenial. However, the relevant componets are part of 'ocaml' package, later ubuntu split up that package ...
 RUN apt-get update \
- && DEBIAN_FRONTEND="noninteractive" \
+ && DEBIAN_FRONTEND="noninteractive" TZ="UTC" \
   # above makes sure any install of 'tzdata' or alike (as e.g., pulled in via ubuntu 20.04) does not hang ...
   apt-get install -y -q\
     autoconf \
@@ -169,9 +169,10 @@ RUN SGX_SDK_BIN_REPO=https://download.01.org/intel-sgx/sgx-linux/${SGX}/distro/u
 
 # LVI mitigations, needed to compile sgxssl, requires a
 #   recent version of binutils (>= 2.32). Ubuntu 18.04 only
-#   has 2.30 but Intel ships binary distro for 2.32.51.20190719
-RUN [ "$UBUNTU_VERSION" = "18.04" ] \
-  && SGX_SDK_BINUTILS_REPO=https://download.01.org/intel-sgx/sgx-linux/${SGX} \
+#   has 2.30 but Intel ships binary distro for 2.32.51.20190719.
+#   As sgx ships tools also for 20.04, use these for simplicity and uniformity reason
+RUN \
+     SGX_SDK_BINUTILS_REPO=https://download.01.org/intel-sgx/sgx-linux/${SGX} \
   && SGX_SDK_BINUTILS_FILE=$(cd /tmp; wget --spider --recursive --level=1 --no-parent ${SGX_SDK_BINUTILS_REPO} 2>&1 | perl  -ne 'if (m|'${SGX_SDK_BINUTILS_REPO}'/(as.ld.objdump.*)|) { print "$1\n"; }') \
   && wget -q ${SGX_SDK_BINUTILS_REPO}/${SGX_SDK_BINUTILS_FILE} \
   && mkdir sgxsdk.extras \


### PR DESCRIPTION
As `apt update` bumps the sgx debian packages (not-so)auto-magically to latest version, i've tested PDO v2.12 and with a few caveat it still works.  As part of that i bumped the version also in the pdo-dev docker image and also enabled ubuntu 20.04.  I didn't update the docu, though, as it still does work with the old version and there is nothing short of ubuntu 20.04 support (which we currently do not support in PDO) according to the sgxsdk release notes ...

Now the caveats:
- `apt update` can result in a broken upgrade -- intel definitely doesn't have the strongest QA pipeline for these packages, every second upgrade breaks ... but a simple `apt --fix-broken install` does provide remedy
- it seems on FLC NUCs you now need the dcap driver (1.36.2), the old-style driver 2.11) does not seem to work anymore.  Note, though, that [download site](https://download.01.org/intel-sgx/sgx-linux/2.12/distro/ubuntu18.04-server/) provides both.
- as i was at it, i also tried to bump sgxssl from current `lin2.10_1.1.1.g` to latest `lin2.11_1.1.1.g`. Alas, that fails due to some not-really-documented changes they have done to pthreads in [this commit](https://github.com/intel/intel-sgx-ssl/commit/8c0866516ad6eb5f0bd47d15eced0d8c35723f2a) which makes `common/crypto` fail to build with 
```[ 90%] Linking CXX shared library ../../../libTestEnclave.so /opt/intel/sgxsdk.extras/external/toolset/ubuntu18.04/ld: /opt/intel/sgxssl/lib64/libsgx_tsgxssl_crypto.a(threads_pthread.o): in function `CRYPTO_THREAD_lock_new':
threads_pthread.c:(.text+0x45): undefined reference to `pthread_rwlock_init'```
  these functions were previously provided but now are removed. Not sure how exactly we pull them in. Didn't investigate much on how to resolve as i guess we do not have a need to upgrade and i have never looked at how we make use of pthreads; just a heads-up in case of anybody would have been tempted to try.
- lastly, the docker-image sets up properly with ubuntu 20.04, and even builds most of pdo until eventually fails with below. Didn't see a quick fix and i think there might be a few follow-up issues also on how we then test in docker-compose with sawtooth. So just a heads-up (e.g., if you need a sgx development environment based on 20.04, the dockerfile could be useful on its own).
```make[4]: Leaving directory '/project/pdo/src/private-data-objects/contracts/cdi/build'
make[3]: Leaving directory '/project/pdo/src/private-data-objects/contracts/cdi'
make[2]: Leaving directory '/project/pdo/src/private-data-objects/contracts'
 build.sh: operation failed: make all -j4
make[1]: *** [Makefile:121: build] Error 111
make[1]: Leaving directory '/project/pdo/src/private-data-objects/build'
make: Leaving directory '/project/pdo/src/private-data-objects/build'
make: *** [Makefile:124: verified-build] Error 2
Service 'pdo-build' failed to build: The command '/bin/sh -c echo "export PDO_SOURCE_ROOT=/project/pdo/src/private-data-objects" >> /etc/profile.d/pdo.sh  && . /etc/profile.d/pdo.sh  && echo "export SGX_MODE=${SGX_MODE}" >> /etc/profile.d/pdo.sh  && `/project/pdo/src/private-data-objects/build/common-config.sh -e`   && env | grep PDO | egrep -v 'PDO_ENCLAVE_CODE_SIGN_PEM|PDO_INSTALL_ROOT|PDO_HOME' | sed 's/^PDO/export PDO/g' >> /etc/profile.d/pdo.sh  && make -C /project/pdo/src/private-data-objects/build/ NO_SGX_RUN_DURING_BUILD=true  && echo '. /project/pdo/build/bin/activate' >> /etc/profile.d/pdo.sh  && . /project/pdo/build/bin/activate  && cd /project/pdo/src/private-data-objects  && sawtooth/bin/build_sawtooth_proto  && cd python  && python3 setup.py build_ext  && python3 setup.py install  && cd ../sawtooth  && python3 setup.py install  && cd /project/pdo/src/private-data-objects/eservice/  && sed -i 's/python /python3 /g' Makefile  && make  && make install  && python3 setup.py install  && cd ..  && sawtooth/bin/build_sawtooth_proto  && cd python/  && python3 setup.py install' returned a non-zero code: 2
Makefile:63: recipe for target 'pdo-composition' failed
make: *** [pdo-composition] Error 1
make: Leaving directory '/home/msteiner/src/projects/intel/PoET-et-al/pdo/src/PrivateDataObjects.git/docker'```
