### PR TITLE
Migrate from emscripten to wasi-sdk for the wasm development tool chain

### DIFF
--- a/common/interpreter/wawaka_wasm/README.md
+++ b/common/interpreter/wawaka_wasm/README.md
@@ -28,14 +28,14 @@ enclave with Wawaka enabled, you will need to do the following:
 ### Install WASM Development Toolchain ###
 
 There are many toolchains that could be used to build a WASM code. By default, Wawaka contracts are
-developed with the [WASI SDK](https://github.com/WebAssembly/wasi-sdk).
+compiled with the compilers provided by [WASI SDK](https://github.com/WebAssembly/wasi-sdk). To use
+WASI SDK, download and install the appropriate package file from
+https://github.com/WebAssembly/wasi-sdk/releases (we have verified that release wasi-sdk-12 works
+with WAMR version WAMR-03-25-2021).
 
 ```bash
-cd ${PDO_SOURCE_ROOT}
-wget -q -P /tmp https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk-12.0-linux.tar.gz
-tar -zxf /tmp/wasi-sdk-12.0-linux.tar.gz
-
-export WASI_SDK_DIR=${PDO_SOURCE_ROOT}/wasi-sdk-12.0
+wget -q -P /tmp https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk_12.0_amd64.deb
+sudo dpkg --install /tmp/wasi-sdk_12.0_amd64.deb
 ```
 
 These directions assume that the SDK will be installed in the PDO source tree. Typically, the WASI

--- a/common/interpreter/wawaka_wasm/README.md
+++ b/common/interpreter/wawaka_wasm/README.md
@@ -39,8 +39,7 @@ sudo dpkg --install /tmp/wasi-sdk_12.0_amd64.deb
 ```
 
 These directions assume that the SDK will be installed in the PDO source tree. Typically, the WASI
-SDK would be installed in the directory `/opt/wasi-sdk`. Please set the environment variable
-`WASI_SDK_DIR` to the directory where the SDK is installed.
+SDK would be installed in the directory `/opt/wasi-sdk`. 
 
 ### Set Up WAMR ###
 

--- a/common/interpreter/wawaka_wasm/WasmExtensions.cpp
+++ b/common/interpreter/wawaka_wasm/WasmExtensions.cpp
@@ -135,6 +135,11 @@ extern "C" double strtod_wrapper(
     return num;
 }
 
+extern "C" void abort_wrapper(wasm_exec_env_t exec_env)
+{
+    abort();
+}
+
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #ifdef __cplusplus
@@ -163,6 +168,7 @@ static NativeSymbol native_symbols[] =
 #if 0
     EXPORT_WASM_API_WITH_SIG2(isascii,"(i)i"),
 #endif
+    EXPORT_WASM_API_WITH_SIG2(abort,"()"),
 
     /* Crypto operations from WasmCryptoExtensions.h */
     EXPORT_WASM_API_WITH_SIG2(b64_encode,"(iiii)i"),

--- a/common/interpreter/wawaka_wasm/WasmExtensions.h
+++ b/common/interpreter/wawaka_wasm/WasmExtensions.h
@@ -24,7 +24,9 @@ provided by the Wawaka interpreter.
 extern "C" {
 #endif
 #include <stdint.h>
-#include <stdio.h>
+
+int snprintf(char *str, size_t size, const char *format, ...);
+int sprintf(char *str, const char *format, ...);
 
 // From WasmStateExtensions
 bool key_value_set(

--- a/common/interpreter/wawaka_wasm/WawakaInterpreter.cpp
+++ b/common/interpreter/wawaka_wasm/WawakaInterpreter.cpp
@@ -177,7 +177,11 @@ int32 WawakaInterpreter::initialize_contract(
     int32 result = 0;
 
     SAFE_LOG(PDO_LOG_DEBUG, "wasm initialize_contract");
-    wasm_func = wasm_runtime_lookup_function(wasm_module_inst, "_ww_initialize", "(i32)i32");
+
+    wasm_func = wasm_runtime_lookup_function(wasm_module_inst, "ww_initialize", "(i32)i32");
+    if (wasm_func == NULL)
+        wasm_func = wasm_runtime_lookup_function(wasm_module_inst, "_ww_initialize", "(i32)i32");
+
     pe::ThrowIfNull(wasm_func, "Unable to locate the initialize function");
 
     uint32 argv[1], buf_offset = 0;
@@ -224,7 +228,10 @@ int32 WawakaInterpreter::evaluate_function(
     SAFE_LOG(PDO_LOG_DEBUG, "evaluate_function");
     pc::validate_invocation_request(args);
 
-    wasm_func = wasm_runtime_lookup_function(wasm_module_inst, "_ww_dispatch", "(i32i32)i32");
+    wasm_func = wasm_runtime_lookup_function(wasm_module_inst, "ww_dispatch", "(i32i32)i32");
+    if (wasm_func == NULL)
+        wasm_func = wasm_runtime_lookup_function(wasm_module_inst, "_ww_dispatch", "(i32i32)i32");
+
     pe::ThrowIfNull(wasm_func, "Unable to locate the dispatch function");
 
     uint32 argv[2], buf_offset0 = 0, buf_offset1 = 0;

--- a/common/packages/parson/parson.cpp
+++ b/common/packages/parson/parson.cpp
@@ -28,7 +28,14 @@
 
 #include "parson.h"
 
-#include <stdio.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+int snprintf(char *str, size_t size, const char *format, ...);
+#ifdef __cplusplus
+}
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>

--- a/contracts/wawaka/CMakeLists.txt
+++ b/contracts/wawaka/CMakeLists.txt
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CMAKE_MINIMUM_REQUIRED(VERSION 3.2 FATAL_ERROR)
+cmake_minimum_required (VERSION 3.5 FATAL_ERROR)
 
 INCLUDE(contract-build.cmake)
 
-ADD_SUBDIRECTORY(interface-test)
 ADD_SUBDIRECTORY(mock-contract)
+ADD_SUBDIRECTORY(interface-test)
 ADD_SUBDIRECTORY(interpreter-test)
 ADD_SUBDIRECTORY(memory-test)
 ADD_SUBDIRECTORY(exchange)

--- a/contracts/wawaka/Makefile
+++ b/contracts/wawaka/Makefile
@@ -23,57 +23,63 @@ endif
 SCRIPTDIR ?= $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 DSTDIR ?= $(PDO_INSTALL_ROOT)
 
-# skip downloading LLVM and building wamrc unless we're in wawaka-aot mode
-ifeq ($(PDO_INTERPRETER),wawaka-aot)
-BUILD_AOT:=build-wamrc
-endif
+WAMR_ROOT=${PDO_SOURCE_ROOT}/interpreters/wasm-micro-runtime
+WAMR_TOOLCHAIN=$(WAMR_ROOT)/wamr-sdk/app/wasi_toolchain.cmake
 
-LLVM_VERSION=10.0.0
-LLVM_REPO=https://github.com/llvm/llvm-project/releases/download/llvmorg-$(LLVM_VERSION)
-LLVM_TAR=clang+llvm-$(LLVM_VERSION)-x86_64-linux-gnu-ubuntu-18.04
-LLVM_BIN=$(WASM_SRC)/core/deps/llvm/build/llvm/bin/llvm-lto # proxy for llvm dependency
+TEST_LOG_LEVEL ?= warn
+TEST_LOG_FILE ?= /dev/null
 
-CDI_COMPILER_SIGN_PEM=$(PDO_INSTALL_ROOT)/opt/pdo/keys/cdi_compiler1_private.pem
-CDI_COMPILER_VERIF_PEM=$(PDO_INSTALL_ROOT)/opt/pdo/keys/cdi_compiler1_public.pem
+## This would point you to the WAMR version of the built in libraries
+## WAMR_TOOLCHAIN=$(WAMR_ROOT)/wamr-sdk/app/wamr_toolchain.cmake
 
 all : build
 	@cd build && make all
 
 clean :
 	@echo Remove build directory
-	@rm -rf build $(WASM_SRC)/core/deps/llvm/build $(WASM_SRC)/wamr-compiler/build
-	@$(MAKE) -C benchmarks clean
+	@rm -rf build
 
 debug :
 	@echo No debug build defined
 
-test :
-	. $(abspath $(DSTDIR)/bin/activate) && pdo-test-contract --no-ledger --contract interface-test --expressions ${SCRIPTDIR}/interface-test/test-short.json
-	. $(abspath $(DSTDIR)/bin/activate) && pdo-test-contract --no-ledger --contract mock-contract --expressions ${SCRIPTDIR}/mock-contract/test-short.json
-	. $(abspath $(DSTDIR)/bin/activate) && pdo-test-contract --no-ledger --contract interpreter-test --expressions ${SCRIPTDIR}/interpreter-test/test-short.json
+test : install interface-test interpreter-test memory-test mock-contract-test
+
+interface-test:
+	@echo run test: $@
+	@ . $(abspath $(DSTDIR)/bin/activate) && pdo-test-contract --no-ledger \
+		--loglevel $(TEST_LOG_LEVEL) --logfile $(TEST_LOG_FILE) \
+		--contract $@ \
+		--expressions ${SCRIPTDIR}/$@/test-short.json
+
+interpreter-test:
+	@echo run test: $@
+	@ . $(abspath $(DSTDIR)/bin/activate) && pdo-test-contract --no-ledger \
+		--loglevel $(TEST_LOG_LEVEL) --logfile $(TEST_LOG_FILE) \
+		--contract $@ \
+		--expressions ${SCRIPTDIR}/$@/test-short.json
+
+memory-test:
+	@echo run test: $@
+	@ . $(abspath $(DSTDIR)/bin/activate) && pdo-test-contract --no-ledger \
+		--loglevel $(TEST_LOG_LEVEL) --logfile $(TEST_LOG_FILE) \
+		--contract $@ \
+		--expressions ${SCRIPTDIR}/$@/test-short.json
+
+mock-contract-test :
+	@echo run test: $@
+	@ . $(abspath $(DSTDIR)/bin/activate) && pdo-test-contract --no-ledger \
+		--loglevel $(TEST_LOG_LEVEL) --logfile $(TEST_LOG_FILE) \
+		--contract mock-contract \
+		--expressions ${SCRIPTDIR}/mock-contract/test-short.json
+
+.PHONY: test interface-test mock-contract-test interpreter-test memory-test
 
 install : build
 	@echo install contracts
 	@cd build && make install
 
-build : $(CDI_COMPILER_SIGN_PEM) $(BUILD_AOT)
+build :
 	mkdir -p $@
-	cd $@ && emcmake cmake ..
-
-$(CDI_COMPILER_SIGN_PEM):
-	@echo Generating CDI compiler keys
-	@openssl ecparam -name secp256k1 -genkey -noout -out $(CDI_COMPILER_SIGN_PEM)
-	@openssl ec -in  $(CDI_COMPILER_SIGN_PEM) -pubout -out $(CDI_COMPILER_VERIF_PEM)
-
-$(LLVM_BIN):
-	@echo Downloading LLVM dependencies
-	@cd $(WASM_SRC)/core/deps && mkdir -p llvm/build/ && \
-	wget -q $(LLVM_REPO)/$(LLVM_TAR).tar.xz && \
-	tar -xf $(LLVM_TAR).tar.xz -C llvm/build/ && \
-	cd llvm/build/ && mv $(LLVM_TAR) llvm
-
-build-wamrc: $(LLVM_BIN)
-	@echo Building wamrc
-	@cd $(WASM_SRC)/wamr-compiler && mkdir -p build && cd build && cmake .. && make
+	cd $@ && cmake .. -DCMAKE_TOOLCHAIN_FILE=$(WAMR_TOOLCHAIN)
 
 .PHONY : all clean debug install test

--- a/contracts/wawaka/benchmarks/fibonacci/fibonacci.cpp
+++ b/contracts/wawaka/benchmarks/fibonacci/fibonacci.cpp
@@ -16,7 +16,6 @@
 #include <malloc.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
 
 #include "Dispatch.h"
 

--- a/contracts/wawaka/common/KeyValue.h
+++ b/contracts/wawaka/common/KeyValue.h
@@ -15,7 +15,6 @@
 
 #pragma once
 
-#include <stdio.h>
 #include <stdint.h>
 
 #include "StringArray.h"

--- a/contracts/wawaka/common/Util.cpp
+++ b/contracts/wawaka/common/Util.cpp
@@ -13,12 +13,20 @@
  * limitations under the License.
  */
 
-#include <malloc.h>
+#include <stdlib.h>
 #include <stdint.h>
 
 #include "Util.h"
 
+#ifdef USE_WASI_SDK
 #include <new>
+
+// this function does not appear to be defined in the wasi-sdk
+// lib c++. we need
+std::new_handler std::get_new_handler() _NOEXCEPT
+{
+    return NULL;
+}
 
 void * operator new(size_t sz) throw(std::bad_alloc)
 {
@@ -34,6 +42,8 @@ void operator delete(void *ptr) _NOEXCEPT
 {
     free(ptr);
 }
+
+#endif
 
 /* ----------------------------------------------------------------- *
  * NAME: copy_internal_pointer

--- a/contracts/wawaka/contract-build.cmake
+++ b/contracts/wawaka/contract-build.cmake
@@ -24,7 +24,7 @@ SET(PDO_SOURCE_ROOT $ENV{PDO_SOURCE_ROOT})
 SET(WAWAKA_ROOT ${PDO_SOURCE_ROOT}/contracts/wawaka)
 
 IF (NOT DEFINED ENV{WASM_SRC})
-  MESSAGE(FATAL_ERROR "WASM_MEM_CONFIG environment variable not defined!")
+  MESSAGE(FATAL_ERROR "WASM_SRC environment variable not defined!")
 ENDIF()
 SET(WASM_SRC "$ENV{WASM_SRC}")
 

--- a/contracts/wawaka/contract-build.cmake
+++ b/contracts/wawaka/contract-build.cmake
@@ -33,10 +33,9 @@ IF (NOT DEFINED ENV{WASM_MEM_CONFIG})
 ENDIF()
 SET(WASM_MEM_CONFIG "$ENV{WASM_MEM_CONFIG}")
 
-IF (NOT DEFINED ENV{WASI_SDK_DIR})
-  SET(WASI_SDK_DIR "/opt/wasi-sdk")
-ELSE()
-  SET(WASI_SDK_DIR "$ENV{WASI_SDK_DIR}")
+# this should be set by the WAMR toolchain file
+IF (NOT DEFINED WASI_SDK_DIR)
+  MESSAGE(FATAL_ERROR "WASM_SDK_DIR was not defined, check toolchain defines")
 ENDIF()
 
 # ---------------------------------------------

--- a/contracts/wawaka/exchange/scripts/run-tests.sh
+++ b/contracts/wawaka/exchange/scripts/run-tests.sh
@@ -56,4 +56,4 @@ fi
 # -----------------------------------------------------------------
 cd "${EXCHANGE_ROOT}"
 
-try scripts/functional_test.psh --loglevel info --ledger ${PDO_LEDGER_URL}
+try scripts/functional_test.psh -m path ${SCRIPTDIR} --loglevel info --ledger ${PDO_LEDGER_URL}

--- a/contracts/wawaka/interface-test/interface-test.cpp
+++ b/contracts/wawaka/interface-test/interface-test.cpp
@@ -16,7 +16,6 @@
 #include <malloc.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
 
 #include "Dispatch.h"
 

--- a/contracts/wawaka/interpreter-test/interpreter-test.cpp
+++ b/contracts/wawaka/interpreter-test/interpreter-test.cpp
@@ -16,7 +16,6 @@
 #include <malloc.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
 
 #include "Dispatch.h"
 

--- a/contracts/wawaka/mock-contract/mock-contract.cpp
+++ b/contracts/wawaka/mock-contract/mock-contract.cpp
@@ -16,7 +16,6 @@
 #include <malloc.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
 
 #include "Dispatch.h"
 

--- a/docker/Dockerfile.pdo-dev
+++ b/docker/Dockerfile.pdo-dev
@@ -26,7 +26,7 @@
 
 # Build:
 #   $ docker build docker -f docker/Dockerfile.pdo-dev -t pdo-dev
-#   - if you want to build with different version than 18.04/bionic, say 20.04/focal, 
+#   - if you want to build with different version than 18.04/bionic, say 20.04/focal,
 #     add --build-arg UBUNTU_VERSION=18.04  --build-arg UBUNTU_NAME=focal
 #   - if behind a proxy, make sure you've configured ~/.docker/config.json with your proxy setting
 #     and the docker daemon itself also has the proxy properly configured, for systemd based hosts
@@ -50,11 +50,11 @@
 
 ARG UBUNTU_VERSION=18.04
 ARG UBUNTU_NAME=bionic
-# NOTE: 
+# NOTE:
 # - unfortunately, we do need both name (for repo) and version (for sgx directories), only docker image supports both ..
 #   18.04 <-> bionic, 20.04 <-> focal
-# - right now, full sgx support exists only for bionic; 
-#   xenial (16.04) has support only PSW but not SDK; 
+# - right now, full sgx support exists only for bionic;
+#   xenial (16.04) has support only PSW but not SDK;
 #   support for focal is still in the making but hopefully will exist soon...
 
 FROM ubuntu:${UBUNTU_VERSION}
@@ -128,9 +128,9 @@ RUN echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu ${U
  && apt-get install -y \
     # We do not need daemons like AESMD as we run them on host (side-steps also
     # issues with config of /etc/aesmd.conf like proxy ..). Without this option
-    # aesmd and lots of other plugsin are automatically pulled in. 
+    # aesmd and lots of other plugsin are automatically pulled in.
     # See SGX Installation notes and, in particular, linux/installer/docker/Dockerfile
-    # in linux-sgx git repo of sdk/psw source. 
+    # in linux-sgx git repo of sdk/psw source.
     --no-install-recommends \
     # - dependencies
       build-essential python \
@@ -141,15 +141,15 @@ RUN echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu ${U
     #   - basic architectural services, e.g., launch & attestation
       # sgx-aesm-service (see above why commented out)
       libsgx-uae-service
-      # Note: 
+      # Note:
       # - above is "old" style from epid days. Since sdk 2.7 libsgx-uae-service is
       #   split into subpackages
       #   - launch service
-      #     libsgx-launch 
+      #     libsgx-launch
       #   - algorithm agnostic attestation service
-      #     libsgx-quote-ex 
-      #   - EPID-based attestation service 
-      #     libsgx-epid 
+      #     libsgx-quote-ex
+      #   - EPID-based attestation service
+      #     libsgx-epid
       #   - DCAP-based attesation service
       #     libsgx-dcap* ...
       #   correspondingly, also libsgx_uae_service.so and <sgx_uae_service.h>
@@ -179,7 +179,7 @@ RUN [ "$UBUNTU_VERSION" = "18.04" ] \
   && tar -zxf ../${SGX_SDK_BINUTILS_FILE} \
   && rm ../${SGX_SDK_BINUTILS_FILE} \
   && echo "export PATH=/opt/intel/sgxsdk.extras/external/toolset/ubuntu${UBUNTU_VERSION}:${PATH}" >> /etc/profile.d/pdo.sh
-# Note: above install file contains binutitls for all supported distros. 
+# Note: above install file contains binutitls for all supported distros.
 #   So to same some space (~100m) & make smaller images one could delete
 #   all subdirectores other than ${UBUNTU_VERSION} ...
 ENV PATH="/opt/intel/sgxsdk.extras/external/toolset/ubuntu${UBUNTU_VERSION}:${PATH}"
@@ -210,17 +210,13 @@ RUN wget -q https://downloads.sourceforge.net/project/tinyscheme/tinyscheme/tiny
  && make FEATURES='-DUSE_DL=1 -DUSE_PLIST=1' \
  && echo "export TINY_SCHEME_SRC=$(pwd)" >> /etc/profile.d/pdo.sh
 
-#   - get emscripten tooling
-RUN mkdir -p /project/pdo/wasm/src \
- && cd /project/pdo/wasm/src \
- && git clone https://github.com/emscripten-core/emsdk.git \
- && cd emsdk \
- && git checkout 1.39.20 \
- && ./emsdk install latest-fastcomp \
- && ./emsdk activate latest-fastcomp \
- && echo 'cd /project/pdo/wasm/src/emsdk/; if [ -z "$BASH_SOURCE" ]; then BASH_SOURCE=./emsdk_env.sh; . ./emsdk_env.sh; unset BASH_SOURCE; else . ./emsdk_env.sh; fi' >> /etc/profile.d/pdo.sh
-# Note: above convoluted BASH_SOURCE hack is necessary as (a) emsdk_env.sh 
-#       assumes we run in bash but (b) as we build we actually run in sh
+#   - get wasi sdk
+RUN mkdir -p /opt/wasi-sdk
+WORKDIR /opt/wasi-sdk
+RUN wget -q https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk-12.0-linux.tar.gz \
+ && tar --strip-components=1 -zxf wasi-sdk-12.0-linux.tar.gz wasi-sdk-12.0 \
+ && rm wasi-sdk-12.0-linux.tar.gz \
+ && echo "export WASI_SDK_DIR=$(pwd)" >> /etc/profile.d/pdo.sh
 
 # Install ccf client. Unfortunately entire ccf base needs to be installed. there is no
 # installer for client alone

--- a/docker/Dockerfile.pdo-dev
+++ b/docker/Dockerfile.pdo-dev
@@ -211,12 +211,8 @@ RUN wget -q https://downloads.sourceforge.net/project/tinyscheme/tinyscheme/tiny
  && echo "export TINY_SCHEME_SRC=$(pwd)" >> /etc/profile.d/pdo.sh
 
 #   - get wasi sdk
-RUN mkdir -p /opt/wasi-sdk
-WORKDIR /opt/wasi-sdk
-RUN wget -q https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk-12.0-linux.tar.gz \
- && tar --strip-components=1 -zxf wasi-sdk-12.0-linux.tar.gz wasi-sdk-12.0 \
- && rm wasi-sdk-12.0-linux.tar.gz \
- && echo "export WASI_SDK_DIR=$(pwd)" >> /etc/profile.d/pdo.sh
+RUN wget -q -P /tmp https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk_12.0_amd64.deb \
+ && dpkg --install /tmp/wasi-sdk_12.0_amd64.deb
 
 # Install ccf client. Unfortunately entire ccf base needs to be installed. there is no
 # installer for client alone

--- a/docker/README.md
+++ b/docker/README.md
@@ -35,6 +35,29 @@ and `no_proxy` environment variables defined, it essentially means:
   systemctl daemon-reload
   systemctl restart docker
 ```
+
+You also need to ensure that your docker configuration file
+(`.docker/config.json`) contains an appropriate configuration for the
+proxies. For example, if you don't currently have a configuration file,
+the following will create one to support currently defined proxies:
+
+```bash
+mkdir ~/.docker
+cat >> ~/.docker/config.json.new << EOM
+{
+  "proxies":
+  {
+    "default":
+    {
+      "httpProxy": "${http_proxy}",
+      "httpsProxy": "${https_proxy}",
+      "noProxy": "${no_proxy}"
+    }
+  }
+}
+EOM
+```
+
 If your system runs systemd-resolved (which is now default for
 ubuntu), make sure you are running a version 18.09 of docker or
 greater. Recently refreshed versions of ubuntu 18.04 should meet this
@@ -77,7 +100,7 @@ By default it will build and run tests only in SGX simulator mode but
 the makefile does honor
 the `SGX_MODE` environment variable if you want to test in SGX HW
 mode (in which case, though, you will have to put proper sgx attestation info
-files (`sgx_spid.txt`,  `sgx_spid_api_key`, `sgx_ias_key.pem`) into the 
+files (`sgx_spid.txt`,  `sgx_spid_api_key`, `sgx_ias_key.pem`) into the
 sgx sub-directory or define the `PDO_SGX_KEY_ROOT` environment variable to
 point to a suiteable destination.
 See `../build/common-config.sh --help` for more information on


### PR DESCRIPTION
Deprecate the use of emscripten for developing contracts for wawaka. We have struggled to support current version of emscripten. In an attempt to be more consistent with WAMR, this PR moves the toolchain to [WASI-SDK](https://github.com/WebAssembly/wasi-sdk). 

The migration enables the use of many classes from the C++ std library (strings, vectors, ...) which should make it significantly easier to write wawaka contracts.