### PR TITLE
Add policy-based verification of additional quote statuses

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -8,7 +8,7 @@ AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 #AlignAfterOpenBracket: Align
-AlignAfterOpenBracket: DontAlign
+AlignAfterOpenBracket: Align
 ColumnLimit:     100
 BraceWrapping:
   AfterClass:      true
@@ -27,3 +27,4 @@ NamespaceIndentation: Inner
 DerivePointerAlignment: false
 AccessModifierOffset: -4
 BinPackParameters: false
+BinPackArguments: false

--- a/common/crypto/CMakeLists.txt
+++ b/common/crypto/CMakeLists.txt
@@ -52,7 +52,7 @@ ENDIF()
 SET(COMMON_CXX_FLAGS ${IAS_CA_CERT_REQUIRED_FLAGS} "-m64" "-fvisibility=hidden" "-fpie" "-fPIC" "-fstack-protector" "-std=c++11" "-Wall")
 
 # required for: `types.h` and `error.h` in common
-SET(PRIVATE_DEPS_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/.." "${CMAKE_CURRENT_SOURCE_DIR}/../packages/base64")
+SET(PRIVATE_DEPS_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/.." "${CMAKE_CURRENT_SOURCE_DIR}/../packages/base64" "${CMAKE_CURRENT_SOURCE_DIR}/../packages/parson")
 
 # required for:`sgx_error.h` in sgx-sdk
 SET(PUBLIC_INCLUDE_DIRS "$ENV{SGX_SDK}/include")

--- a/common/crypto/verify_ias_report/verify-report.cpp
+++ b/common/crypto/verify_ias_report/verify-report.cpp
@@ -32,8 +32,10 @@
 /* EVP_DecodeBlock pads its output with \0 if the output length is not
    a multiple of 3. Check if the base64 string is padded at the end
    and adjust the output length. */
-static int EVP_DecodeBlock_wrapper(
-    unsigned char* out, int out_len, const unsigned char* in, int in_len)
+static int EVP_DecodeBlock_wrapper(unsigned char* out,
+                                   int out_len,
+                                   const unsigned char* in,
+                                   int in_len)
 {
     /* Use a temporary output buffer. We do not want to disturb the
        original output buffer with extraneous \0 bytes. */
@@ -63,13 +65,17 @@ err:
 
 #define IAS_QUOTE_STATUS_JSON_STRING "isvEnclaveQuoteStatus"
 
-struct qss {
+struct qss
+{
     const char* s;
     size_t l;
 };
 
-#define MAKE_QSS_ITEM(x) {x, sizeof(x) - 1}
-#define INIT_QS_ARRAY_ITEM(x, y) [x]=MAKE_QSS_ITEM(y)
+#define MAKE_QSS_ITEM(x) \
+    {                    \
+        x, sizeof(x) - 1 \
+    }
+#define INIT_QS_ARRAY_ITEM(x, y) [x] = MAKE_QSS_ITEM(y)
 
 const struct qss quote_status[QS_NUMBER] = {
     INIT_QS_ARRAY_ITEM(QS_INVALID, "INVALID"),
@@ -77,8 +83,8 @@ const struct qss quote_status[QS_NUMBER] = {
     INIT_QS_ARRAY_ITEM(QS_GROUP_OUT_OF_DATE, "GROUP_OUT_OF_DATE"),
     INIT_QS_ARRAY_ITEM(QS_CONFIGURATION_NEEDED, "CONFIGURATION_NEEDED"),
     INIT_QS_ARRAY_ITEM(QS_SW_HARDENING_NEEDED, "SW_HARDENING_NEEDED"),
-    INIT_QS_ARRAY_ITEM(QS_CONFIGURATION_AND_SW_HARDENING_NEEDED, "CONFIGURATION_AND_SW_HARDENING_NEEDED")
-};
+    INIT_QS_ARRAY_ITEM(QS_CONFIGURATION_AND_SW_HARDENING_NEEDED,
+                       "CONFIGURATION_AND_SW_HARDENING_NEEDED")};
 
 quote_status_e get_quote_status(const char* ias_report, unsigned int ias_report_len)
 {
@@ -96,12 +102,12 @@ quote_status_e get_quote_status(const char* ias_report, unsigned int ias_report_
 
     s = json_object_get_string(jo, IAS_QUOTE_STATUS_JSON_STRING);
     COND2ERR(s == NULL);
-    s_length = strnlen(s, ias_report_len); // s is null-terminated by parson; s_length < ias_report_len
+    // s is null-terminated by parson; s_length < ias_report_len
+    s_length = strnlen(s, ias_report_len);
 
     for (i = 1; i < QS_NUMBER; i++)
     {
-        if (s_length == quote_status[i].l &&
-            0 == strncmp(s, quote_status[i].s, s_length))
+        if (s_length == quote_status[i].l && 0 == strncmp(s, quote_status[i].s, s_length))
         {
             return (quote_status_e)i;
         }
@@ -156,10 +162,10 @@ err:
 }
 
 verify_status_t verify_ias_report_signature(const char* ias_attestation_signing_cert_pem,
-    const char* ias_report,
-    unsigned int ias_report_len,
-    char* ias_signature,
-    unsigned int ias_signature_len)
+                                            const char* ias_report,
+                                            unsigned int ias_report_len,
+                                            char* ias_signature,
+                                            unsigned int ias_signature_len)
 {
     X509* crt = NULL;
     int ret = -1;
@@ -184,8 +190,10 @@ verify_status_t verify_ias_report_signature(const char* ias_attestation_signing_
     ret = EVP_VerifyUpdate(ctx, ias_report, ias_report_len);
     COND2ERR(ret != 1);
 
-    ret = EVP_DecodeBlock_wrapper(ias_signature_decoded, ias_signature_decoded_len,
-        (unsigned char*)ias_signature, ias_signature_len);
+    ret = EVP_DecodeBlock_wrapper(ias_signature_decoded,
+                                  ias_signature_decoded_len,
+                                  (unsigned char*)ias_signature,
+                                  ias_signature_len);
     COND2ERR(ret == -1);
 
     ret = EVP_VerifyFinal(ctx, (unsigned char*)ias_signature_decoded, ret, key);
@@ -267,8 +275,9 @@ err:
  *
  * @return 0 if verified successfully, 1 otherwise.
  */
-verify_status_t verify_enclave_quote_status(
-    const char* ias_report, unsigned int ias_report_len, unsigned int quote_status_flags)
+verify_status_t verify_enclave_quote_status(const char* ias_report,
+                                            unsigned int ias_report_len,
+                                            unsigned int quote_status_flags)
 {
     quote_status_e qs;
 

--- a/common/crypto/verify_ias_report/verify-report.h
+++ b/common/crypto/verify_ias_report/verify-report.h
@@ -18,34 +18,57 @@
 
 #include <sgx_quote.h>
 
-typedef enum {
+typedef enum
+{
     VERIFY_SUCCESS,
     VERIFY_FAILURE
 } verify_status_t;
+
+typedef enum
+{
+    QS_INVALID,
+    QS_OK,
+    QS_GROUP_OUT_OF_DATE,
+    QS_CONFIGURATION_NEEDED,
+    QS_SW_HARDENING_NEEDED,
+    QS_CONFIGURATION_AND_SW_HARDENING_NEEDED,
+    QS_NUMBER
+} quote_status_e;
+
+#define QSF_ACCEPT_GROUP_OUT_OF_DATE (1 << QS_GROUP_OUT_OF_DATE)
+#define QSF_ACCEPT_CONFIGURATION_NEEDED (1 << QS_CONFIGURATION_NEEDED)
+#define QSF_ACCEPT_SW_HARDENING_NEEDED (1 << QS_SW_HARDENING_NEEDED)
+#define QSF_ACCEPT_CONFIGURATION_AND_SW_HARDENING_NEEDED \
+    (1 << QS_CONFIGURATION_AND_SW_HARDENING_NEEDED)
+#define QSF_ACCEPT_ALL UINT_MAX
+#define QSF_REJECT_ALL (0)
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 int get_quote_from_report(const uint8_t* report, const int report_len, sgx_quote_t* quote);
-verify_status_t verify_enclave_quote_status(const char* ias_report, int ias_report_len, int group_out_of_date_is_ok);
+verify_status_t verify_enclave_quote_status(
+    const char* ias_report, unsigned int ias_report_len, unsigned int quote_status_flags);
 verify_status_t verify_ias_certificate_chain(const char* cert_pem);
 verify_status_t verify_ias_report_signature(const char* ias_attestation_signing_cert_pem,
-                                            const char* ias_report,
-                                            unsigned int ias_report_len,
-                                            char* ias_signature,
-                                            unsigned int ias_signature_len);
+    const char* ias_report,
+    unsigned int ias_report_len,
+    char* ias_signature,
+    unsigned int ias_signature_len);
+
+quote_status_e get_quote_status(const char* ias_report, unsigned int ias_report_len);
 #ifdef __cplusplus
 }
 #endif
 
-#define COND2ERR(b) \
-    do \
-    { \
-        if(b) \
-        { \
+#define COND2ERR(b)   \
+    do                \
+    {                 \
+        if (b)        \
+        {             \
             goto err; \
-        } \
-    } while(0)
+        }             \
+    } while (0)
 
 #endif

--- a/common/crypto/verify_ias_report/verify-report.h
+++ b/common/crypto/verify_ias_report/verify-report.h
@@ -48,14 +48,15 @@ extern "C" {
 #endif
 
 int get_quote_from_report(const uint8_t* report, const int report_len, sgx_quote_t* quote);
-verify_status_t verify_enclave_quote_status(
-    const char* ias_report, unsigned int ias_report_len, unsigned int quote_status_flags);
+verify_status_t verify_enclave_quote_status(const char* ias_report,
+                                            unsigned int ias_report_len,
+                                            unsigned int quote_status_flags);
 verify_status_t verify_ias_certificate_chain(const char* cert_pem);
 verify_status_t verify_ias_report_signature(const char* ias_attestation_signing_cert_pem,
-    const char* ias_report,
-    unsigned int ias_report_len,
-    char* ias_signature,
-    unsigned int ias_signature_len);
+                                            const char* ias_report,
+                                            unsigned int ias_report_len,
+                                            char* ias_signature,
+                                            unsigned int ias_signature_len);
 
 quote_status_e get_quote_status(const char* ias_report, unsigned int ias_report_len);
 #ifdef __cplusplus

--- a/common/tests/crypto/testCrypto.cpp
+++ b/common/tests/crypto/testCrypto.cpp
@@ -15,16 +15,17 @@
 
 //***Unit Test***////
 #include "testCrypto.h"
-#include "crypto.h"
-#include "error.h"
-#include "log.h"
-#include "pdo_error.h"
-#include "c11_support.h"
-#include "crypto/verify_ias_report/ias-certificates.h"
-
 
 #include <assert.h>
 #include <string.h>
+
+#include "c11_support.h"
+#include "crypto.h"
+#include "crypto/verify_ias_report/ias-certificates.h"
+#include "error.h"
+#include "log.h"
+#include "packages/parson/parson.h"
+#include "pdo_error.h"
 #if _UNTRUSTED_
 
 #include <openssl/crypto.h>
@@ -62,7 +63,8 @@ int pcrypto::testCrypto()
     try
     {
         rand = pcrypto::RandomBitString(0);
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: RandomBitString invalid length argument undetected.\n");
+        SAFE_LOG(
+            PDO_LOG_ERROR, "testCrypto: RandomBitString invalid length argument undetected.\n");
         return -1;
     }
     catch (const Error::ValueError& e)
@@ -75,7 +77,8 @@ int pcrypto::testCrypto()
         return -1;
     }
 
-    SAFE_LOG(PDO_LOG_DEBUG, "RandomBitString test successful!\n%s\n\n", ByteArrayToBase64EncodedString(rand).c_str());
+    SAFE_LOG(PDO_LOG_DEBUG, "RandomBitString test successful!\n%s\n\n",
+        ByteArrayToBase64EncodedString(rand).c_str());
 
     // Test ECDSA key management functions
     try
@@ -102,7 +105,8 @@ int pcrypto::testCrypto()
     }
     catch (const Error::RuntimeError& e)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: ECDSA keypair constructors test failed.\n%s\n", e.what());
+        SAFE_LOG(
+            PDO_LOG_ERROR, "testCrypto: ECDSA keypair constructors test failed.\n%s\n", e.what());
         return -1;
     }
 
@@ -121,7 +125,8 @@ int pcrypto::testCrypto()
     }
     catch (const Error::RuntimeError& e)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: Serialize ECDSA private key test failed.\n%s\n", e.what());
+        SAFE_LOG(
+            PDO_LOG_ERROR, "testCrypto: Serialize ECDSA private key test failed.\n%s\n", e.what());
         return -1;
     }
 
@@ -132,7 +137,8 @@ int pcrypto::testCrypto()
     }
     catch (const Error::RuntimeError& e)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: Serialize ECDSA public key test failed.\n%s\n", e.what());
+        SAFE_LOG(
+            PDO_LOG_ERROR, "testCrypto: Serialize ECDSA public key test failed.\n%s\n", e.what());
         return -1;
     }
 
