### PR TITLE
Make elliptic curve parameterizable

### DIFF
--- a/common/crypto/sig.h
+++ b/common/crypto/sig.h
@@ -27,7 +27,7 @@ namespace crypto
     namespace constants
     {
         // Elliptic curve
-        const int CURVE = NID_secp256k1;
+        const int CURVE = PDO_USE_ECDSA_CURVE;
         const int MAX_SIG_SIZE = 72;
     }
 }

--- a/common/crypto/sig.h
+++ b/common/crypto/sig.h
@@ -15,6 +15,11 @@
 
 #pragma once
 #include <openssl/obj_mac.h>
+
+#ifndef PDO_USE_ECDSA_CURVE
+#define PDO_USE_ECDSA_CURVE NID_secp256k1
+#endif
+
 namespace pdo
 {
 namespace crypto


### PR DESCRIPTION
This allows to define the elliptic curve used by the PDO crypto via the
-DPDO_USE_ECDSA_CURVE flag during compile time. When not defined, the
default curve is secp256k1 as used in BTC. This commit is motivated by
the use of the PDO crypto with Fabric Private Chaincode. In Fabric,
however, the default ellipctic curve is secp256r1 (aka prime256v1). This
compile flag allows to change the curve when used with FPC to be
complient with Fabric.

Signed-off-by: Marcus Brandenburger <bur@zurich.ibm.com>