### PR TITLE
Upgrade to SGX SDK 2.13 and WAMR-01-29-2021

### DIFF
--- a/common/interpreter/wawaka_wasm/README.md
+++ b/common/interpreter/wawaka_wasm/README.md
@@ -48,14 +48,14 @@ source ./emsdk_env.sh
 If wawaka is configured as the contract interpreter, the libraries implementing the WASM interpreter
 will be built for use with Intel SGX. The source for the WAMR interpreter is
 included as a submodule in the interpreters/ folder, and will
-always point to the latest tagged commit that we have validated: `WAMR-09-29-2020`.
+always point to the latest tagged commit that we have validated: `WAMR-01-29-2021`.
 If the PDO parent repo was not cloned with the `--recurse-submodules` flag,
 you will have to explictly pull the submodule source.
 
 ```
 cd ${PDO_SOURCE_ROOT}/interpreters/wasm-micro-runtime
 git submodule update --init
-git checkout WAMR-09-29-2020 # optional
+git checkout WAMR-01-29-2021 # optional
 ```
 
 The WAMR API is built during the Wawaka build, so no additional

--- a/contracts/wawaka/contract-build.cmake
+++ b/contracts/wawaka/contract-build.cmake
@@ -60,7 +60,7 @@ STRING(REPLACE ";" " " EMCC_LINK_OPTIONS "${EMCC_LINK_OPTIONS}")
 
 # the -O2 is actually required for the moment because it removes
 # uncalled functions that clutter the wasm file