@@ -148,7 +154,8 @@ int pcrypto::testCrypto()
     }
     catch (const Error::ValueError& e)
     {
-        SAFE_LOG(PDO_LOG_DEBUG, "testCrypto: Deserialize invalid ECDSA private key detected!\n%s\n", e.what());
+        SAFE_LOG(PDO_LOG_DEBUG, "testCrypto: Deserialize invalid ECDSA private key detected!\n%s\n",
+            e.what());
     }
     catch (const Error::RuntimeError& e)
     {
@@ -165,7 +172,8 @@ int pcrypto::testCrypto()
     }
     catch (const Error::ValueError& e)
     {
-        SAFE_LOG(PDO_LOG_DEBUG, "testCrypto: Deserialize invalid ECDSA public key detected!\n%s\n", e.what());
+        SAFE_LOG(PDO_LOG_DEBUG, "testCrypto: Deserialize invalid ECDSA public key detected!\n%s\n",
+            e.what());
     }
     catch (const Error::RuntimeError& e)
     {
@@ -196,11 +204,13 @@ int pcrypto::testCrypto()
     }
     catch (const Error::RuntimeError& e)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: Deserialize ECDSA keypair test failed.\n%s\n", e.what());
+        SAFE_LOG(
+            PDO_LOG_ERROR, "testCrypto: Deserialize ECDSA keypair test failed.\n%s\n", e.what());
         return -1;
     }
 
-    SAFE_LOG(PDO_LOG_DEBUG, "testCrypto: Serialize/Deserialize ECDSA keypairs tests successful!\n\n");
+    SAFE_LOG(
+        PDO_LOG_DEBUG, "testCrypto: Serialize/Deserialize ECDSA keypairs tests successful!\n\n");
     // Test ComputeMessageHash
 
     std::string msgStr("Proof of Elapsed Time");
@@ -221,8 +231,8 @@ int pcrypto::testCrypto()
 
     // Test ComputeMessageHMAC
 
-    {//test expected hmac
-        ByteArray hmackey {4, 6, 8, 5, 1, 2, 3, 4, 3, 4, 7, 8, 9, 7, 8, 0};
+    {  // test expected hmac
+        ByteArray hmackey{4, 6, 8, 5, 1, 2, 3, 4, 3, 4, 7, 8, 9, 7, 8, 0};
         std::string msgStr("Proof of Elapsed Time");
         ByteArray msg;
         msg.insert(msg.end(), msgStr.data(), msgStr.data() + msgStr.size());
@@ -238,8 +248,8 @@ int pcrypto::testCrypto()
         }
     }
 
-    {//test unexpected hmac (due to wrong key)
-        ByteArray hmackey {0, 6, 8, 5, 1, 2, 3, 4, 3, 4, 7, 8, 9, 7, 8, 0};
+    {  // test unexpected hmac (due to wrong key)
+        ByteArray hmackey{0, 6, 8, 5, 1, 2, 3, 4, 3, 4, 7, 8, 9, 7, 8, 0};
         std::string msgStr("Proof of Elapsed Time");
         ByteArray msg;
         msg.insert(msg.end(), msgStr.data(), msgStr.data() + msgStr.size());
@@ -248,13 +258,14 @@ int pcrypto::testCrypto()
         std::string hmacStr_B64 = ByteArrayToBase64EncodedString(hmac);
         if (hmacStr_B64.compare(msg_SHA256HMAC_B64) == 0)
         {
-            SAFE_LOG(PDO_LOG_ERROR, "testCrypto: ComputeMessageHMAC, wrong key test shoud have failed.\n");
+            SAFE_LOG(PDO_LOG_ERROR,
+                "testCrypto: ComputeMessageHMAC, wrong key test shoud have failed.\n");
             return -1;
         }
     }
 
-    {//test unexpected hmac (due to wrong message)
-        ByteArray hmackey {4, 6, 8, 5, 1, 2, 3, 4, 3, 4, 7, 8, 9, 7, 8, 0};
+    {  // test unexpected hmac (due to wrong message)
+        ByteArray hmackey{4, 6, 8, 5, 1, 2, 3, 4, 3, 4, 7, 8, 9, 7, 8, 0};
         std::string msgStr("proof of Elapsed Time");
         ByteArray msg;
         msg.insert(msg.end(), msgStr.data(), msgStr.data() + msgStr.size());
@@ -263,50 +274,53 @@ int pcrypto::testCrypto()
         std::string hmacStr_B64 = ByteArrayToBase64EncodedString(hmac);
         if (hmacStr_B64.compare(msg_SHA256HMAC_B64) == 0)
         {
-            SAFE_LOG(PDO_LOG_ERROR, "testCrypto: ComputeMessageHMAC, wrong message test should have failed.\n");
+            SAFE_LOG(PDO_LOG_ERROR,
+                "testCrypto: ComputeMessageHMAC, wrong message test should have failed.\n");
             return -1;
         }
     }
 
-    {//test big key big data hmac
-        ByteArray hmackey(1<<18, 0);
-        ByteArray msg(1<<18, 1);
+    {  // test big key big data hmac
+        ByteArray hmackey(1 << 18, 0);
+        ByteArray msg(1 << 18, 1);
         try
         {
             ByteArray hmac = ComputeMessageHMAC(hmackey, msg);
         }
-        catch(...)
+        catch (...)
         {
             SAFE_LOG(PDO_LOG_ERROR, "testCrypto: ComputeMessageHMAC, test big key/data failed.\n");
             return -1;
         }
     }
 
-    {//test zero key hmac
+    {  // test zero key hmac
         ByteArray hmackey;
-        ByteArray msg(1,0);
+        ByteArray msg(1, 0);
         try
         {
             ByteArray hmac = ComputeMessageHMAC(hmackey, msg);
-            throw pdo::error::RuntimeError("testCrypto: ComputeMessageHMAC, test zero key should have failed.\n");
+            throw pdo::error::RuntimeError(
+                "testCrypto: ComputeMessageHMAC, test zero key should have failed.\n");
         }
-        catch(...)
+        catch (...)
         {
-            //test success, do nothing
+            // test success, do nothing
         }
     }
 
-    {//test zero data hmac
-        ByteArray hmackey(1,0);
+    {  // test zero data hmac
+        ByteArray hmackey(1, 0);
         ByteArray msg;
         try
         {
             ByteArray hmac = ComputeMessageHMAC(hmackey, msg);
-            throw pdo::error::RuntimeError("testCrypto: ComputeMessageHMAC, test zero data should have failed.\n");
+            throw pdo::error::RuntimeError(
+                "testCrypto: ComputeMessageHMAC, test zero data should have failed.\n");
         }
-        catch(...)
+        catch (...)
         {
-            //test success, do nothing
+            // test success, do nothing
         }
     }
 
@@ -321,7 +335,8 @@ int pcrypto::testCrypto()
     }
     catch (const Error::RuntimeError& e)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: SignMessage test failed, signature not computed.\n%s\n", e.what());
+        SAFE_LOG(PDO_LOG_ERROR,
+            "testCrypto: SignMessage test failed, signature not computed.\n%s\n", e.what());
         return -1;
     }
     SAFE_LOG(PDO_LOG_DEBUG, "testCrypto: SignMessage test passed!\n\n");
@@ -348,7 +363,8 @@ int pcrypto::testCrypto()
     }
     catch (const Error::RuntimeError& e)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: SignMessage test failed, signature not computed.\n%s\n", e.what());
+        SAFE_LOG(PDO_LOG_ERROR,
+            "testCrypto: SignMessage test failed, signature not computed.\n%s\n", e.what());
         return -1;
     }
 
@@ -360,7 +376,8 @@ int pcrypto::testCrypto()
     }
     if (res == 1)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: VerifySignature test failed, invalid message not detected!\n");
+        SAFE_LOG(PDO_LOG_ERROR,
+            "testCrypto: VerifySignature test failed, invalid message not detected!\n");
         return -1;
     }
 
@@ -373,7 +390,8 @@ int pcrypto::testCrypto()
     }
     if (res == 1)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: VerifySignature test failed, invalid signature not detected!\n");
+        SAFE_LOG(PDO_LOG_ERROR,
+            "testCrypto: VerifySignature test failed, invalid signature not detected!\n");
         return -1;
     }
     SAFE_LOG(PDO_LOG_DEBUG, "testCrypto: VerifySignature, invalid signature detected!\n");
@@ -406,7 +424,8 @@ int pcrypto::testCrypto()
     }
     catch (const Error::RuntimeError& e)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: RSA keypair constructors test failed.\n%s\n", e.what());
+        SAFE_LOG(
+            PDO_LOG_ERROR, "testCrypto: RSA keypair constructors test failed.\n%s\n", e.what());
         return -1;
     }
 
@@ -425,7 +444,8 @@ int pcrypto::testCrypto()
     }
     catch (const Error::RuntimeError& e)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: RSA private key serialize test failed.\n%s\n", e.what());
+        SAFE_LOG(
+            PDO_LOG_ERROR, "testCrypto: RSA private key serialize test failed.\n%s\n", e.what());
         return -1;
     }
 
@@ -436,7 +456,8 @@ int pcrypto::testCrypto()
     }
     catch (const Error::RuntimeError& e)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: RSA public key serialize test failed.\n%s\n", e.what());
+        SAFE_LOG(
+            PDO_LOG_ERROR, "testCrypto: RSA public key serialize test failed.\n%s\n", e.what());
         return -1;
     }
 
@@ -453,7 +474,8 @@ int pcrypto::testCrypto()
     }
     catch (const Error::ValueError& e)
     {
-        SAFE_LOG(PDO_LOG_DEBUG, "testCrypto: RSA invalid private key deserialize detected!\n%s\n", e.what());
+        SAFE_LOG(PDO_LOG_DEBUG, "testCrypto: RSA invalid private key deserialize detected!\n%s\n",
+            e.what());
     }
     catch (const std::exception& e)
     {
@@ -472,11 +494,13 @@ int pcrypto::testCrypto()
     }
     catch (const Error::ValueError& e)
     {
-        SAFE_LOG(PDO_LOG_DEBUG, "testCrypto: RSA invalid public key deserialize detected!\n%s\n", e.what());
+        SAFE_LOG(PDO_LOG_DEBUG, "testCrypto: RSA invalid public key deserialize detected!\n%s\n",
+            e.what());
     }
     catch (const Error::RuntimeError& e)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: RSA invalid public key deserialize internal error!\n%s\n", e.what());
+        SAFE_LOG(PDO_LOG_ERROR,
+            "testCrypto: RSA invalid public key deserialize internal error!\n%s\n", e.what());
         return -1;
     }
 
@@ -514,7 +538,8 @@ int pcrypto::testCrypto()
     }
     catch (const Error::ValueError& e)
     {
-        SAFE_LOG(PDO_LOG_DEBUG, "testCrypto: RSA decryption test invalid RSA ciphertext correctly detected!\n");
+        SAFE_LOG(PDO_LOG_DEBUG,
+            "testCrypto: RSA decryption test invalid RSA ciphertext correctly detected!\n");
     }
     catch (const std::exception& e)
     {
@@ -566,12 +591,14 @@ int pcrypto::testCrypto()
     try
     {
         ctAES = pcrypto::skenc::EncryptMessage(key, iv, empty);
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: AES-GCM empty message encryption test failed: undetected.\n");
+        SAFE_LOG(PDO_LOG_ERROR,
+            "testCrypto: AES-GCM empty message encryption test failed: undetected.\n");
         return -1;
     }
     catch (const std::exception& e)
     {
-        SAFE_LOG(PDO_LOG_DEBUG, "testCrypto: AES-GCM empty message encryption test successful (detected)!\n%s\n",
+        SAFE_LOG(PDO_LOG_DEBUG,
+            "testCrypto: AES-GCM empty message encryption test successful (detected)!\n%s\n",
             e.what());
     }
 
@@ -609,7 +636,8 @@ int pcrypto::testCrypto()
     try
     {
         ctAES = pcrypto::skenc::EncryptMessage(empty, iv, msg);
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: AES-GCM encryption test failed, bad key undetected.\n");
+        SAFE_LOG(
+            PDO_LOG_ERROR, "testCrypto: AES-GCM encryption test failed, bad key undetected.\n");
         return -1;
     }
     catch (const Error::ValueError& e)
@@ -625,16 +653,19 @@ int pcrypto::testCrypto()
     try
     {
         ctAES = pcrypto::skenc::EncryptMessage(empty, msg);
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: AES-GCM (random IV) encryption test failed, bad key undetected.\n");
+        SAFE_LOG(PDO_LOG_ERROR,
+            "testCrypto: AES-GCM (random IV) encryption test failed, bad key undetected.\n");
         return -1;
     }
     catch (const Error::ValueError& e)
     {
-        SAFE_LOG(PDO_LOG_DEBUG, "testCrypto: AES-GCM (random IV) encryption correct, bad key detected!\n\n");
+        SAFE_LOG(PDO_LOG_DEBUG,
+            "testCrypto: AES-GCM (random IV) encryption correct, bad key detected!\n\n");
     }
     catch (const std::exception& e)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: AES-GCM (random IV) encryption test failed.\n%s\n", e.what());
+        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: AES-GCM (random IV) encryption test failed.\n%s\n",
+            e.what());
         return -1;
     }
 
