### PR TITLE
Bump RSA key size

### DIFF
--- a/common/crypto/pkenc.h
+++ b/common/crypto/pkenc.h
@@ -23,7 +23,7 @@ namespace crypto
     {
         //***RSA is not quantum resistant ***//
         //*** USE 3072 for long term security ***//
-        const int RSA_KEY_SIZE = 2048;
+        const int RSA_KEY_SIZE = 3072;
         const int RSA_PADDING_SIZE = 41;
 
         //*** OAEP or better should always be used for RSA encrytpion ***//


### PR DESCRIPTION
This PR bumps the default RSA key size to 3072 bits as recommended by NIST. Moreover, this PR is motivated by the use of the PDO crypto lib by Fabric Private Chaincode, see corresponding [issue](https://github.com/hyperledger/fabric-private-chaincode/issues/478).

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>