### PR TITLE
experimental feature to allow an external kv store to be used by a contract object

### DIFF
--- a/build/tests/wawaka/interpreter-test.json
+++ b/build/tests/wawaka/interpreter-test.json
@@ -1,5 +1,7 @@
 [
     { "MethodName" : "ecdsa_test", "KeywordParameters": { "message" : "hello there" } },
     { "MethodName" : "aes_test", "KeywordParameters": { "message" : "hello there" } },
-    { "MethodName" : "rsa_test"}
+    { "MethodName" : "rsa_test"},
+    { "MethodName" : "kv_test_set", "expected" : "[tT]rue"},
+    { "MethodName" : "kv_test_get", "expected" : "1"}
 ]

--- a/common/interpreter/wawaka_wasm/WasmExtensions.cpp
+++ b/common/interpreter/wawaka_wasm/WasmExtensions.cpp
@@ -181,8 +181,17 @@ static NativeSymbol native_symbols[] =
     EXPORT_WASM_API_WITH_SIG2(random_identifier,"(ii)i"),
 
     /* Persistent store operations from WasmStateExtensions.h */
+#if 0
     EXPORT_WASM_API_WITH_SIG2(key_value_set,"(*~*~)i"),
     EXPORT_WASM_API_WITH_SIG2(key_value_get,"(*~ii)i"),
+#endif
+    EXPORT_WASM_API_WITH_SIG2(key_value_set,"(i*~*~)i"),
+    EXPORT_WASM_API_WITH_SIG2(key_value_get,"(i*~ii)i"),
+
+    EXPORT_WASM_API_WITH_SIG2(key_value_create,"(*~)i"),
+    EXPORT_WASM_API_WITH_SIG2(key_value_open,"(*~*~)i"),
+    EXPORT_WASM_API_WITH_SIG2(key_value_finalize,"(iii)i"),
+
 
     /* Utility functions */
     EXPORT_WASM_API_WITH_SIG2(contract_log, "(i$)i"),