@@ -670,7 +701,8 @@ int pcrypto::testCrypto()
     try
     {
         ptAES = pcrypto::skenc::DecryptMessage(empty, iv, ctAES);
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: AES-GCM decryption test failed, bad key undetected.\n");
+        SAFE_LOG(
+            PDO_LOG_ERROR, "testCrypto: AES-GCM decryption test failed, bad key undetected.\n");
         return -1;
     }
     catch (const Error::ValueError& e)
@@ -743,7 +775,8 @@ int pcrypto::testCrypto()
     }
     catch (const std::exception& e)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: AES-GCM (random IV) encryption test failed.\n%s\n", e.what());
+        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: AES-GCM (random IV) encryption test failed.\n%s\n",
+            e.what());
         return -1;
     }
 
@@ -751,16 +784,19 @@ int pcrypto::testCrypto()
     try
     {
         ptAES = pcrypto::skenc::DecryptMessage(empty, ctAES);
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: AES-GCM (random IV) decryption test failed, bad key undetected.\n");
+        SAFE_LOG(PDO_LOG_ERROR,
+            "testCrypto: AES-GCM (random IV) decryption test failed, bad key undetected.\n");
         return -1;
     }
     catch (const Error::ValueError& e)
     {
-        SAFE_LOG(PDO_LOG_DEBUG, "testCrypto: AES-GCM (random IV) decryption correct, bad key detected!\n\n");
+        SAFE_LOG(PDO_LOG_DEBUG,
+            "testCrypto: AES-GCM (random IV) decryption correct, bad key detected!\n\n");
     }
     catch (const std::exception& e)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: AES-GCM (random IV) decryption test failed.\n%s\n", e.what());
+        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: AES-GCM (random IV) decryption test failed.\n%s\n",
+            e.what());
         return -1;
     }
 
@@ -771,7 +807,8 @@ int pcrypto::testCrypto()
     }
     catch (const std::exception& e)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: AES-GCM (random IV) decryption test failed.\n%s\n", e.what());
+        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: AES-GCM (random IV) decryption test failed.\n%s\n",
+            e.what());
         return -1;
     }
 
@@ -792,7 +829,8 @@ int pcrypto::testCrypto()
     }
     catch (const std::exception& e)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: AES-GCM (random IV) decryption test failed\n%s\n", e.what());
+        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: AES-GCM (random IV) decryption test failed\n%s\n",
+            e.what());
         return -1;
     }
 
@@ -812,7 +850,8 @@ int pcrypto::testCrypto()
     }
     catch (const std::exception& e)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: AES-GCM (random IV) decryption test failed\n%s\n", e.what());
+        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: AES-GCM (random IV) decryption test failed\n%s\n",
+            e.what());
         return -1;
     }
 
@@ -825,9 +864,10 @@ int pcrypto::testCrypto()
     }
     SAFE_LOG(PDO_LOG_DEBUG, "testCrypto: user seeded IV generation successful!\n\n");
 
-    //Test verify report
+    // Test verify report
     res = testVerifyReport();
-    if(res != 0) {
+    if (res != 0)
+    {
         SAFE_LOG(PDO_LOG_ERROR, "testCrypto: verify report failed\n");
         return -1;
     }
@@ -836,10 +876,34 @@ int pcrypto::testCrypto()
     return 0;
 }  // pcrypto::testCrypto()
 
-int pcrypto::testVerifyReport() {
-    unsigned char mock_verification_report[] = "{\"nonce\":\"35E8FB64ACFB4A8E\",\"id\":\"284773557701539118279755254416631834508\",\"timestamp\":\"2018-07-11T19:30:35.556996\",\"epidPseudonym\":\"2iBfFyk5LE9du4skK9JjlRh1x5RvCIz/Z2nnoViIYY8W8TmIHg53UlEm2sp8NYVgT+LGSp0oxZgFcIg4p0BWxXqoBEEDnJFaVxgw0fS/RfhtF8yVNbVQjYjgQjw06wPalXzzNnjFpb873Rycj3JKSzkR3KfvKZfA/CJqEkTZK7U=\",\"isvEnclaveQuoteStatus\":\"GROUP_OUT_OF_DATE\",\"platformInfoBlob\":\"1502006504000700000808010101010000000000000000000007000006000000020000000000000AE791776C1D5C169132CA96D56CC2D59E5A46F23E39933DFB3B4962A8608AB53D84F77D254627D906B46F08073D33FF511E74BC318E8E0C37483C5B08899D1B5E9F\",\"isvEnclaveQuoteBody\":\"AgABAOcKAAAGAAUAAAAAAImTjvVbjrhQGXLFwbdtyMgAAAAAAAAAAAAAAAAAAAAABwf///8BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAHAAAAAAAAAMnL+UpC5HcF6MBCXsbYd5KUw2gc1tWgNPHNtK4g1NgKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACp0uDGT8avpUCoA1LU47KLt5L/RJSpeFFT9807MyvETgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOeQAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAy7+m9Dx2rPbbbBWJUud3AHHnxoFWhlMQCyNjtVRvD2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"}";
+int pcrypto::testVerifyReport()
+{
+    unsigned char mock_verification_report[] =
+        "{\"nonce\":\"35E8FB64ACFB4A8E\",\"id\":\"284773557701539118279755254416631834508\","
+        "\"timestamp\":\"2018-07-11T19:30:35.556996\",\"epidPseudonym\":"
+        "\"2iBfFyk5LE9du4skK9JjlRh1x5RvCIz/"
+        "Z2nnoViIYY8W8TmIHg53UlEm2sp8NYVgT+LGSp0oxZgFcIg4p0BWxXqoBEEDnJFaVxgw0fS/"
+        "RfhtF8yVNbVQjYjgQjw06wPalXzzNnjFpb873Rycj3JKSzkR3KfvKZfA/"
+        "CJqEkTZK7U=\",\"isvEnclaveQuoteStatus\":\"GROUP_OUT_OF_DATE\",\"platformInfoBlob\":"
+        "\"1502006504000700000808010101010000000000000000000007000006000000020000000000000AE791776C"
+        "1D5C169132CA96D56CC2D59E5A46F23E39933DFB3B4962A8608AB53D84F77D254627D906B46F08073D33FF511E"
+        "74BC318E8E0C37483C5B08899D1B5E9F\",\"isvEnclaveQuoteBody\":"
+        "\"AgABAOcKAAAGAAUAAAAAAImTjvVbjrhQGXLFwbdtyMgAAAAAAAAAAAAAAAAAAAAABwf///"
+        "8BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAHAAAAAAAAAMnL+"
+        "UpC5HcF6MBCXsbYd5KUw2gc1tWgNPHNtK4g1NgKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACp0uDGT8a"
+        "vpUCoA1LU47KLt5L/"
+        "RJSpeFFT9807MyvETgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOeQAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAy7+"
+        "m9Dx2rPbbbBWJUud3AHHnxoFWhlMQCyNjtVRvD2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"}";
     unsigned int mock_report_len = strlen((char*)mock_verification_report);
-    unsigned char mock_signature[] = "TuHse3QCPZtyZP436ltUAc6cVlIDzwKyjguOBDMmoou/NlGylzY0EtOEbHvVZ28HT8U1CiCVVmZso2ut2HY3zFDfpUg5/FV7FUSw/UhDOu3xkDwicrOvd/P1C3BKWJ6vJWghv3QLpgDItQPapFH/3OfciWs10kC3KV4UY+Irkrrck9+h3+FaltM/52AL1m1QWZIutMk1gDs5nz5N87gGvbc9VJKXx/RDDmvX1rLfqnPpH3owkprVLhU8iLcmPPN+irjfH4f4GGrnbWYCYK5wfB1BBbFl8ppqxm4Gr8ekePCPLMjYYLpKYWEipvTgaYl63zg+C9r8g+sIA3I9Jr3Exg==";
+    unsigned char mock_signature[] =
+        "TuHse3QCPZtyZP436ltUAc6cVlIDzwKyjguOBDMmoou/"
+        "NlGylzY0EtOEbHvVZ28HT8U1CiCVVmZso2ut2HY3zFDfpUg5/FV7FUSw/UhDOu3xkDwicrOvd/"
+        "P1C3BKWJ6vJWghv3QLpgDItQPapFH/3OfciWs10kC3KV4UY+Irkrrck9+h3+FaltM/"
+        "52AL1m1QWZIutMk1gDs5nz5N87gGvbc9VJKXx/"
+        "RDDmvX1rLfqnPpH3owkprVLhU8iLcmPPN+"
+        "irjfH4f4GGrnbWYCYK5wfB1BBbFl8ppqxm4Gr8ekePCPLMjYYLpKYWEipvTgaYl63zg+C9r8g+sIA3I9Jr3Exg==";
     const char ias_report_signing_cert_pem[] = R"MLT(
 -----BEGIN CERTIFICATE-----
 MIIEoTCCAwmgAwIBAgIJANEHdl0yo7CWMA0GCSqGSIb3DQEBCwUAMH4xCzAJBgNV
@@ -870,166 +934,336 @@ d4poyb6IW8KCJbxfMJvkordNOgOUUxndPHEi/tb/U7uLjLOgPA==
 -----END CERTIFICATE-----
 )MLT";
 