-SET(CMAKE_CXX_FLAGS "-O2 -fPIC -fno-exceptions ${EMCC_BUILD_OPTIONS}")
+SET(CMAKE_CXX_FLAGS "-O2 -fPIC -fno-exceptions -std=c++11 ${EMCC_BUILD_OPTIONS}")
 SET(CMAKE_EXECUTABLE_SUFFIX ".wasm")
 
 FILE(GLOB COMMON_SOURCE ${PDO_TOP_DIR}/contracts/wawaka/common/*.cpp)

--- a/docker/Dockerfile.pdo-build
+++ b/docker/Dockerfile.pdo-build
@@ -24,7 +24,7 @@
 #  - pdo repo branch to use:			PDO_REPO_BRANCH (default: master)
 #  - build in debug mode:			PDO_DEBUG_BUILD (default: 0)
 #  - contract interpreter (gipsy or wawaka):	PDO_INTERPRETER (default: gipsy)
-#  - wamr version:		                WAMR    (default: WAMR-09-29-2020)
+#  - wamr version:		                WAMR    (default: WAMR-01-29-2021)
 
 # Build:
 #   $ docker build -f docker/Dockerfile.pdo-build -t pdo-build docker
@@ -109,7 +109,7 @@ ENV PDO_LEDGER_KEY_ROOT=${PDO_LEDGER_KEY_ROOT}
 
 # - web-assembly/wasm/wawaka
 #   - Configure WAMR source
-ARG WAMR=WAMR-09-29-2020
+ARG WAMR=WAMR-01-29-2021
 RUN cd /project/pdo/src/private-data-objects/interpreters/wasm-micro-runtime \
  && git checkout ${WAMR}\
  && echo "export WASM_SRC=$(pwd)" >> /etc/profile.d/pdo.sh

--- a/docker/Dockerfile.pdo-dev
+++ b/docker/Dockerfile.pdo-dev
@@ -19,7 +19,7 @@
 #  Configuration (build) paramaters
 #  - ubuntu version to use: 	  UBUNTU_VERSION (default: 18.04)
 #  - ubuntu name to use: 	  UBUNTU_NAME (default: bionic)
-#  - sgx sdk/psw version: 	  SGX (default: 2.10)
+#  - sgx sdk/psw version: 	  SGX (default: 2.13)
 #  - openssl version: 		  OPENSSL (default: 1.1.1g)
 #  - sgxssl version: 		  SGXSSL  (default: 2.10_1.1.1g)
 #  - additional apt packages:	  ADD_APT_PKGS (default: )
@@ -63,7 +63,7 @@ FROM ubuntu:${UBUNTU_VERSION}
 ARG UBUNTU_VERSION
 ARG UBUNTU_NAME
 
-ARG SGX=2.10
+ARG SGX=2.13
 ARG OPENSSL=1.1.1g
 ARG SGXSSL=2.10_1.1.1g
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -27,7 +27,7 @@ DOCKER_COMPOSE_FILES_STL += sawtooth-pdo.yaml sawtooth-pdo.local-code.yaml
 DOCKER_COMPOSE_FILES_CCF += ccf-pdo.yaml ccf-pdo.local-code.yaml
 ifeq ($(SGX_MODE),HW)
    DOCKER_COMPOSE_FILES_STL += sawtooth-pdo.sgx.yaml
-   SGX_DEVICE_PATH=$(shell if [ -e "/dev/isgx" ]; then echo "/dev/isgx"; elif [ -e "/dev/sgx" ]; then echo "/dev/sgx"; else echo "ERROR: NO SGX DEVICE FOUND"; fi)
+   SGX_DEVICE_PATH=$(shell if [ -e "/dev/isgx" ]; then echo "/dev/isgx"; elif [ -e "/dev/sgx/enclave" ]; then echo "/dev/sgx/enclave"; else echo "ERROR: NO SGX DEVICE FOUND"; fi)
    DOCKER_COMPOSE_COMMAND := env SGX_DEVICE_PATH=${SGX_DEVICE_PATH} ${DOCKER_COMPOSE_COMMAND}
 endif
 ifdef http_proxy

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -118,7 +118,7 @@ the contract enclave.
 `WASM_SRC` points to the installation of the wasm-micro-runtime. This
 is used to build the WASM interpreter for the wawaka contract interpreter.
 The git submodule points to the latest tagged commit of [WAMR](https://github.com/bytecodealliance/wasm-micro-runtime) we have validated:
-`WAMR-09-29-2020`.
+`WAMR-01-29-2021`.
 
 <!-- -------------------------------------------------- -->
 ### `WASM_MEM_CONFIG`

--- a/docs/host_install.md
+++ b/docs/host_install.md
@@ -89,17 +89,17 @@ in `/etc/aesmd.confg` and restart aesmd with `systemctl restart aesmd.
 
 ## Install the SGX SDK
 
-Private Data Objects has been tested with version 2.10 of the SGX
+Private Data Objects has been tested with version 2.13 of the SGX
 SDK. You can download prebuilt binaries for the SDK and kernel drivers
-from [01.org](https://download.01.org/intel-sgx/sgx-linux/2.10/distro/ubuntu18.04-server/).
+from [01.org](https://download.01.org/intel-sgx/sgx-linux/2.13/distro/ubuntu18.04-server/).
 
-The following commands will download and install version 2.10 of the SGX
+The following commands will download and install version 2.13 of the SGX
 SDK. When asked for the installation directory, we suggest that you install
 the SDK into the directory `/opt/intel`.
 
 ```bash
-DRIVER_REPO=https://download.01.org/intel-sgx/sgx-linux/2.10/distro/ubuntu18.04-server/
-SDK_FILE=sgx_linux_x64_sdk_2.10.100.2.bin
+DRIVER_REPO=https://download.01.org/intel-sgx/sgx-linux/2.13/distro/ubuntu18.04-server/
+SDK_FILE=sgx_linux_x64_sdk_2.13.100.4.bin
 
 wget ${DRIVER_REPO}/${SDK_FILE} -P /tmp
 chmod a+x /tmp/${SDK_FILE}
@@ -130,9 +130,9 @@ that contain the necessary LVI mitigations. The following
 commands will download and install these binaries:
 
 ```bash
-wget "https://download.01.org/intel-sgx/sgx-linux/2.10/as.ld.objdump.gold.r2.tar.gz" -P /tmp
+wget "https://download.01.org/intel-sgx/sgx-linux/2.13/as.ld.objdump.gold.r3.tar.gz" -P /tmp
 sudo mkdir /opt/intel/sgxsdk.extras
-sudo tar -xzf /tmp/as.ld.objdump.gold.r2.tar.gz -C /opt/intel/sgxsdk.extras
+sudo tar -xzf /tmp/as.ld.objdump.gold.r3.tar.gz -C /opt/intel/sgxsdk.extras
 export PATH=/opt/intel/sgxsdk.extras/external/toolset/ubuntu18.04:${PATH}
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -158,12 +158,12 @@ Note:
 ##### HW which does not support Flexible Launch Control (FLC)
 <!-- SDK kernel driver installation -->
 
-The following commands will download and install the SDK driver version 2.6 of
+The following commands will download and install the SDK driver version 2.11 of
 the SGX kernel driver (for Ubuntu 18.04 server):
 
 ```bash
 DRIVER_REPO=https://download.01.org/intel-sgx/sgx-linux/2.13/distro/ubuntu18.04-server
-DRIVER_FILE=sgx_linux_x64_driver_2.6.0_602374c.bin
+DRIVER_FILE=ssgx_linux_x64_driver_2.11.0_0373e2e.bin
 
 wget ${DRIVER_REPO}/${DRIVER_FILE} -P /tmp
 chmod a+x /tmp/${DRIVER_FILE}

--- a/docs/install.md
+++ b/docs/install.md
@@ -138,12 +138,12 @@ different drivers.
 
 ##### HW with support for DCAP / Flexible Launch Control (FLC)
 <!-- DCAP kernel driver installation -->
-The following commands will download and install the driver version 1.3 of
+The following commands will download and install the driver version 1.41 of
 the DCAP SGX kernel driver (for Ubuntu 18.04 server):
 
 ```bash
-DRIVER_REPO=https://download.01.org/intel-sgx/sgx-dcap/1.7/linux/distro/ubuntu18.04-server/
-DRIVER_FILE=sgx_linux_x64_driver_1.35.bin
+DRIVER_REPO=https://download.01.org/intel-sgx/sgx-linux/2.13/distro/ubuntu18.04-server/
+DRIVER_FILE=sgx_linux_x64_driver_1.41.bin
 
 wget ${DRIVER_REPO}/${DRIVER_FILE} -P /tmp
 chmod a+x /tmp/${DRIVER_FILE}
@@ -162,7 +162,7 @@ The following commands will download and install the SDK driver version 2.6 of
 the SGX kernel driver (for Ubuntu 18.04 server):
 
 ```bash
-DRIVER_REPO=https://download.01.org/intel-sgx/sgx-linux/2.10/distro/ubuntu18.04-server
+DRIVER_REPO=https://download.01.org/intel-sgx/sgx-linux/2.13/distro/ubuntu18.04-server
 DRIVER_FILE=sgx_linux_x64_driver_2.6.0_602374c.bin
 
 wget ${DRIVER_REPO}/${DRIVER_FILE} -P /tmp


### PR DESCRIPTION
This PR upgrades the SGX SDK version to 2.13 and WAMR to the latest release tag `WAMR-01-29-2021`. Together these updates resolve the pthread-related issues we were seeing in #308. 

Notes:
- The changes in this PR have been tested in HW mode only on IceLake client with DCAP driver 1.41 (documentation updated to reflect this).
- This PR does not update the sgxssl version (yet).