### PR TITLE
Fix build of IAS certs

### DIFF
--- a/common/crypto/verify_ias_report/build_ias_certificates_cpp.sh
+++ b/common/crypto/verify_ias_report/build_ias_certificates_cpp.sh
@@ -28,24 +28,20 @@ fi
 Cleanup () {
     echo "Cleaning up"
     rm ias-certificates.cpp.tmp -f
-    rm RK_PUB.zip -f
-    rm AttestationReportSigningCACert.pem -f
+    rm Intel_SGX_Attestation_RootCA.pem -f
 }
 
 trap 'echo "**ERROR - line $LINENO**"; Cleanup; exit 1' HUP INT QUIT PIPE TERM ERR
 
 #get certificate from Intel
-wget https://software.intel.com/sites/default/files/managed/7b/de/RK_PUB.zip
-test -e RK_PUB.zip
-echo "Zipped certificated downloaded"
-
-unzip -o RK_PUB.zip
-test -e AttestationReportSigningCACert.pem
+wget https://certificates.trustedservices.intel.com/Intel_SGX_Attestation_RootCA.pem
+test -e Intel_SGX_Attestation_RootCA.pem
+echo "Certificate downloaded"
 
 echo ""
 echo -n "Building ias-certificates.cpp ... "
 #replace the placemark in the template with the der certificate
-sed -e '/IAS_REPORT_SIGNING_CA_CERT_PEM_PLACEMARK/ r ./AttestationReportSigningCACert.pem' -e 's/IAS_REPORT_SIGNING_CA_CERT_PEM_PLACEMARK//' < ias-certificates.template > ias-certificates.cpp
+sed -e '/IAS_REPORT_SIGNING_CA_CERT_PEM_PLACEMARK/ r ./Intel_SGX_Attestation_RootCA.pem' -e 's/IAS_REPORT_SIGNING_CA_CERT_PEM_PLACEMARK//' < ias-certificates.template > ias-certificates.cpp
 test -e ias-certificates.cpp
 echo "done"
 


### PR DESCRIPTION
The IAS root certificate has moved to a different location, so the build fails in HW mode.
This PR fixes the issue.

Signed-off-by: Bruno Vavala <bruno.vavala@intel.com>