-    {   //verify good group-out-of-date quote, with group-out-of-date not allowed
-        int r = verify_enclave_quote_status((char*)mock_verification_report, mock_report_len, 0);
+    {  // verify good group-out-of-date quote, with group-out-of-date not allowed
+        int r = verify_enclave_quote_status(
+            (char*)mock_verification_report, mock_report_len, QSF_REJECT_ALL);
 
         // failure expected
-        COND2LOGERR(r != VERIFY_FAILURE, "verify good group-out-of-date quote, with group-out-of-date not allowed\n");
+        COND2LOGERR(r != VERIFY_FAILURE,
+            "verify good group-out-of-date quote, with group-out-of-date not allowed\n");
     }
 
-    {   // verify good group-out-of-date quote, with group-of-date allowed
-        int r = verify_enclave_quote_status((char*)mock_verification_report, mock_report_len, 1);
+    {
+        // check get quote status
+        unsigned char mock_quote_status[] =
+            "{\"n\":\"3\",\"isvEnclaveQuoteStatus\":\"bad\",\"p\":\"F\"}";
+        quote_status_e qs = get_quote_status((char*)mock_quote_status, mock_report_len);
+        COND2LOGERR(qs != QS_INVALID, "get INVALID status from quote");
+    }
+
+    {
+        // check get quote status
+        unsigned char mock_quote_status[] =
+            "{\"n\":\"3\",\"isvEnclaveQuoteStatus\":\"OK\",\"p\":\"F\"}";
+        quote_status_e qs = get_quote_status((char*)mock_quote_status, mock_report_len);
+        COND2LOGERR(qs != QS_OK, "get OK status from quote");
+    }
+
+    {
+        // check get quote status
+        unsigned char mock_quote_status[] =
+            "{\"n\":\"3\",\"isvEnclaveQuoteStatus\":\"GROUP_OUT_OF_DATE\",\"p\":\"F\"}";
+        quote_status_e qs = get_quote_status((char*)mock_quote_status, mock_report_len);
+        COND2LOGERR(qs != QS_GROUP_OUT_OF_DATE, "get GROUP_OUT_OF_DATE status from quote");
+    }
+
+    {
+        // check get quote status
+        unsigned char mock_quote_status[] =
+            "{\"n\":\"3\",\"isvEnclaveQuoteStatus\":\"CONFIGURATION_NEEDED\",\"p\":\"F\"}";
+        quote_status_e qs = get_quote_status((char*)mock_quote_status, mock_report_len);
+        COND2LOGERR(qs != QS_CONFIGURATION_NEEDED, "get QS_CONFIGURATION_NEEDED status from quote");
+    }
+
+    {
+        // check get quote status
+        unsigned char mock_quote_status[] =
+            "{\"n\":\"3\",\"isvEnclaveQuoteStatus\":\"SW_HARDENING_NEEDED\",\"p\":\"F\"}";
+        quote_status_e qs = get_quote_status((char*)mock_quote_status, mock_report_len);
+        COND2LOGERR(qs != QS_SW_HARDENING_NEEDED, "get SW_HARDENING_NEEDED status from quote");
+    }
+
+    {
+        // check get quote status
+        unsigned char mock_quote_status[] =
+            "{\"n\":\"3\",\"isvEnclaveQuoteStatus\":\"CONFIGURATION_AND_SW_HARDENING_NEEDED\","
+            "\"p\":\"F\"}";
+        quote_status_e qs = get_quote_status((char*)mock_quote_status, mock_report_len);
+        COND2LOGERR(qs != QS_CONFIGURATION_AND_SW_HARDENING_NEEDED,
+            "get CONFIGURATION_AND_SW_HARDENING_NEEDED status from quote");
+    }
+
+    {  // verify good group-out-of-date quote, with group-of-date allowed
+        int r = verify_enclave_quote_status(
+            (char*)mock_verification_report, mock_report_len, QSF_ACCEPT_GROUP_OUT_OF_DATE);
         // success expected
-        COND2LOGERR(r != VERIFY_SUCCESS, "verify good group-out-of-date quote, with group-out-of-date allowed\n");
+        COND2LOGERR(r != VERIFY_SUCCESS,
+            "verify good group-out-of-date quote, with group-out-of-date allowed\n");
     }
 
-    {   // verify quote with no isvEnclaveQuoteStatus
+    {  // verify good group-out-of-date quote, with all statuses (except OK) rejected
+        int r = verify_enclave_quote_status(
+            (char*)mock_verification_report, mock_report_len, QSF_REJECT_ALL);
+        // success expected
+        COND2LOGERR(r != VERIFY_FAILURE,
+            "verify good group-out-of-date quote, with all statuses rejected\n");
+    }
+
+    {  // verify good group-out-of-date quote, with a status other than group-out-of-date accepted
+        int r = verify_enclave_quote_status(
+            (char*)mock_verification_report, mock_report_len, QSF_ACCEPT_CONFIGURATION_NEEDED);
+        // success expected
+        COND2LOGERR(r != VERIFY_FAILURE,
+            "verify good group-out-of-date quote, with a status other than group-out-of-date "
+            "accepted\n");
+    }
+
+    {  // verify quote with no isvEnclaveQuoteStatus
         // bad quote status: change string
-        unsigned char bad_mock_verification_report[] = "{\"nonce\":\"35E8FB64ACFB4A8E\",\"id\":\"284773557701539118279755254416631834508\",\"timestamp\":\"2018-07-11T19:30:35.556996\",\"epidPseudonym\":\"2iBfFyk5LE9du4skK9JjlRh1x5RvCIz/Z2nnoViIYY8W8TmIHg53UlEm2sp8NYVgT+LGSp0oxZgFcIg4p0BWxXqoBEEDnJFaVxgw0fS/RfhtF8yVNbVQjYjgQjw06wPalXzzNnjFpb873Rycj3JKSzkR3KfvKZfA/CJqEkTZK7U=\",\"BADISVENCLAVQUOTESTATUS\":\"GROUP_OUT_OF_DATE\",\"platformInfoBlob\":\"1502006504000700000808010101010000000000000000000007000006000000020000000000000AE791776C1D5C169132CA96D56CC2D59E5A46F23E39933DFB3B4962A8608AB53D84F77D254627D906B46F08073D33FF511E74BC318E8E0C37483C5B08899D1B5E9F\",\"isvEnclaveQuoteBody\":\"AgABAOcKAAAGAAUAAAAAAImTjvVbjrhQGXLFwbdtyMgAAAAAAAAAAAAAAAAAAAAABwf///8BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAHAAAAAAAAAMnL+UpC5HcF6MBCXsbYd5KUw2gc1tWgNPHNtK4g1NgKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACp0uDGT8avpUCoA1LU47KLt5L/RJSpeFFT9807MyvETgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOeQAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAy7+m9Dx2rPbbbBWJUud3AHHnxoFWhlMQCyNjtVRvD2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"}";
-        int r = verify_enclave_quote_status((char*)bad_mock_verification_report, strlen((char*)bad_mock_verification_report), 1);
+        unsigned char bad_mock_verification_report[] =
+            "{\"nonce\":\"35E8FB64ACFB4A8E\",\"id\":\"284773557701539118279755254416631834508\","
+            "\"timestamp\":\"2018-07-11T19:30:35.556996\",\"epidPseudonym\":"
+            "\"2iBfFyk5LE9du4skK9JjlRh1x5RvCIz/"
+            "Z2nnoViIYY8W8TmIHg53UlEm2sp8NYVgT+LGSp0oxZgFcIg4p0BWxXqoBEEDnJFaVxgw0fS/"
+            "RfhtF8yVNbVQjYjgQjw06wPalXzzNnjFpb873Rycj3JKSzkR3KfvKZfA/"
+            "CJqEkTZK7U=\",\"BADISVENCLAVQUOTESTATUS\":\"GROUP_OUT_OF_DATE\",\"platformInfoBlob\":"
+            "\"1502006504000700000808010101010000000000000000000007000006000000020000000000000AE791"
+            "776C1D5C169132CA96D56CC2D59E5A46F23E39933DFB3B4962A8608AB53D84F77D254627D906B46F08073D"
+            "33FF511E74BC318E8E0C37483C5B08899D1B5E9F\",\"isvEnclaveQuoteBody\":"
+            "\"AgABAOcKAAAGAAUAAAAAAImTjvVbjrhQGXLFwbdtyMgAAAAAAAAAAAAAAAAAAAAABwf///"
+            "8BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAHAAAAAAAAAMnL+"
+            "UpC5HcF6MBCXsbYd5KUw2gc1tWgNPHNtK4g1NgKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACp0uD"
+            "GT8avpUCoA1LU47KLt5L/"
+            "RJSpeFFT9807MyvETgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOeQAQAAAAAAAAAAAAAAAAAAAAAA"
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAy7+"
+            "m9Dx2rPbbbBWJUud3AHHnxoFWhlMQCyNjtVRvD2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"}";
+        int r = verify_enclave_quote_status((char*)bad_mock_verification_report,
+            strlen((char*)bad_mock_verification_report), QSF_ACCEPT_GROUP_OUT_OF_DATE);
         // failure expected
         COND2LOGERR(r != VERIFY_FAILURE, "verify quote with no isvEnclaveQuoteStatus\n");
     }
 
-    {   // verify IAS CA certificate against hard-coded one
+    {  // verify IAS CA certificate against hard-coded one
         // TODO: Could check for identity but should probably also work in usual check?
         int r = verify_ias_certificate_chain(ias_report_signing_ca_cert_pem);
 #ifdef IAS_CA_CERT_REQUIRED
         // success expected
-        COND2LOGERR(r != VERIFY_SUCCESS, "verify good IAS CA certificate with IAS CA certificate required\n");
+        COND2LOGERR(r != VERIFY_SUCCESS,
+            "verify good IAS CA certificate with IAS CA certificate required\n");
 #else
         // failure expected
-        COND2LOGERR(r != VERIFY_FAILURE, "verify good IAS CA certificate with IAS CA certificate NOT required\n");
+        COND2LOGERR(r != VERIFY_FAILURE,
+            "verify good IAS CA certificate with IAS CA certificate NOT required\n");
 #endif
     }
 
-    {   // verify IAS report signing certificate
+    {  // verify IAS report signing certificate
         int r = verify_ias_certificate_chain(ias_report_signing_cert_pem);
 #ifdef IAS_CA_CERT_REQUIRED
         // success expected
-        COND2LOGERR(r != VERIFY_SUCCESS, "verify IAS report signing certificate with IAS CA certificate required\n");
+        COND2LOGERR(r != VERIFY_SUCCESS,
+            "verify IAS report signing certificate with IAS CA certificate required\n");
 #else
         // failure expected
-        COND2LOGERR(r != VERIFY_FAILURE, "verify IAS report signing certificate with IAS CA certificate NOT required\n");
+        COND2LOGERR(r != VERIFY_FAILURE,
+            "verify IAS report signing certificate with IAS CA certificate NOT required\n");
 #endif
     }
 
-    {   // verify IAS report signing certificate with null certificate
+    {  // verify IAS report signing certificate with null certificate
         int r = verify_ias_certificate_chain(NULL);
         // failure expected
         COND2LOGERR(r != VERIFY_FAILURE, "verify null IAS certificate\n");
     }
 
-    {   // verify IAS report signing certificate with bad certificate
+    {  // verify IAS report signing certificate with bad certificate
         int r = verify_ias_certificate_chain("this is a bad certificate");
         // failure expected
         COND2LOGERR(r != VERIFY_FAILURE, "verify null IAS certificate\n");
     }
 
-    {   // verify bad IAS signature
+    {  // verify bad IAS signature
         // bad signature: change first char of good one
-        unsigned char bad_mock_signature[] = "UuHse3QCPZtyZP436ltUAc6cVlIDzwKyjguOBDMmoou/NlGylzY0EtOEbHvVZ28HT8U1CiCVVmZso2ut2HY3zFDfpUg5/FV7FUSw/UhDOu3xkDwicrOvd/P1C3BKWJ6vJWghv3QLpgDItQPapFH/3OfciWs10kC3KV4UY+Irkrrck9+h3+FaltM/52AL1m1QWZIutMk1gDs5nz5N87gGvbc9VJKXx/RDDmvX1rLfqnPpH3owkprVLhU8iLcmPPN+irjfH4f4GGrnbWYCYK5wfB1BBbFl8ppqxm4Gr8ekePCPLMjYYLpKYWEipvTgaYl63zg+C9r8g+sIA3I9Jr3Exg==";
+        unsigned char bad_mock_signature[] =
+            "UuHse3QCPZtyZP436ltUAc6cVlIDzwKyjguOBDMmoou/"
+            "NlGylzY0EtOEbHvVZ28HT8U1CiCVVmZso2ut2HY3zFDfpUg5/FV7FUSw/UhDOu3xkDwicrOvd/"
+            "P1C3BKWJ6vJWghv3QLpgDItQPapFH/3OfciWs10kC3KV4UY+Irkrrck9+h3+FaltM/"
+            "52AL1m1QWZIutMk1gDs5nz5N87gGvbc9VJKXx/"
+            "RDDmvX1rLfqnPpH3owkprVLhU8iLcmPPN+"
+            "irjfH4f4GGrnbWYCYK5wfB1BBbFl8ppqxm4Gr8ekePCPLMjYYLpKYWEipvTgaYl63zg+C9r8g+"
+            "sIA3I9Jr3Exg==";
         int r = verify_ias_report_signature(ias_report_signing_cert_pem,
-                                        (char*)mock_verification_report,
-                                        mock_report_len,
-                                        (char*)bad_mock_signature,
-                                        strlen((char*)bad_mock_signature));
+            (char*)mock_verification_report, mock_report_len, (char*)bad_mock_signature,
+            strlen((char*)bad_mock_signature));
         // failure expected
         COND2LOGERR(r != VERIFY_FAILURE, "verify bad IAS signature\n");
     }
 
-    {   // verify good IAS signature
+    {  // verify good IAS signature
         int r = verify_ias_report_signature(ias_report_signing_cert_pem,
-                                        (char*)mock_verification_report,
-                                        mock_report_len,
-                                        (char*)mock_signature,
-                                        strlen((char*)mock_signature));
+            (char*)mock_verification_report, mock_report_len, (char*)mock_signature,
+            strlen((char*)mock_signature));
         // success expected
-        COND2LOGERR(r==VERIFY_FAILURE, "verify good IAS signature\n");
+        COND2LOGERR(r == VERIFY_FAILURE, "verify good IAS signature\n");
     }
 
-    {   // verify bad report
+    {  // verify bad report
         // bad report: change first char of nonce
-        unsigned char bad_mock_verification_report[] = "{\"nonce\":\"45E8FB64ACFB4A8E\",\"id\":\"284773557701539118279755254416631834508\",\"timestamp\":\"2018-07-11T19:30:35.556996\",\"epidPseudonym\":\"2iBfFyk5LE9du4skK9JjlRh1x5RvCIz/Z2nnoViIYY8W8TmIHg53UlEm2sp8NYVgT+LGSp0oxZgFcIg4p0BWxXqoBEEDnJFaVxgw0fS/RfhtF8yVNbVQjYjgQjw06wPalXzzNnjFpb873Rycj3JKSzkR3KfvKZfA/CJqEkTZK7U=\",\"isvEnclaveQuoteStatus\":\"GROUP_OUT_OF_DATE\",\"platformInfoBlob\":\"1502006504000700000808010101010000000000000000000007000006000000020000000000000AE791776C1D5C169132CA96D56CC2D59E5A46F23E39933DFB3B4962A8608AB53D84F77D254627D906B46F08073D33FF511E74BC318E8E0C37483C5B08899D1B5E9F\",\"isvEnclaveQuoteBody\":\"AgABAOcKAAAGAAUAAAAAAImTjvVbjrhQGXLFwbdtyMgAAAAAAAAAAAAAAAAAAAAABwf///8BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAHAAAAAAAAAMnL+UpC5HcF6MBCXsbYd5KUw2gc1tWgNPHNtK4g1NgKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACp0uDGT8avpUCoA1LU47KLt5L/RJSpeFFT9807MyvETgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOeQAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAy7+m9Dx2rPbbbBWJUud3AHHnxoFWhlMQCyNjtVRvD2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"}";
+        unsigned char bad_mock_verification_report[] =
+            "{\"nonce\":\"45E8FB64ACFB4A8E\",\"id\":\"284773557701539118279755254416631834508\","
+            "\"timestamp\":\"2018-07-11T19:30:35.556996\",\"epidPseudonym\":"
+            "\"2iBfFyk5LE9du4skK9JjlRh1x5RvCIz/"
+            "Z2nnoViIYY8W8TmIHg53UlEm2sp8NYVgT+LGSp0oxZgFcIg4p0BWxXqoBEEDnJFaVxgw0fS/"
+            "RfhtF8yVNbVQjYjgQjw06wPalXzzNnjFpb873Rycj3JKSzkR3KfvKZfA/"
+            "CJqEkTZK7U=\",\"isvEnclaveQuoteStatus\":\"GROUP_OUT_OF_DATE\",\"platformInfoBlob\":"
+            "\"1502006504000700000808010101010000000000000000000007000006000000020000000000000AE791"
+            "776C1D5C169132CA96D56CC2D59E5A46F23E39933DFB3B4962A8608AB53D84F77D254627D906B46F08073D"
+            "33FF511E74BC318E8E0C37483C5B08899D1B5E9F\",\"isvEnclaveQuoteBody\":"
+            "\"AgABAOcKAAAGAAUAAAAAAImTjvVbjrhQGXLFwbdtyMgAAAAAAAAAAAAAAAAAAAAABwf///"
+            "8BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAHAAAAAAAAAMnL+"
+            "UpC5HcF6MBCXsbYd5KUw2gc1tWgNPHNtK4g1NgKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACp0uD"
+            "GT8avpUCoA1LU47KLt5L/"
+            "RJSpeFFT9807MyvETgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOeQAQAAAAAAAAAAAAAAAAAAAAAA"
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAy7+"
+            "m9Dx2rPbbbBWJUud3AHHnxoFWhlMQCyNjtVRvD2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"}";
         int r = verify_ias_report_signature(ias_report_signing_cert_pem,
-                                        (char*)bad_mock_verification_report,
-                                        strlen((char*)bad_mock_verification_report),
-                                        (char*)mock_signature,
-                                        strlen((char*)mock_signature));
+            (char*)bad_mock_verification_report, strlen((char*)bad_mock_verification_report),
+            (char*)mock_signature, strlen((char*)mock_signature));
         // failure expected
         COND2LOGERR(r != VERIFY_FAILURE, "verify bad IAS report\n");
     }
 
-    {   // verify with null ias certificate
-        int r = verify_ias_report_signature(NULL,
-                                        (char*)mock_verification_report,
-                                        strlen((char*)mock_verification_report),
-                                        (char*)mock_signature,
-                                        strlen((char*)mock_signature));
+    {  // verify with null ias certificate
+        int r = verify_ias_report_signature(NULL, (char*)mock_verification_report,
+            strlen((char*)mock_verification_report), (char*)mock_signature,
+            strlen((char*)mock_signature));
         // failure expected
         COND2LOGERR(r != VERIFY_FAILURE, "verify with null ias certificate\n");
     }
 
-    {   // verify good quote
+    {  // verify good quote
         sgx_quote_t q;
         int r = get_quote_from_report(mock_verification_report, mock_report_len, &q);
         // success expected
         COND2LOGERR(r != 0, "verify  good quote\n");
     }
 
-    {   // verify bad report with no isvEnclaveQuoteBody
+    {  // verify bad report with no isvEnclaveQuoteBody
         // bad report: change isvEnclaveQuoteBody string
-        unsigned char bad_mock_verification_report[] = "{\"nonce\":\"45E8FB64ACFB4A8E\",\"id\":\"284773557701539118279755254416631834508\",\"timestamp\":\"2018-07-11T19:30:35.556996\",\"epidPseudonym\":\"2iBfFyk5LE9du4skK9JjlRh1x5RvCIz/Z2nnoViIYY8W8TmIHg53UlEm2sp8NYVgT+LGSp0oxZgFcIg4p0BWxXqoBEEDnJFaVxgw0fS/RfhtF8yVNbVQjYjgQjw06wPalXzzNnjFpb873Rycj3JKSzkR3KfvKZfA/CJqEkTZK7U=\",\"isvEnclaveQuoteStatus\":\"GROUP_OUT_OF_DATE\",\"platformInfoBlob\":\"1502006504000700000808010101010000000000000000000007000006000000020000000000000AE791776C1D5C169132CA96D56CC2D59E5A46F23E39933DFB3B4962A8608AB53D84F77D254627D906B46F08073D33FF511E74BC318E8E0C37483C5B08899D1B5E9F\",\"NOISVENCLAVEQUOTEBODY\":\"AgABAOcKAAAGAAUAAAAAAImTjvVbjrhQGXLFwbdtyMgAAAAAAAAAAAAAAAAAAAAABwf///8BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAHAAAAAAAAAMnL+UpC5HcF6MBCXsbYd5KUw2gc1tWgNPHNtK4g1NgKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACp0uDGT8avpUCoA1LU47KLt5L/RJSpeFFT9807MyvETgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOeQAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAy7+m9Dx2rPbbbBWJUud3AHHnxoFWhlMQCyNjtVRvD2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"}";
+        unsigned char bad_mock_verification_report[] =
+            "{\"nonce\":\"45E8FB64ACFB4A8E\",\"id\":\"284773557701539118279755254416631834508\","
+            "\"timestamp\":\"2018-07-11T19:30:35.556996\",\"epidPseudonym\":"
+            "\"2iBfFyk5LE9du4skK9JjlRh1x5RvCIz/"
+            "Z2nnoViIYY8W8TmIHg53UlEm2sp8NYVgT+LGSp0oxZgFcIg4p0BWxXqoBEEDnJFaVxgw0fS/"
+            "RfhtF8yVNbVQjYjgQjw06wPalXzzNnjFpb873Rycj3JKSzkR3KfvKZfA/"
+            "CJqEkTZK7U=\",\"isvEnclaveQuoteStatus\":\"GROUP_OUT_OF_DATE\",\"platformInfoBlob\":"
+            "\"1502006504000700000808010101010000000000000000000007000006000000020000000000000AE791"
+            "776C1D5C169132CA96D56CC2D59E5A46F23E39933DFB3B4962A8608AB53D84F77D254627D906B46F08073D"
+            "33FF511E74BC318E8E0C37483C5B08899D1B5E9F\",\"NOISVENCLAVEQUOTEBODY\":"
+            "\"AgABAOcKAAAGAAUAAAAAAImTjvVbjrhQGXLFwbdtyMgAAAAAAAAAAAAAAAAAAAAABwf///"
+            "8BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAHAAAAAAAAAMnL+"
+            "UpC5HcF6MBCXsbYd5KUw2gc1tWgNPHNtK4g1NgKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACp0uD"
+            "GT8avpUCoA1LU47KLt5L/"
+            "RJSpeFFT9807MyvETgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOeQAQAAAAAAAAAAAAAAAAAAAAAA"
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAy7+"
+            "m9Dx2rPbbbBWJUud3AHHnxoFWhlMQCyNjtVRvD2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"}";
         sgx_quote_t q;
-        int r = get_quote_from_report(bad_mock_verification_report, strlen((char*)bad_mock_verification_report), &q);
+        int r = get_quote_from_report(
+            bad_mock_verification_report, strlen((char*)bad_mock_verification_report), &q);
         // failure expected
         COND2LOGERR(r != -1, "verify bad IAS report with no isvEnclaveQuoteBody\n");
     }
 
-    {   // verify bad report with unterminated quote body
+    {  // verify bad report with unterminated quote body
         // bad report: remove final quote body string quotes
-        unsigned char bad_mock_verification_report[] = "{\"nonce\":\"45E8FB64ACFB4A8E\",\"id\":\"284773557701539118279755254416631834508\",\"timestamp\":\"2018-07-11T19:30:35.556996\",\"epidPseudonym\":\"2iBfFyk5LE9du4skK9JjlRh1x5RvCIz/Z2nnoViIYY8W8TmIHg53UlEm2sp8NYVgT+LGSp0oxZgFcIg4p0BWxXqoBEEDnJFaVxgw0fS/RfhtF8yVNbVQjYjgQjw06wPalXzzNnjFpb873Rycj3JKSzkR3KfvKZfA/CJqEkTZK7U=\",\"isvEnclaveQuoteStatus\":\"GROUP_OUT_OF_DATE\",\"platformInfoBlob\":\"1502006504000700000808010101010000000000000000000007000006000000020000000000000AE791776C1D5C169132CA96D56CC2D59E5A46F23E39933DFB3B4962A8608AB53D84F77D254627D906B46F08073D33FF511E74BC318E8E0C37483C5B08899D1B5E9F\",\"isvEnclaveQuoteBody\":\"AgABAOcKAAAGAAUAAAAAAImTjvVbjrhQGXLFwbdtyMgAAAAAAAAAAAAAAAAAAAAABwf///8BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAHAAAAAAAAAMnL+UpC5HcF6MBCXsbYd5KUw2gc1tWgNPHNtK4g1NgKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACp0uDGT8avpUCoA1LU47KLt5L/RJSpeFFT9807MyvETgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOeQAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAy7+m9Dx2rPbbbBWJUud3AHHnxoFWhlMQCyNjtVRvD2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA}";
+        unsigned char bad_mock_verification_report[] =
+            "{\"nonce\":\"45E8FB64ACFB4A8E\",\"id\":\"284773557701539118279755254416631834508\","
+            "\"timestamp\":\"2018-07-11T19:30:35.556996\",\"epidPseudonym\":"
+            "\"2iBfFyk5LE9du4skK9JjlRh1x5RvCIz/"
+            "Z2nnoViIYY8W8TmIHg53UlEm2sp8NYVgT+LGSp0oxZgFcIg4p0BWxXqoBEEDnJFaVxgw0fS/"
+            "RfhtF8yVNbVQjYjgQjw06wPalXzzNnjFpb873Rycj3JKSzkR3KfvKZfA/"
+            "CJqEkTZK7U=\",\"isvEnclaveQuoteStatus\":\"GROUP_OUT_OF_DATE\",\"platformInfoBlob\":"
+            "\"1502006504000700000808010101010000000000000000000007000006000000020000000000000AE791"
+            "776C1D5C169132CA96D56CC2D59E5A46F23E39933DFB3B4962A8608AB53D84F77D254627D906B46F08073D"
+            "33FF511E74BC318E8E0C37483C5B08899D1B5E9F\",\"isvEnclaveQuoteBody\":"
+            "\"AgABAOcKAAAGAAUAAAAAAImTjvVbjrhQGXLFwbdtyMgAAAAAAAAAAAAAAAAAAAAABwf///"
+            "8BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAHAAAAAAAAAMnL+"
+            "UpC5HcF6MBCXsbYd5KUw2gc1tWgNPHNtK4g1NgKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACp0uD"
+            "GT8avpUCoA1LU47KLt5L/"
+            "RJSpeFFT9807MyvETgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOeQAQAAAAAAAAAAAAAAAAAAAAAA"
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAy7+"
+            "m9Dx2rPbbbBWJUud3AHHnxoFWhlMQCyNjtVRvD2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA}";
         sgx_quote_t q;
-        int r = get_quote_from_report(bad_mock_verification_report, strlen((char*)bad_mock_verification_report), &q);
+        int r = get_quote_from_report(
+            bad_mock_verification_report, strlen((char*)bad_mock_verification_report), &q);
         // failure expected
         COND2LOGERR(r != -1, "verify bad IAS report with unterminated isvEnclaveQuoteBody\n");
     }
 
-    {   // verify bad report that fails EVP_DecodeBlock
+    {  // verify bad report that fails EVP_DecodeBlock
         // bad report: single char quote
-        unsigned char bad_mock_verification_report[] = "{\"nonce\":\"45E8FB64ACFB4A8E\",\"id\":\"284773557701539118279755254416631834508\",\"timestamp\":\"2018-07-11T19:30:35.556996\",\"epidPseudonym\":\"2iBfFyk5LE9du4skK9JjlRh1x5RvCIz/Z2nnoViIYY8W8TmIHg53UlEm2sp8NYVgT+LGSp0oxZgFcIg4p0BWxXqoBEEDnJFaVxgw0fS/RfhtF8yVNbVQjYjgQjw06wPalXzzNnjFpb873Rycj3JKSzkR3KfvKZfA/CJqEkTZK7U=\",\"isvEnclaveQuoteStatus\":\"GROUP_OUT_OF_DATE\",\"platformInfoBlob\":\"1502006504000700000808010101010000000000000000000007000006000000020000000000000AE791776C1D5C169132CA96D56CC2D59E5A46F23E39933DFB3B4962A8608AB53D84F77D254627D906B46F08073D33FF511E74BC318E8E0C37483C5B08899D1B5E9F\",\"isvEnclaveQuoteBody\":\"A\"}";
+        unsigned char bad_mock_verification_report[] =
+            "{\"nonce\":\"45E8FB64ACFB4A8E\",\"id\":\"284773557701539118279755254416631834508\","
+            "\"timestamp\":\"2018-07-11T19:30:35.556996\",\"epidPseudonym\":"
+            "\"2iBfFyk5LE9du4skK9JjlRh1x5RvCIz/"
+            "Z2nnoViIYY8W8TmIHg53UlEm2sp8NYVgT+LGSp0oxZgFcIg4p0BWxXqoBEEDnJFaVxgw0fS/"
+            "RfhtF8yVNbVQjYjgQjw06wPalXzzNnjFpb873Rycj3JKSzkR3KfvKZfA/"
+            "CJqEkTZK7U=\",\"isvEnclaveQuoteStatus\":\"GROUP_OUT_OF_DATE\",\"platformInfoBlob\":"
+            "\"1502006504000700000808010101010000000000000000000007000006000000020000000000000AE791"
+            "776C1D5C169132CA96D56CC2D59E5A46F23E39933DFB3B4962A8608AB53D84F77D254627D906B46F08073D"
+            "33FF511E74BC318E8E0C37483C5B08899D1B5E9F\",\"isvEnclaveQuoteBody\":\"A\"}";
         sgx_quote_t q;
-        int r = get_quote_from_report(bad_mock_verification_report, strlen((char*)bad_mock_verification_report), &q);
+        int r = get_quote_from_report(
+            bad_mock_verification_report, strlen((char*)bad_mock_verification_report), &q);
         // failure expected
         COND2LOGERR(r != -1, "verify bad IAS report that fails EVP_DecodeBlock\n");
     }
 
-    {   //verify bad report with long quote
+    {  // verify bad report with long quote
         // bad report: repeat initial quote chars
-        unsigned char bad_mock_verification_report[] = "{\"nonce\":\"45E8FB64ACFB4A8E\",\"id\":\"284773557701539118279755254416631834508\",\"timestamp\":\"2018-07-11T19:30:35.556996\",\"epidPseudonym\":\"2iBfFyk5LE9du4skK9JjlRh1x5RvCIz/Z2nnoViIYY8W8TmIHg53UlEm2sp8NYVgT+LGSp0oxZgFcIg4p0BWxXqoBEEDnJFaVxgw0fS/RfhtF8yVNbVQjYjgQjw06wPalXzzNnjFpb873Rycj3JKSzkR3KfvKZfA/CJqEkTZK7U=\",\"isvEnclaveQuoteStatus\":\"GROUP_OUT_OF_DATE\",\"platformInfoBlob\":\"1502006504000700000808010101010000000000000000000007000006000000020000000000000AE791776C1D5C169132CA96D56CC2D59E5A46F23E39933DFB3B4962A8608AB53D84F77D254627D906B46F08073D33FF511E74BC318E8E0C37483C5B08899D1B5E9F\",\"isvEnclaveQuoteBody\":\"AAgABAOcKAAAGgABAgABAOcKAAAGAAUAAAAAAImTjvVbjrhQGXLFwbdtyMgAAAAAAAAAAAAAAAAAAAAABwf///8BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAHAAAAAAAAAMnL+UpC5HcF6MBCXsbYd5KUw2gc1tWgNPHNtK4g1NgKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACp0uDGT8avpUCoA1LU47KLt5L/RJSpeFFT9807MyvETgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOeQAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAy7+m9Dx2rPbbbBWJUud3AHHnxoFWhlMQCyNjtVRvD2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"}";
+        unsigned char bad_mock_verification_report[] =
+            "{\"nonce\":\"45E8FB64ACFB4A8E\",\"id\":\"284773557701539118279755254416631834508\","
+            "\"timestamp\":\"2018-07-11T19:30:35.556996\",\"epidPseudonym\":"
+            "\"2iBfFyk5LE9du4skK9JjlRh1x5RvCIz/"
+            "Z2nnoViIYY8W8TmIHg53UlEm2sp8NYVgT+LGSp0oxZgFcIg4p0BWxXqoBEEDnJFaVxgw0fS/"
+            "RfhtF8yVNbVQjYjgQjw06wPalXzzNnjFpb873Rycj3JKSzkR3KfvKZfA/"
+            "CJqEkTZK7U=\",\"isvEnclaveQuoteStatus\":\"GROUP_OUT_OF_DATE\",\"platformInfoBlob\":"
+            "\"1502006504000700000808010101010000000000000000000007000006000000020000000000000AE791"
+            "776C1D5C169132CA96D56CC2D59E5A46F23E39933DFB3B4962A8608AB53D84F77D254627D906B46F08073D"
+            "33FF511E74BC318E8E0C37483C5B08899D1B5E9F\",\"isvEnclaveQuoteBody\":"
+            "\"AAgABAOcKAAAGgABAgABAOcKAAAGAAUAAAAAAImTjvVbjrhQGXLFwbdtyMgAAAAAAAAAAAAAAAAAAAAABwf/"
+            "//"
+            "8BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAHAAAAAAAAAMnL+"
+            "UpC5HcF6MBCXsbYd5KUw2gc1tWgNPHNtK4g1NgKAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACp0uD"
+            "GT8avpUCoA1LU47KLt5L/"
+            "RJSpeFFT9807MyvETgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAOeQAQAAAAAAAAAAAAAAAAAAAAAA"
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAy7+"
+            "m9Dx2rPbbbBWJUud3AHHnxoFWhlMQCyNjtVRvD2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"}";
         sgx_quote_t q;
-        int r = get_quote_from_report(bad_mock_verification_report, strlen((char*)bad_mock_verification_report), &q);
+        int r = get_quote_from_report(
+            bad_mock_verification_report, strlen((char*)bad_mock_verification_report), &q);
         // failure expected
         COND2LOGERR(r != -1, "verify bad IAS report with bad quote length\n");
     }
 
-    {   // verify signature with bad certificate
+    {  // verify signature with bad certificate
         int r = verify_ias_report_signature("this is a bad certificate",
-                                        (char*)mock_verification_report,
-                                        mock_report_len,
-                                        (char*)mock_signature,
-                                        strlen((char*)mock_signature));
+            (char*)mock_verification_report, mock_report_len, (char*)mock_signature,
+            strlen((char*)mock_signature));
         // failure expected
         COND2LOGERR(r != VERIFY_FAILURE, "verify signature with bad certificate\n");
     }
 
-    {   // verify signature with bad encoding
+    {  // verify signature with bad encoding
         char bad_mock_signature[] = "Aaa";
         int r = verify_ias_report_signature(ias_report_signing_cert_pem,
-                                        (char*)mock_verification_report,
-                                        mock_report_len,
-                                        (char*)bad_mock_signature,
-                                        strlen((char*)bad_mock_signature));
+            (char*)mock_verification_report, mock_report_len, (char*)bad_mock_signature,
+            strlen((char*)bad_mock_signature));
         // failure expected
         COND2LOGERR(r != VERIFY_FAILURE, "verify signature with bad encoding\n");
     }
@@ -1039,4 +1273,4 @@ d4poyb6IW8KCJbxfMJvkordNOgOUUxndPHEi/tb/U7uLjLOgPA==
 
 err:
     return -1;
-} //int pcrypto::testVerifyReport()
+}  // int pcrypto::testVerifyReport()

--- a/common/tests/crypto/testCrypto.cpp
+++ b/common/tests/crypto/testCrypto.cpp
@@ -63,8 +63,8 @@ int pcrypto::testCrypto()
     try
     {
         rand = pcrypto::RandomBitString(0);
-        SAFE_LOG(
-            PDO_LOG_ERROR, "testCrypto: RandomBitString invalid length argument undetected.\n");
+        SAFE_LOG(PDO_LOG_ERROR,
+                 "testCrypto: RandomBitString invalid length argument undetected.\n");
         return -1;
     }
     catch (const Error::ValueError& e)
@@ -77,8 +77,9 @@ int pcrypto::testCrypto()
         return -1;
     }
 
-    SAFE_LOG(PDO_LOG_DEBUG, "RandomBitString test successful!\n%s\n\n",
-        ByteArrayToBase64EncodedString(rand).c_str());
+    SAFE_LOG(PDO_LOG_DEBUG,
+             "RandomBitString test successful!\n%s\n\n",
+             ByteArrayToBase64EncodedString(rand).c_str());
 
     // Test ECDSA key management functions
     try
@@ -154,15 +155,16 @@ int pcrypto::testCrypto()
     }
     catch (const Error::ValueError& e)
     {
-        SAFE_LOG(PDO_LOG_DEBUG, "testCrypto: Deserialize invalid ECDSA private key detected!\n%s\n",
-            e.what());
+        SAFE_LOG(PDO_LOG_DEBUG,
+                 "testCrypto: Deserialize invalid ECDSA private key detected!\n%s\n",
+                 e.what());
     }
     catch (const Error::RuntimeError& e)
     {
         SAFE_LOG(PDO_LOG_ERROR,
-            "testCrypto: Deserialize invalid ECDSA private key internal "
-            "error.\n%s\n",
-            e.what());
+                 "testCrypto: Deserialize invalid ECDSA private key internal "
+                 "error.\n%s\n",
+                 e.what());
         return -1;
     }
 
