### PR TITLE
miscellaneous clean up and improvements

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -21,7 +21,7 @@ PYTHON_SOURCE = $(shell cat MANIFEST)
 all : $(EGG_FILE)
 
 install: $(EGG_FILE)
-	easy_install $<
+	python setup.py install
 
 $(EGG_FILE) : $(PYTHON_SOURCE) bin/pdo-invoke.psh bin/pdo-create.psh
 	@echo Build Distribution

--- a/client/pdo/client/controller/contract_controller.py
+++ b/client/pdo/client/controller/contract_controller.py
@@ -421,7 +421,19 @@ class ContractController(cmd.Cmd) :
         if self.deferred > 0 : return False
 
         try :
-            print(self.bindings.expand(args))
+            pargs = self.__arg_parse__(args)
+
+            parser = argparse.ArgumentParser(prog='echo')
+            parser.add_argument('-r', '--raw', help='prevent expansion of escape characters', action='store_true')
+            (options, rest) = parser.parse_known_args(pargs)
+
+            expanded_string = ' '.join(rest)
+            if options.raw :
+                print(expanded_string)
+            else :
+                decoded_string = bytes(expanded_string, "utf-8").decode("unicode_escape")
+                print(decoded_string)
+
         except Exception as e :
             return self.__error__('echo', args, str(e))
 

--- a/common/packages/parson/parson.cpp
+++ b/common/packages/parson/parson.cpp
@@ -811,7 +811,9 @@ static int json_serialize_string(const char *string, char *buf) {
     switch (c) {
       case '\"': APPEND_STRING("\\\""); break;
       case '\\': APPEND_STRING("\\\\"); break;
+#if PARSON_ENCODE_SLASH
       case '/':  APPEND_STRING("\\/"); break; /* to make json embeddable in xml\/html */
+#endif
       case '\b': APPEND_STRING("\\b"); break;
       case '\f': APPEND_STRING("\\f"); break;
       case '\n': APPEND_STRING("\\n"); break;

--- a/contracts/wawaka/common/Util.h
+++ b/contracts/wawaka/common/Util.h
@@ -21,7 +21,7 @@
 
 #define ASSERT_SUCCESS(_rsp_, _condition_, _message_)   \
     do {                                                \
-        if (_condition_) {                              \
+        if (! ( _condition_) ) {                        \
             return _rsp_.error(_message_);              \
         }                                               \
     } while (0)

--- a/eservice/Makefile
+++ b/eservice/Makefile
@@ -77,7 +77,7 @@ build :
 	cd $@ && cmake .. -G "Unix Makefiles"
 
 install: $(EGG_FILE)
-	easy_install $<
+	python setup.py install
 
 # these cannot be run in the current directory because python tries to
 # pick up the local versions of the library which do not have the same

--- a/pservice/Makefile
+++ b/pservice/Makefile
@@ -74,7 +74,7 @@ build :
 	cd $@ && cmake .. -G "Unix Makefiles"
 
 install: $(EGG_FILE)
-	easy_install $<
+	python setup.py install
 
 clean:
 	rm -f $(addprefix pdo/pservice/enclave/, pdo_enclave_internal.py pdo_enclave_internal_wrap.cpp)

--- a/python/Makefile
+++ b/python/Makefile
@@ -40,7 +40,7 @@ $(SWIG_TARGET) : $(SWIG_FILES) $(COMMON_LIB)
 	python setup.py build_ext --force
 
 install: $(EGG_FILE)
-	easy_install $<
+	python setup.py install
 
 test: install
 	(cd ../common/tests/crypto && python test_cryptoWrapper.py)
@@ -51,5 +51,5 @@ clean:
 
 .phony : all
 .phony : clean
-.phone : install
+.phony : install
 .phony : test


### PR DESCRIPTION
pdo-shell: add a raw flag to the echo command and process escapes by default (can use colors in echo statements)
parson: turn off escape of '/' in json serialization, the inconsistency with python handling causes no end of problems
wawaka macros: replace ASSERT_CONDTION with ASSERT_SUCCESS for a consistent way of testing conditions in contracts