### PR TITLE
Update the pdoshell to handle errors and subprocesses more cleanly

### DIFF
--- a/client/bin/pdo-create.psh
+++ b/client/bin/pdo-create.psh
@@ -47,21 +47,28 @@ set -q --conditional -s pdo_file -v ${save}/${random_id}.pdo
 
 if -e ${identity} '__unknown__'
    echo missing required parameter, identity
-   exit
+   exit -v -1
 fi
 
 if -n ${class}
    echo missing required parameter, class
-   exit
+   exit -v -1
 fi
 
 if -n ${source}
    echo missing required parameter, source
-   exit
+   exit -v -1
 fi
 
 identity -n ${identity}
+
+trap_error
+
 create -c ${class} -s ${source} -f ${pdo_file} -p ${psgroup} -e ${esgroup}
+if -o ${_error_code_} 0
+   echo ERROR: ${_error_message_}
+   exit -v ${_error_code_}
+fi
 
 echo contract saved to file ${pdo_file}
 exit

--- a/client/bin/pdo-invoke.psh
+++ b/client/bin/pdo-invoke.psh
@@ -33,27 +33,34 @@ set -q --conditional -s method -v ""
 
 script -f ${home}/etc/site.psh
 
-if -e ${identity} '__unknown__'
+if -e ${_identity_} '__unknown__'
    echo missing required parameter, identity
-   exit
+   exit -v -1
 fi
 
 if -n ${pdo_file}
    echo missing required parameter, pdo_file
-   exit
+   exit -v -1
 fi
 
-identity -n ${identity}
+identity -n ${_identity_}
 
 if -n ${method}
    echo missing method to invoke
-   exit
+   exit -v -1
 fi
+
+trap_error
 
 if -n ${params}
    send -f ${pdo_file} ${method}
 else
    send -f ${pdo_file} -p ${params} ${method}
+fi
+
+if -o ${_error_code_} 0
+   echo ERROR: ${_error_message_}
+   exit -v ${_error_code_}
 fi
 
 exit

--- a/client/pdo/client/controller/commands/create.py
+++ b/client/pdo/client/controller/commands/create.py
@@ -125,7 +125,7 @@ def command_create(state, bindings, pargs) :
 
     # ---------- load the invoker's keys ----------
     try :
-        keyfile = state.get(['Key', 'FileName'])
+        keyfile = state.private_key_file
         keypath = state.get(['Key', 'SearchPath'])
         client_keys = ServiceKeys.read_from_file(keyfile, keypath)
     except Exception as e :

--- a/client/pdo/client/controller/commands/send.py
+++ b/client/pdo/client/controller/commands/send.py
@@ -37,7 +37,7 @@ def send_to_contract(state, save_file, message, eservice_url=None, quiet=False, 
 
     # ---------- load the invoker's keys ----------
     try :
-        keyfile = state.get(['Key', 'FileName'])
+        keyfile = state.private_key_file
         keypath = state.get(['Key', 'SearchPath'])
         client_keys = ServiceKeys.read_from_file(keyfile, keypath)
     except Exception as e :

--- a/client/pdo/client/scripts/ShellCLI.py
+++ b/client/pdo/client/scripts/ShellCLI.py
@@ -27,17 +27,18 @@ from pdo.contract.response import ContractResponse
 ## -----------------------------------------------------------------
 ## -----------------------------------------------------------------
 def LocalMain(config) :
-    shell = ContractController(config)
-
     # if there is a script file, process it; the interactive
     # shell will start unless there is an explicit exit in the script
     script_file = config.get("ScriptFile")
     if script_file :
-        logger.info("Processing script file %s", str(script_file))
-        if not ContractController.ProcessScript(shell, script_file) :
-            ContractResponse.exit_commit_workers()
-            sys.exit(shell.exit_code)
+        shell = ContractController.CreateController(config, echo=False, interactive=False)
 
+        logger.info("Processing script file %s", str(script_file))
+        exit_code = ContractController.ProcessScript(shell, script_file)
+        ContractResponse.exit_commit_workers()
+        sys.exit(exit_code)
+
+    shell = ContractController.CreateController(config, echo=True, interactive=True)
     shell.cmdloop()
     print("")
 


### PR DESCRIPTION
Add the ability to handle errors in subcommands. The command "trap_error"
will convert errors in commands from exceptions to successful returns. If
an error does occur, then the symbols "_error_code_" and "_error_message_"
will be set with the numeric code (generally -1) and error message from
the failed command. This is critical for writing negative tests (that is,
writing tests that are supposed to fail).

Enable the creation of script local bindings. In the past, the "script"
command operated on the current bindings. as a result, any changes in
the bindings made in the child script were transparently propogated to
the parent script. The new shell generally preserves that behavior, but
introduces a script local format for variables. In this case, any variable
that starts with '_' is considered a script local variable. This means that
any "global" variable may be changed at random by a sub-script. But that
script local variables will not change.

Signed-off-by: Mic Bowman <mic.bowman@intel.com>