@@ -172,15 +174,16 @@ int pcrypto::testCrypto()
     }
     catch (const Error::ValueError& e)
     {
-        SAFE_LOG(PDO_LOG_DEBUG, "testCrypto: Deserialize invalid ECDSA public key detected!\n%s\n",
-            e.what());
+        SAFE_LOG(PDO_LOG_DEBUG,
+                 "testCrypto: Deserialize invalid ECDSA public key detected!\n%s\n",
+                 e.what());
     }
     catch (const Error::RuntimeError& e)
     {
         SAFE_LOG(PDO_LOG_ERROR,
-            "testCrypto: Deserialize invalid ECDSA public key internal "
-            "error.\n%s\n",
-            e.what());
+                 "testCrypto: Deserialize invalid ECDSA public key internal "
+                 "error.\n%s\n",
+                 e.what());
         return -1;
     }
 
@@ -209,8 +212,8 @@ int pcrypto::testCrypto()
         return -1;
     }
 
-    SAFE_LOG(
-        PDO_LOG_DEBUG, "testCrypto: Serialize/Deserialize ECDSA keypairs tests successful!\n\n");
+    SAFE_LOG(PDO_LOG_DEBUG,
+             "testCrypto: Serialize/Deserialize ECDSA keypairs tests successful!\n\n");
     // Test ComputeMessageHash
 
     std::string msgStr("Proof of Elapsed Time");
