### PR TITLE
Upgrade WAMR to WAMR-04-15-2021 release

### DIFF
--- a/common/interpreter/wawaka_wasm/README.md
+++ b/common/interpreter/wawaka_wasm/README.md
@@ -31,7 +31,7 @@ There are many toolchains that could be used to build a WASM code. By default, W
 compiled with the compilers provided by [WASI SDK](https://github.com/WebAssembly/wasi-sdk). To use
 WASI SDK, download and install the appropriate package file from
 https://github.com/WebAssembly/wasi-sdk/releases (we have verified that release wasi-sdk-12 works
-with WAMR version WAMR-03-25-2021).
+with WAMR version WAMR-04-15-2021).
 
 ```bash
 wget -q -P /tmp https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk_12.0_amd64.deb
@@ -46,14 +46,14 @@ SDK would be installed in the directory `/opt/wasi-sdk`.
 If wawaka is configured as the contract interpreter, the libraries implementing the WASM interpreter
 will be built for use with Intel SGX. The source for the WAMR interpreter is
 included as a submodule in the interpreters/ folder, and will
-always point to the latest tagged commit that we have validated: `WAMR-03-25-2021`.
+always point to the latest tagged commit that we have validated: `WAMR-04-15-2021`.
 If the PDO parent repo was not cloned with the `--recurse-submodules` flag,
 you will have to explictly pull the submodule source.
 
 ```
 cd ${PDO_SOURCE_ROOT}/interpreters/wasm-micro-runtime
 git submodule update --init
-git checkout WAMR-03-25-2021 # optional
+git checkout WAMR-04-15-2021 # optional
 ```
 
 The WAMR API is built during the Wawaka build, so no additional

--- a/docker/Dockerfile.pdo-build
+++ b/docker/Dockerfile.pdo-build
@@ -24,7 +24,7 @@
 #  - pdo repo branch to use:			PDO_REPO_BRANCH (default: master)
 #  - build in debug mode:			PDO_DEBUG_BUILD (default: 0)
 #  - contract interpreter (gipsy or wawaka):	PDO_INTERPRETER (default: gipsy)
-#  - wamr version:		                WAMR    (default: WAMR-01-29-2021)
+#  - wamr version:		                WAMR    (default: WAMR-04-15-2021)
 
 # Build:
 #   $ docker build -f docker/Dockerfile.pdo-build -t pdo-build docker
@@ -109,7 +109,7 @@ ENV PDO_LEDGER_KEY_ROOT=${PDO_LEDGER_KEY_ROOT}
 
 # - web-assembly/wasm/wawaka
 #   - Configure WAMR source
-ARG WAMR=WAMR-01-29-2021
+ARG WAMR=WAMR-04-15-2021
 RUN cd /project/pdo/src/private-data-objects/interpreters/wasm-micro-runtime \
  && git checkout ${WAMR}\
  && echo "export WASM_SRC=$(pwd)" >> /etc/profile.d/pdo.sh

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -118,7 +118,7 @@ the contract enclave.
 `WASM_SRC` points to the installation of the wasm-micro-runtime. This
 is used to build the WASM interpreter for the wawaka contract interpreter.
 The git submodule points to the latest tagged commit of [WAMR](https://github.com/bytecodealliance/wasm-micro-runtime) we have validated:
-`WAMR-01-29-2021`.
+`WAMR-04-15-2021`.
 
 <!-- -------------------------------------------------- -->
 ### `WASM_MEM_CONFIG`


### PR DESCRIPTION
This latest release implements auxiliary stack overflow/underflow check for WAMR in AOT/JIT/interpreter modes, implements a realloc wrapper in the builtin libc, and fixes several issues when using libpthread.

See https://github.com/bytecodealliance/wasm-micro-runtime/releases/tag/WAMR-04-15-2021 for the full release notes.