--- a/common/interpreter/wawaka_wasm/WasmExtensions.h
+++ b/common/interpreter/wawaka_wasm/WasmExtensions.h
@@ -42,14 +42,14 @@ bool key_value_get(
     size_t* val_length_pointer);
 
 int key_value_create(
-    const uint8_t* key_buffer,
-    const size_t key_buffer_length);
+    const uint8_t* aes_key_buffer,
+    const size_t aes_key_buffer_length);
 
 int key_value_open(
     const uint8_t* id_hash_buffer,
     const size_t id_hash_buffer_length,
-    const uint8_t* key_buffer,
-    const size_t key_buffer_length);
+    const uint8_t* aes_key_buffer,
+    const size_t aes_key_buffer_length);
 
 bool key_value_finalize(
     const int kv_store_handle,

--- a/common/interpreter/wawaka_wasm/WasmExtensions.h
+++ b/common/interpreter/wawaka_wasm/WasmExtensions.h
@@ -28,16 +28,33 @@ extern "C" {
 
 // From WasmStateExtensions
 bool key_value_set(
+    const size_t handle,
     const uint8_t* key_buffer,
     const size_t key_buffer_length,
     const uint8_t* val_buffer,
     const size_t val_buffer_length);
 
 bool key_value_get(
+    const size_t handle,
     const uint8_t* key_buffer,
     const size_t key_buffer_length,
     uint8_t** val_buffer_pointer,
     size_t* val_length_pointer);
+
+int key_value_create(
+    const uint8_t* key_buffer,
+    const size_t key_buffer_length);
+
+int key_value_open(
+    const uint8_t* id_hash_buffer,
+    const size_t id_hash_buffer_length,
+    const uint8_t* key_buffer,
+    const size_t key_buffer_length);
+
+bool key_value_finalize(
+    const int kv_store_handle,
+    uint8_t** id_hash_buffer_pointer,
+    size_t* id_hash_length_pointer);
 
 // From WasmCryptoExtensions
 bool b64_encode(

--- a/common/interpreter/wawaka_wasm/WasmStateExtensions.cpp
+++ b/common/interpreter/wawaka_wasm/WasmStateExtensions.cpp
@@ -22,6 +22,7 @@
 
 #include "basic_kv.h"
 #include "error.h"
+#include "interpreter_kv.h"
 #include "log.h"
 #include "pdo_error.h"
 #include "types.h"
@@ -31,6 +32,7 @@
 #include <ctype.h>
 #include <math.h>
 
+#include "WawakaInterpreter.h"
 #include "WasmStateExtensions.h"
 #include "WasmUtil.h"
 
@@ -42,6 +44,7 @@ namespace pstate = pdo::state;
  * ----------------------------------------------------------------- */
 extern "C" bool key_value_set_wrapper(
     wasm_exec_env_t exec_env,
+    const int32 kv_store_handle,
     const uint8_t* key_buffer,
     const int32 key_buffer_length, // size_t
     const uint8_t* val_buffer,
@@ -49,10 +52,17 @@ extern "C" bool key_value_set_wrapper(
 {
     wasm_module_inst_t module_inst = wasm_runtime_get_module_inst(exec_env);
     try {
-        pstate::Basic_KV_Plus* state = (pstate::Basic_KV_Plus*)wasm_runtime_get_custom_data(module_inst);
+        if (kv_store_handle < 0 || kv_store_handle >= KV_STORE_POOL_MAX_SIZE)
+        {
+            SAFE_LOG(PDO_LOG_ERROR, "invalid state handle");
+            return false;
+        }
+
+        pstate::Basic_KV_Plus** kv_store_pool = (pstate::Basic_KV_Plus**)wasm_runtime_get_custom_data(module_inst);
+        pstate::Basic_KV_Plus* state = kv_store_pool[kv_store_handle];
         if (state == NULL)
         {
-            SAFE_LOG(PDO_LOG_ERROR, "state was not initialized");
+            SAFE_LOG(PDO_LOG_ERROR, "state was not initialized (set)");
             return false;
         }
 
@@ -83,6 +93,7 @@ extern "C" bool key_value_set_wrapper(
  * ----------------------------------------------------------------- */
 extern "C" bool key_value_get_wrapper(
     wasm_exec_env_t exec_env,
+    const int32 kv_store_handle,
     const uint8_t* key_buffer,
     const int32 key_buffer_length, // size_t
     int32 val_buffer_pointer_offset, // uint8_t**
@@ -90,10 +101,17 @@ extern "C" bool key_value_get_wrapper(
 {
     wasm_module_inst_t module_inst = wasm_runtime_get_module_inst(exec_env);
     try {
-        pstate::Basic_KV_Plus* state = (pstate::Basic_KV_Plus*)wasm_runtime_get_custom_data(module_inst);
+        if (kv_store_handle < 0 || kv_store_handle >= KV_STORE_POOL_MAX_SIZE)
+        {
+            SAFE_LOG(PDO_LOG_ERROR, "invalid state handle");
+            return false;
+        }
+
+        pstate::Basic_KV_Plus** kv_store_pool = (pstate::Basic_KV_Plus**)wasm_runtime_get_custom_data(module_inst);
+        pstate::Basic_KV_Plus* state = kv_store_pool[kv_store_handle];
         if (state == NULL)
         {
-            SAFE_LOG(PDO_LOG_ERROR, "state was not initialized");
+            SAFE_LOG(PDO_LOG_ERROR, "state was not initialized (get)");
             return false;
         }
 
@@ -112,6 +130,173 @@ extern "C" bool key_value_get_wrapper(
             return false;
 
         return true;
+    }
+    catch (pdo::error::Error& e) {
+        SAFE_LOG(PDO_LOG_ERROR, "failure in %s; %s", __FUNCTION__, e.what());
+        return false;
+    }
+    catch (...) {
+        SAFE_LOG(PDO_LOG_ERROR, "unexpected failure in %s", __FUNCTION__);
+        return false;
+    }
+}
+
+/* ----------------------------------------------------------------- *
+ * NAME: _key_value_create_wrapper
+ * ----------------------------------------------------------------- */
+extern "C" int32 key_value_create_wrapper(
+    wasm_exec_env_t exec_env,
+    const uint8_t* key_buffer,
+    const int32 key_buffer_length)
+{
+    wasm_module_inst_t module_inst = wasm_runtime_get_module_inst(exec_env);
+    try {
+        if (key_buffer == NULL || key_buffer_length != 16)
+        {
+            SAFE_LOG(PDO_LOG_ERROR, "invalid encryption key; %d", key_buffer_length);
+            return false;
+        }
+
+        ByteArray ba_encryption_key(key_buffer, key_buffer + key_buffer_length);
+
+        // find an empty slot we can use for the kv store
+        pstate::Basic_KV_Plus** kv_store_pool = (pstate::Basic_KV_Plus**)wasm_runtime_get_custom_data(module_inst);
+
+        size_t kv_store_handle;
+        for (kv_store_handle = 1; kv_store_handle < KV_STORE_POOL_MAX_SIZE; kv_store_handle++)
+            if (kv_store_pool[kv_store_handle] == NULL) break;
+
+        if (kv_store_handle == KV_STORE_POOL_MAX_SIZE)
+        {
+            SAFE_LOG(PDO_LOG_WARNING, "no kv store handles available");
+            return -1;
+        }
+
+        pstate::Interpreter_KV* state = new pstate::Interpreter_KV(ba_encryption_key);
+        if (state == NULL)
+        {
+            SAFE_LOG(PDO_LOG_ERROR, "state was not initialized (get)");
+            return -1;
+        }
+
+        kv_store_pool[kv_store_handle] = (pstate::Basic_KV_Plus*)state;
+        return kv_store_handle;
+    }
+    catch (pdo::error::Error& e) {
+        SAFE_LOG(PDO_LOG_ERROR, "failure in %s; %s", __FUNCTION__, e.what());
+        return -1;
+    }
+    catch (...) {
+        SAFE_LOG(PDO_LOG_ERROR, "unexpected failure in %s", __FUNCTION__);
+        return -1;
+    }
+}
+
+/* ----------------------------------------------------------------- *
+ * NAME: _key_value_open_wrapper
+ * ----------------------------------------------------------------- */
+extern "C" int32 key_value_open_wrapper(
+    wasm_exec_env_t exec_env,
+    const uint8_t* id_hash_buffer,
+    const int32 id_hash_buffer_length,
+    const uint8_t* key_buffer,
+    const int32 key_buffer_length)
+{
+    wasm_module_inst_t module_inst = wasm_runtime_get_module_inst(exec_env);
+    try {
+        if (id_hash_buffer == NULL || id_hash_buffer_length <= 0)
+            return false;
+
+        ByteArray ba_id_hash(id_hash_buffer, id_hash_buffer + id_hash_buffer_length);
+
+        if (key_buffer == NULL || key_buffer_length != 16)
+        {
+            SAFE_LOG(PDO_LOG_ERROR, "invalid encryption key; %d", key_buffer_length);
+            return false;
+        }
+
+        ByteArray ba_encryption_key(key_buffer, key_buffer + key_buffer_length);
+
+        // find an empty slot we can use for the kv store
+        pstate::Basic_KV_Plus** kv_store_pool = (pstate::Basic_KV_Plus**)wasm_runtime_get_custom_data(module_inst);
+
+        size_t kv_store_handle;
+        for (kv_store_handle = 1; kv_store_handle < KV_STORE_POOL_MAX_SIZE; kv_store_handle++)
+            if (kv_store_pool[kv_store_handle] == NULL) break;
+
+        if (kv_store_handle == KV_STORE_POOL_MAX_SIZE)
+        {
+            SAFE_LOG(PDO_LOG_WARNING, "no kv store handles available");
+            return -1;
+        }
+
+        pstate::Interpreter_KV* state = new pstate::Interpreter_KV(ba_id_hash, ba_encryption_key);
+        if (state == NULL)
+        {
+            SAFE_LOG(PDO_LOG_ERROR, "state was not initialized (get)");
+            return -1;
+        }
+
+        kv_store_pool[kv_store_handle] = (pstate::Basic_KV_Plus*)state;
+        return kv_store_handle;
+    }
+    catch (pdo::error::Error& e) {
+        SAFE_LOG(PDO_LOG_ERROR, "failure in %s; %s", __FUNCTION__, e.what());
+        return -1;
+    }
+    catch (...) {
+        SAFE_LOG(PDO_LOG_ERROR, "unexpected failure in %s", __FUNCTION__);
+        return -1;
+    }
+}
+
+/* ----------------------------------------------------------------- *
+ * NAME: _key_value_finalize_wrapper
+ * ----------------------------------------------------------------- */
+extern "C" bool key_value_finalize_wrapper(
+    wasm_exec_env_t exec_env,
+    const int32 kv_store_handle,
+    int32 id_hash_buffer_pointer_offset,
+    int32 id_hash_length_pointer_offset)
+{
+    wasm_module_inst_t module_inst = wasm_runtime_get_module_inst(exec_env);
+    try {
+        if (kv_store_handle <= 0 || kv_store_handle >= KV_STORE_POOL_MAX_SIZE)
+        {
+            SAFE_LOG(PDO_LOG_WARNING, "invalid state handle");
+            return false;
+        }
+
+        pstate::Basic_KV_Plus** kv_store_pool = (pstate::Basic_KV_Plus**)wasm_runtime_get_custom_data(module_inst);
+        pstate::Basic_KV_Plus* state = kv_store_pool[kv_store_handle];
+        if (state == NULL)
+        {
+            SAFE_LOG(PDO_LOG_ERROR, "state was not initialized (finalize)");
+            return false;
+        }
+
+        // Call finalize and cross your fingers
+        ByteArray ba_val;
+
+        state->Finalize(ba_val);
+        if (ba_val.size() == 0)
+        {
+            SAFE_LOG(PDO_LOG_ERROR, "failed to finalize key/value store");
+            return false;
+        }
+
+        // Clean up the memory used
+        delete state;
+        kv_store_pool[kv_store_handle] = NULL;
+
+        // Save the block identifier in the output parameters
+        if (! save_buffer(module_inst,
+                          (const char*)ba_val.data(), ba_val.size(),
+                          id_hash_buffer_pointer_offset, id_hash_length_pointer_offset))
+            return false;
+
+        return true;
+
     }
     catch (pdo::error::Error& e) {
         SAFE_LOG(PDO_LOG_ERROR, "failure in %s; %s", __FUNCTION__, e.what());

--- a/common/interpreter/wawaka_wasm/WasmStateExtensions.h
+++ b/common/interpreter/wawaka_wasm/WasmStateExtensions.h
@@ -22,6 +22,7 @@
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 extern "C" bool key_value_set_wrapper(
     wasm_exec_env_t exec_env,
+    const int32 kv_store_handle,
     const uint8_t* key_buffer,
     const int32 key_buffer_length,
     const uint8_t* val_buffer,
@@ -29,7 +30,26 @@ extern "C" bool key_value_set_wrapper(
 
 extern "C" bool key_value_get_wrapper(
     wasm_exec_env_t exec_env,
+    const int32 kv_store_handle,
     const uint8_t* key_buffer,
     const int32 key_buffer_length,
     int32 val_buffer_pointer_offset,  /* uint8_t** */
     int32 val_length_pointer_offset); /* size_t* */
+
+extern "C" int key_value_create_wrapper(
+    wasm_exec_env_t exec_env,
+    const uint8_t* key_buffer,
+    const int32 key_buffer_length);
+
+extern "C" int key_value_open_wrapper(
+    wasm_exec_env_t exec_env,
+    const uint8_t* id_hash_buffer,
+    const int32 id_hash_buffer_length,
+    const uint8_t* key_buffer,
+    const int32 key_buffer_length);
+
+extern "C" bool key_value_finalize_wrapper(
+    wasm_exec_env_t exec_env,
+    const int32 kv_start_handle,
+    int32 id_hash_buffer_pointer_offset,  /* uint8_t** */
+    int32 id_hash_length_pointer_offset); /* size_t* */

--- a/common/interpreter/wawaka_wasm/WawakaInterpreter.h
+++ b/common/interpreter/wawaka_wasm/WawakaInterpreter.h
@@ -26,6 +26,8 @@ extern "C" {
 #include "bh_platform.h"
 }
 
+#define KV_STORE_POOL_MAX_SIZE 8
+
 namespace pc = pdo::contracts;
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -40,12 +42,13 @@ private:
     wasm_module_inst_t wasm_module_inst = NULL;
     wasm_exec_env_t wasm_exec_env = NULL;
     ByteArray binary_code_;
+    pdo::state::Basic_KV_Plus* kv_store_pool[KV_STORE_POOL_MAX_SIZE] = { 0 };
 
     void parse_response_string(
         int32 response_app,
         std::string& outResult,
         bool& outStateChanged,
-        std::map<string,string>& outDependencies);
+        std::map<std::string,std::string>& outDependencies);
 
     const char* report_interpreter_error(
         const char* message,
@@ -81,7 +84,7 @@ public:
         const pdo::state::StateBlockId& inContractStateHash,
         pdo::state::Basic_KV_Plus& inoutContractState,
         bool& outStateChangedFlag,
-        std::map<string,string>& outDependencies,
+        std::map<std::string,std::string>& outDependencies,
         std::string& outMessageResult
         );
 

--- a/contracts/wawaka/common/Cryptography.cpp
+++ b/contracts/wawaka/common/Cryptography.cpp
@@ -105,8 +105,6 @@ bool ww::crypto::aes::generate_key(StringArray& key)
         return false;
     }
 
-    verify_null_terminated((const char*)data_pointer, data_size);
-
     return copy_internal_pointer(key, data_pointer, data_size);
 }
 
@@ -143,8 +141,6 @@ bool ww::crypto::aes::encrypt_message(
     const StringArray& iv,
     StringArray& cipher)
 {
-    verify_null_terminated((const char*)key.c_data(), key.size());
-
     uint8_t* data_pointer = NULL;
     size_t data_size = 0;
 
@@ -173,8 +169,6 @@ bool ww::crypto::aes::decrypt_message(
     const StringArray& iv,
     StringArray& message)
 {
-    verify_null_terminated((const char*)key.c_data(), key.size());
-
     uint8_t* data_pointer = NULL;
     size_t data_size = 0;
 

--- a/contracts/wawaka/common/KeyValue.h
+++ b/contracts/wawaka/common/KeyValue.h
@@ -22,11 +22,16 @@
 
 class KeyValueStore
 {
+    size_t handle_;
     const StringArray prefix_;
     bool make_key(const StringArray& key, StringArray& prefixed_key) const;
 
 public:
-    KeyValueStore(const char* prefix) : prefix_(prefix) {};
+    KeyValueStore(const char* prefix, size_t handle = 0) : handle_(handle), prefix_(prefix) {};
+
+    static int create(const StringArray& key);
+    static int open(const StringArray& block_hash, const StringArray& key);
+    static bool finalize(const int kv_store_handle, StringArray& block_hash);
 
     bool get(const StringArray& key, uint32_t& val) const;
     bool set(const StringArray& key, const uint32_t val) const;

--- a/contracts/wawaka/common/Util.h
+++ b/contracts/wawaka/common/Util.h
@@ -19,10 +19,12 @@
 
 #include "StringArray.h"
 
-#define ASSERT_CONDITION(_cond, _rsp) \
-    do { \
-    if (! _cond)
-
+#define ASSERT_SUCCESS(_rsp_, _condition_, _message_)   \
+    do {                                                \
+        if (_condition_) {                              \
+            return _rsp_.error(_message_);              \
+        }                                               \
+    } while (0)
 
 #define ASSERT_SENDER_IS_OWNER(_env, _rsp)                              \
     do {                                                                \

--- a/contracts/wawaka/interpreter-test/test-short.json
+++ b/contracts/wawaka/interpreter-test/test-short.json
@@ -1,5 +1,7 @@
 [
     { "MethodName" : "ecdsa_test", "KeywordParameters": { "message" : "hello there" } },
     { "MethodName" : "aes_test", "KeywordParameters": { "message" : "hello there" } },
-    { "MethodName" : "rsa_test"}
+    { "MethodName" : "rsa_test"},
+    { "MethodName" : "kv_test_set", "expected" : "[tT]rue"},
+    { "MethodName" : "kv_test_get", "expected" : "1"}
 ]


### PR DESCRIPTION
add create, open and finalize operations so that contracts can use key/value store that is distinct from the contract state. the basic idea is that data can be shared securely between contract objects. for example, the aggregator in a federated learning system could store the model in a separate store that could be shared to objects that update the model securely with local updates.

this feature is experimental. while minimal testing is provided in the commit, far more is necessary.