@@ -222,8 +225,8 @@ int pcrypto::testCrypto()
     if (hashStr_B64.compare(msg_SHA256_B64) != 0)
     {
         SAFE_LOG(PDO_LOG_ERROR,
-            "testCrypto: ComputeMessageHash test failed, SHA256 digest "
-            "mismatch.\n");
+                 "testCrypto: ComputeMessageHash test failed, SHA256 digest "
+                 "mismatch.\n");
         return -1;
     }
     SAFE_LOG(PDO_LOG_DEBUG, "testCrypto: ComputeMessageHash test passed!\n\n");
@@ -242,8 +245,8 @@ int pcrypto::testCrypto()
         if (hmacStr_B64.compare(msg_SHA256HMAC_B64) != 0)
         {
             SAFE_LOG(PDO_LOG_ERROR,
-                "testCrypto: ComputeMessageHMAC test failed, SHA256 digest "
-                "mismatch.\n");
+                     "testCrypto: ComputeMessageHMAC test failed, SHA256 digest "
+                     "mismatch.\n");
             return -1;
         }
     }
@@ -259,7 +262,7 @@ int pcrypto::testCrypto()
         if (hmacStr_B64.compare(msg_SHA256HMAC_B64) == 0)
         {
             SAFE_LOG(PDO_LOG_ERROR,
-                "testCrypto: ComputeMessageHMAC, wrong key test shoud have failed.\n");
+                     "testCrypto: ComputeMessageHMAC, wrong key test shoud have failed.\n");
             return -1;
         }
     }
