### PR TITLE
Fix secp256k1

### DIFF
--- a/build/Makefile
+++ b/build/Makefile
@@ -98,7 +98,7 @@ $(PYTHON_DIR) :
 	. $(abspath $(DSTDIR)/bin/activate) && pip install --upgrade pyyaml
 	. $(abspath $(DSTDIR)/bin/activate) && pip install --upgrade google
 	. $(abspath $(DSTDIR)/bin/activate) && pip install --upgrade protobuf
-	. $(abspath $(DSTDIR)/bin/activate) && pip install --upgrade secp256k1
+	. $(abspath $(DSTDIR)/bin/activate) && pip install secp256k1==0.13.2
 	. $(abspath $(DSTDIR)/bin/activate) && pip install --upgrade cryptography
 	. $(abspath $(DSTDIR)/bin/activate) && pip install --upgrade pyparsing
 	. $(abspath $(DSTDIR)/bin/activate) && pip install --upgrade lmdb


### PR DESCRIPTION
The build fails due to a recent update to the secp256k1 API which is used for Sawtooth.
We stick for now to the original old version.

Signed-off-by: Bruno Vavala <bruno.vavala@intel.com>