@@ -275,7 +278,7 @@ int pcrypto::testCrypto()
         if (hmacStr_B64.compare(msg_SHA256HMAC_B64) == 0)
         {
             SAFE_LOG(PDO_LOG_ERROR,
-                "testCrypto: ComputeMessageHMAC, wrong message test should have failed.\n");
+                     "testCrypto: ComputeMessageHMAC, wrong message test should have failed.\n");
             return -1;
         }
     }
@@ -336,7 +339,8 @@ int pcrypto::testCrypto()
     catch (const Error::RuntimeError& e)
     {
         SAFE_LOG(PDO_LOG_ERROR,
-            "testCrypto: SignMessage test failed, signature not computed.\n%s\n", e.what());
+                 "testCrypto: SignMessage test failed, signature not computed.\n%s\n",
+                 e.what());
         return -1;
     }
     SAFE_LOG(PDO_LOG_DEBUG, "testCrypto: SignMessage test passed!\n\n");
@@ -364,7 +368,8 @@ int pcrypto::testCrypto()
     catch (const Error::RuntimeError& e)
     {
         SAFE_LOG(PDO_LOG_ERROR,
-            "testCrypto: SignMessage test failed, signature not computed.\n%s\n", e.what());
+                 "testCrypto: SignMessage test failed, signature not computed.\n%s\n",
+                 e.what());
         return -1;
     }
 
@@ -377,7 +382,7 @@ int pcrypto::testCrypto()
     if (res == 1)
     {
         SAFE_LOG(PDO_LOG_ERROR,
-            "testCrypto: VerifySignature test failed, invalid message not detected!\n");
+                 "testCrypto: VerifySignature test failed, invalid message not detected!\n");
         return -1;
     }
 
@@ -391,7 +396,7 @@ int pcrypto::testCrypto()
     if (res == 1)
     {
         SAFE_LOG(PDO_LOG_ERROR,
-            "testCrypto: VerifySignature test failed, invalid signature not detected!\n");
+                 "testCrypto: VerifySignature test failed, invalid signature not detected!\n");
         return -1;
     }
     SAFE_LOG(PDO_LOG_DEBUG, "testCrypto: VerifySignature, invalid signature detected!\n");
@@ -474,15 +479,16 @@ int pcrypto::testCrypto()
     }
     catch (const Error::ValueError& e)
     {
-        SAFE_LOG(PDO_LOG_DEBUG, "testCrypto: RSA invalid private key deserialize detected!\n%s\n",
-            e.what());
+        SAFE_LOG(PDO_LOG_DEBUG,
+                 "testCrypto: RSA invalid private key deserialize detected!\n%s\n",
+                 e.what());
     }
     catch (const std::exception& e)
     {
         SAFE_LOG(PDO_LOG_ERROR,
-            "testCrypto: RSA invalid private key deserialize internal "
-            "error!\n%s\n",
-            e.what());
+                 "testCrypto: RSA invalid private key deserialize internal "
+                 "error!\n%s\n",
+                 e.what());
         return -1;
     }
 
@@ -494,13 +500,15 @@ int pcrypto::testCrypto()
     }
     catch (const Error::ValueError& e)
     {
-        SAFE_LOG(PDO_LOG_DEBUG, "testCrypto: RSA invalid public key deserialize detected!\n%s\n",
-            e.what());
+        SAFE_LOG(PDO_LOG_DEBUG,
+                 "testCrypto: RSA invalid public key deserialize detected!\n%s\n",
+                 e.what());
     }
     catch (const Error::RuntimeError& e)
     {
         SAFE_LOG(PDO_LOG_ERROR,
-            "testCrypto: RSA invalid public key deserialize internal error!\n%s\n", e.what());
+                 "testCrypto: RSA invalid public key deserialize internal error!\n%s\n",
+                 e.what());
         return -1;
     }
 
@@ -539,7 +547,7 @@ int pcrypto::testCrypto()
     catch (const Error::ValueError& e)
     {
         SAFE_LOG(PDO_LOG_DEBUG,
-            "testCrypto: RSA decryption test invalid RSA ciphertext correctly detected!\n");
+                 "testCrypto: RSA decryption test invalid RSA ciphertext correctly detected!\n");
     }
     catch (const std::exception& e)
     {
@@ -592,29 +600,30 @@ int pcrypto::testCrypto()
     {
         ctAES = pcrypto::skenc::EncryptMessage(key, iv, empty);
         SAFE_LOG(PDO_LOG_ERROR,
-            "testCrypto: AES-GCM empty message encryption test failed: undetected.\n");
+                 "testCrypto: AES-GCM empty message encryption test failed: undetected.\n");
         return -1;
     }
     catch (const std::exception& e)
     {
         SAFE_LOG(PDO_LOG_DEBUG,
-            "testCrypto: AES-GCM empty message encryption test successful (detected)!\n%s\n",
-            e.what());
+                 "testCrypto: AES-GCM empty message encryption test successful (detected)!\n%s\n",
+                 e.what());
     }
 
     try
     {
         ctAES = pcrypto::skenc::EncryptMessage(key, empty);
-        SAFE_LOG(PDO_LOG_ERROR,
+        SAFE_LOG(
+            PDO_LOG_ERROR,
             "testCrypto: AES-GCM (random IV) empty message encryption test failed: undetected.\n");
         return -1;
     }
     catch (const std::exception& e)
     {
         SAFE_LOG(PDO_LOG_DEBUG,
-            "testCrypto: AES-GCM (random IV) empty message encryption test successful "
-            "(detected)!\n%s\n",
-            e.what());
+                 "testCrypto: AES-GCM (random IV) empty message encryption test successful "
+                 "(detected)!\n%s\n",
+                 e.what());
     }
 
     try
@@ -636,8 +645,8 @@ int pcrypto::testCrypto()
     try
     {
         ctAES = pcrypto::skenc::EncryptMessage(empty, iv, msg);
-        SAFE_LOG(
-            PDO_LOG_ERROR, "testCrypto: AES-GCM encryption test failed, bad key undetected.\n");
+        SAFE_LOG(PDO_LOG_ERROR,
+                 "testCrypto: AES-GCM encryption test failed, bad key undetected.\n");
         return -1;
     }
     catch (const Error::ValueError& e)
@@ -654,18 +663,19 @@ int pcrypto::testCrypto()
     {
         ctAES = pcrypto::skenc::EncryptMessage(empty, msg);
         SAFE_LOG(PDO_LOG_ERROR,
-            "testCrypto: AES-GCM (random IV) encryption test failed, bad key undetected.\n");
+                 "testCrypto: AES-GCM (random IV) encryption test failed, bad key undetected.\n");
         return -1;
     }
     catch (const Error::ValueError& e)
     {
         SAFE_LOG(PDO_LOG_DEBUG,
-            "testCrypto: AES-GCM (random IV) encryption correct, bad key detected!\n\n");
+                 "testCrypto: AES-GCM (random IV) encryption correct, bad key detected!\n\n");
     }
     catch (const std::exception& e)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: AES-GCM (random IV) encryption test failed.\n%s\n",
-            e.what());
+        SAFE_LOG(PDO_LOG_ERROR,
+                 "testCrypto: AES-GCM (random IV) encryption test failed.\n%s\n",
+                 e.what());
         return -1;
     }
 
@@ -701,8 +711,8 @@ int pcrypto::testCrypto()
     try
     {
         ptAES = pcrypto::skenc::DecryptMessage(empty, iv, ctAES);
-        SAFE_LOG(
-            PDO_LOG_ERROR, "testCrypto: AES-GCM decryption test failed, bad key undetected.\n");
+        SAFE_LOG(PDO_LOG_ERROR,
+                 "testCrypto: AES-GCM decryption test failed, bad key undetected.\n");
         return -1;
     }
     catch (const Error::ValueError& e)
@@ -731,15 +741,15 @@ int pcrypto::testCrypto()
     {
         ptAES = pcrypto::skenc::DecryptMessage(key, iv, ctAES);
         SAFE_LOG(PDO_LOG_ERROR,
-            "testCrypto: AES-GCM decryption test failed, ciphertext tampering "
-            "undetected.\n");
+                 "testCrypto: AES-GCM decryption test failed, ciphertext tampering "
+                 "undetected.\n");
         return -1;
     }
     catch (const Error::CryptoError& e)
     {
         SAFE_LOG(PDO_LOG_DEBUG,
-            "testCrypto: AES-GCM decryption correct, ciphertext tampering "
-            "detected!\n\n");
+                 "testCrypto: AES-GCM decryption correct, ciphertext tampering "
+                 "detected!\n\n");
     }
     catch (const std::exception& e)
     {
@@ -751,15 +761,15 @@ int pcrypto::testCrypto()
     {
         ptAES = pcrypto::skenc::DecryptMessage(key, iv, empty);
         SAFE_LOG(PDO_LOG_ERROR,
-            "testCrypto: AES-GCM decryption test failed, invalid ciphertext size "
-            "undetected.\n");
+                 "testCrypto: AES-GCM decryption test failed, invalid ciphertext size "
+                 "undetected.\n");
         return -1;
     }
     catch (const Error::ValueError& e)
     {
         SAFE_LOG(PDO_LOG_DEBUG,
-            "testCrypto: AES-GCM decryption correct, invalid ciphertext size "
-            "detected!\n\n");
+                 "testCrypto: AES-GCM decryption correct, invalid ciphertext size "
+                 "detected!\n\n");
     }
     catch (const std::exception& e)
     {
@@ -775,8 +785,9 @@ int pcrypto::testCrypto()
     }
     catch (const std::exception& e)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: AES-GCM (random IV) encryption test failed.\n%s\n",
-            e.what());
+        SAFE_LOG(PDO_LOG_ERROR,
+                 "testCrypto: AES-GCM (random IV) encryption test failed.\n%s\n",
+                 e.what());
         return -1;
     }
 
@@ -785,18 +796,19 @@ int pcrypto::testCrypto()
     {
         ptAES = pcrypto::skenc::DecryptMessage(empty, ctAES);
         SAFE_LOG(PDO_LOG_ERROR,
-            "testCrypto: AES-GCM (random IV) decryption test failed, bad key undetected.\n");
+                 "testCrypto: AES-GCM (random IV) decryption test failed, bad key undetected.\n");
         return -1;
     }
     catch (const Error::ValueError& e)
     {
         SAFE_LOG(PDO_LOG_DEBUG,
-            "testCrypto: AES-GCM (random IV) decryption correct, bad key detected!\n\n");
+                 "testCrypto: AES-GCM (random IV) decryption correct, bad key detected!\n\n");
     }
     catch (const std::exception& e)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: AES-GCM (random IV) decryption test failed.\n%s\n",
-            e.what());
+        SAFE_LOG(PDO_LOG_ERROR,
+                 "testCrypto: AES-GCM (random IV) decryption test failed.\n%s\n",
+                 e.what());
         return -1;
     }
 
@@ -807,8 +819,9 @@ int pcrypto::testCrypto()
     }
     catch (const std::exception& e)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: AES-GCM (random IV) decryption test failed.\n%s\n",
-            e.what());
+        SAFE_LOG(PDO_LOG_ERROR,
+                 "testCrypto: AES-GCM (random IV) decryption test failed.\n%s\n",
+                 e.what());
         return -1;
     }
 
@@ -817,20 +830,21 @@ int pcrypto::testCrypto()
     {
         ptAES = pcrypto::skenc::DecryptMessage(key, ctAES);
         SAFE_LOG(PDO_LOG_ERROR,
-            "testCrypto: AES-GCM (random IV) decryption test failed, ciphertext tampering "
-            "undetected.\n");
+                 "testCrypto: AES-GCM (random IV) decryption test failed, ciphertext tampering "
+                 "undetected.\n");
         return -1;
     }
     catch (const Error::CryptoError& e)
     {
         SAFE_LOG(PDO_LOG_DEBUG,
-            "testCrypto: AES-GCM (random IV) decryption correct, ciphertext tampering "
-            "detected!\n\n");
+                 "testCrypto: AES-GCM (random IV) decryption correct, ciphertext tampering "
+                 "detected!\n\n");
     }
     catch (const std::exception& e)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: AES-GCM (random IV) decryption test failed\n%s\n",
-            e.what());
+        SAFE_LOG(PDO_LOG_ERROR,
+                 "testCrypto: AES-GCM (random IV) decryption test failed\n%s\n",
+                 e.what());
         return -1;
     }
 
@@ -838,20 +852,21 @@ int pcrypto::testCrypto()
     {
         ptAES = pcrypto::skenc::DecryptMessage(key, empty);
         SAFE_LOG(PDO_LOG_ERROR,
-            "testCrypto: AES-GCM (random IV) decryption test failed, invalid ciphertext size "
-            "undetected.\n");
+                 "testCrypto: AES-GCM (random IV) decryption test failed, invalid ciphertext size "
+                 "undetected.\n");
         return -1;
     }
     catch (const Error::ValueError& e)
     {
         SAFE_LOG(PDO_LOG_DEBUG,
-            "testCrypto: AES-GCM (random IV) decryption correct, invalid ciphertext size "
-            "detected!\n\n");
+                 "testCrypto: AES-GCM (random IV) decryption correct, invalid ciphertext size "
+                 "detected!\n\n");
     }
     catch (const std::exception& e)
     {
-        SAFE_LOG(PDO_LOG_ERROR, "testCrypto: AES-GCM (random IV) decryption test failed\n%s\n",
-            e.what());
+        SAFE_LOG(PDO_LOG_ERROR,
+                 "testCrypto: AES-GCM (random IV) decryption test failed\n%s\n",
+                 e.what());
         return -1;
     }
 
@@ -940,7 +955,7 @@ d4poyb6IW8KCJbxfMJvkordNOgOUUxndPHEi/tb/U7uLjLOgPA==
 
         // failure expected
         COND2LOGERR(r != VERIFY_FAILURE,
-            "verify good group-out-of-date quote, with group-out-of-date not allowed\n");
+                    "verify good group-out-of-date quote, with group-out-of-date not allowed\n");
     }
 
     {
@@ -990,7 +1005,7 @@ d4poyb6IW8KCJbxfMJvkordNOgOUUxndPHEi/tb/U7uLjLOgPA==
             "\"p\":\"F\"}";
         quote_status_e qs = get_quote_status((char*)mock_quote_status, mock_report_len);
         COND2LOGERR(qs != QS_CONFIGURATION_AND_SW_HARDENING_NEEDED,
-            "get CONFIGURATION_AND_SW_HARDENING_NEEDED status from quote");
+                    "get CONFIGURATION_AND_SW_HARDENING_NEEDED status from quote");
     }
 
     {  // verify good group-out-of-date quote, with group-of-date allowed
@@ -998,7 +1013,7 @@ d4poyb6IW8KCJbxfMJvkordNOgOUUxndPHEi/tb/U7uLjLOgPA==
             (char*)mock_verification_report, mock_report_len, QSF_ACCEPT_GROUP_OUT_OF_DATE);
         // success expected
         COND2LOGERR(r != VERIFY_SUCCESS,
-            "verify good group-out-of-date quote, with group-out-of-date allowed\n");
+                    "verify good group-out-of-date quote, with group-out-of-date allowed\n");
     }
 
     {  // verify good group-out-of-date quote, with all statuses (except OK) rejected
@@ -1006,14 +1021,15 @@ d4poyb6IW8KCJbxfMJvkordNOgOUUxndPHEi/tb/U7uLjLOgPA==
             (char*)mock_verification_report, mock_report_len, QSF_REJECT_ALL);
         // success expected
         COND2LOGERR(r != VERIFY_FAILURE,
-            "verify good group-out-of-date quote, with all statuses rejected\n");
+                    "verify good group-out-of-date quote, with all statuses rejected\n");
     }
 
     {  // verify good group-out-of-date quote, with a status other than group-out-of-date accepted
         int r = verify_enclave_quote_status(
             (char*)mock_verification_report, mock_report_len, QSF_ACCEPT_CONFIGURATION_NEEDED);
         // success expected
-        COND2LOGERR(r != VERIFY_FAILURE,
+        COND2LOGERR(
+            r != VERIFY_FAILURE,
             "verify good group-out-of-date quote, with a status other than group-out-of-date "
             "accepted\n");
     }
@@ -1039,7 +1055,8 @@ d4poyb6IW8KCJbxfMJvkordNOgOUUxndPHEi/tb/U7uLjLOgPA==
             "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAy7+"
             "m9Dx2rPbbbBWJUud3AHHnxoFWhlMQCyNjtVRvD2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"}";
         int r = verify_enclave_quote_status((char*)bad_mock_verification_report,
-            strlen((char*)bad_mock_verification_report), QSF_ACCEPT_GROUP_OUT_OF_DATE);
+                                            strlen((char*)bad_mock_verification_report),
+                                            QSF_ACCEPT_GROUP_OUT_OF_DATE);
         // failure expected
         COND2LOGERR(r != VERIFY_FAILURE, "verify quote with no isvEnclaveQuoteStatus\n");
     }
@@ -1050,11 +1067,11 @@ d4poyb6IW8KCJbxfMJvkordNOgOUUxndPHEi/tb/U7uLjLOgPA==
 #ifdef IAS_CA_CERT_REQUIRED
         // success expected
         COND2LOGERR(r != VERIFY_SUCCESS,
-            "verify good IAS CA certificate with IAS CA certificate required\n");
+                    "verify good IAS CA certificate with IAS CA certificate required\n");
 #else
         // failure expected
         COND2LOGERR(r != VERIFY_FAILURE,
-            "verify good IAS CA certificate with IAS CA certificate NOT required\n");
+                    "verify good IAS CA certificate with IAS CA certificate NOT required\n");
 #endif
     }
 
@@ -1063,11 +1080,11 @@ d4poyb6IW8KCJbxfMJvkordNOgOUUxndPHEi/tb/U7uLjLOgPA==
 #ifdef IAS_CA_CERT_REQUIRED
         // success expected
         COND2LOGERR(r != VERIFY_SUCCESS,
-            "verify IAS report signing certificate with IAS CA certificate required\n");
+                    "verify IAS report signing certificate with IAS CA certificate required\n");
 #else
         // failure expected
         COND2LOGERR(r != VERIFY_FAILURE,
-            "verify IAS report signing certificate with IAS CA certificate NOT required\n");
+                    "verify IAS report signing certificate with IAS CA certificate NOT required\n");
 #endif
     }
 
@@ -1094,16 +1111,20 @@ d4poyb6IW8KCJbxfMJvkordNOgOUUxndPHEi/tb/U7uLjLOgPA==
             "irjfH4f4GGrnbWYCYK5wfB1BBbFl8ppqxm4Gr8ekePCPLMjYYLpKYWEipvTgaYl63zg+C9r8g+"
             "sIA3I9Jr3Exg==";
         int r = verify_ias_report_signature(ias_report_signing_cert_pem,
-            (char*)mock_verification_report, mock_report_len, (char*)bad_mock_signature,
-            strlen((char*)bad_mock_signature));
+                                            (char*)mock_verification_report,
+                                            mock_report_len,
+                                            (char*)bad_mock_signature,
+                                            strlen((char*)bad_mock_signature));
         // failure expected
         COND2LOGERR(r != VERIFY_FAILURE, "verify bad IAS signature\n");
     }
 
     {  // verify good IAS signature
         int r = verify_ias_report_signature(ias_report_signing_cert_pem,
-            (char*)mock_verification_report, mock_report_len, (char*)mock_signature,
-            strlen((char*)mock_signature));
+                                            (char*)mock_verification_report,
+                                            mock_report_len,
+                                            (char*)mock_signature,
+                                            strlen((char*)mock_signature));
         // success expected
         COND2LOGERR(r == VERIFY_FAILURE, "verify good IAS signature\n");
     }
@@ -1129,16 +1150,20 @@ d4poyb6IW8KCJbxfMJvkordNOgOUUxndPHEi/tb/U7uLjLOgPA==
             "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAy7+"
             "m9Dx2rPbbbBWJUud3AHHnxoFWhlMQCyNjtVRvD2AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\"}";
         int r = verify_ias_report_signature(ias_report_signing_cert_pem,
-            (char*)bad_mock_verification_report, strlen((char*)bad_mock_verification_report),
-            (char*)mock_signature, strlen((char*)mock_signature));
+                                            (char*)bad_mock_verification_report,
+                                            strlen((char*)bad_mock_verification_report),
+                                            (char*)mock_signature,
+                                            strlen((char*)mock_signature));
         // failure expected
         COND2LOGERR(r != VERIFY_FAILURE, "verify bad IAS report\n");
     }
 
     {  // verify with null ias certificate
-        int r = verify_ias_report_signature(NULL, (char*)mock_verification_report,
-            strlen((char*)mock_verification_report), (char*)mock_signature,
-            strlen((char*)mock_signature));
+        int r = verify_ias_report_signature(NULL,
+                                            (char*)mock_verification_report,
+                                            strlen((char*)mock_verification_report),
+                                            (char*)mock_signature,
+                                            strlen((char*)mock_signature));
         // failure expected
         COND2LOGERR(r != VERIFY_FAILURE, "verify with null ias certificate\n");
     }
@@ -1253,8 +1278,10 @@ d4poyb6IW8KCJbxfMJvkordNOgOUUxndPHEi/tb/U7uLjLOgPA==
 
     {  // verify signature with bad certificate
         int r = verify_ias_report_signature("this is a bad certificate",
-            (char*)mock_verification_report, mock_report_len, (char*)mock_signature,
-            strlen((char*)mock_signature));
+                                            (char*)mock_verification_report,
+                                            mock_report_len,
+                                            (char*)mock_signature,
+                                            strlen((char*)mock_signature));
         // failure expected
         COND2LOGERR(r != VERIFY_FAILURE, "verify signature with bad certificate\n");
     }
@@ -1262,8 +1289,10 @@ d4poyb6IW8KCJbxfMJvkordNOgOUUxndPHEi/tb/U7uLjLOgPA==
     {  // verify signature with bad encoding
         char bad_mock_signature[] = "Aaa";
         int r = verify_ias_report_signature(ias_report_signing_cert_pem,
-            (char*)mock_verification_report, mock_report_len, (char*)bad_mock_signature,
-            strlen((char*)bad_mock_signature));
+                                            (char*)mock_verification_report,
+                                            mock_report_len,
+                                            (char*)bad_mock_signature,
+                                            strlen((char*)bad_mock_signature));
         // failure expected
         COND2LOGERR(r != VERIFY_FAILURE, "verify signature with bad encoding\n");
     }

--- a/pservice/lib/libpdo_enclave/secret_enclave.cpp
+++ b/pservice/lib/libpdo_enclave/secret_enclave.cpp
@@ -614,8 +614,8 @@ pdo_err_t VerifyEnclaveInfo(const std::string& enclaveInfo,
     //Verify verification report signature
 
     int r;
-    //verify good quote, but group-of-date is not considered ok
-    r = verify_enclave_quote_status(verificationReport.c_str(), verificationReport.length(), 1);
+    // verify quote (group-of-date is considered ok)
+    r = verify_enclave_quote_status(verificationReport.c_str(), verificationReport.length(), QSF_ACCEPT_GROUP_OUT_OF_DATE);
     pdo::error::ThrowIf<pdo::error::ValueError>(
         r!=VERIFY_SUCCESS, "Invalid Enclave Quote:  group-of-date NOT OKAY");
 


### PR DESCRIPTION
This PR contributes:
* an improved parsing of the json blob in the quote/report
* an extension to the report verification process to include additional SGX quote statuses
* a generalization of the policy-based verification procedure whereby users can specify whether to accept/reject specific quote statuses (among the `*_NEEDED` ones)
* tests related to the added/improved functionality

Signed-off-by: Bruno Vavala <bruno.vavala@intel.com>