### PR TITLE
Implement wawaka function for parsing an SGX quote & report body

### DIFF
--- a/client/pdo/client/controller/contract_controller.py
+++ b/client/pdo/client/controller/contract_controller.py
@@ -311,6 +311,9 @@ class ContractController(cmd.Cmd) :
         self.bindings.bind('_error_code_', str(0))
         self.bindings.bind('_error_message_', "")
 
+        self.exit_code = 0
+        self.exit_message = ''
+
         return False
 
     # -----------------------------------------------------------------
@@ -319,6 +322,12 @@ class ContractController(cmd.Cmd) :
         untrap_error -- stop catching errors
         """
         if self.deferred > 0 : return False
+
+        self.bindings.bind('_error_code_', str(0))
+        self.bindings.bind('_error_message_', "")
+
+        self.exit_code = 0
+        self.exit_message = ''
 
         self.__error__ = self.__default_error_handler__
         return False

--- a/common/interpreter/wawaka_wasm/WasmCryptoExtensions.h
+++ b/common/interpreter/wawaka_wasm/WasmCryptoExtensions.h
@@ -138,3 +138,10 @@ extern "C" bool verify_sgx_report_wrapper(
     const int32 report_buffer_length,
     const int32 signature_buffer_offset,
     const int32 signature_buffer_length);
+
+extern "C" bool parse_sgx_report_wrapper(
+    wasm_exec_env_t exec_env,
+    const int32 report_buffer_offset,
+    const int32 report_buffer_length,
+    int32 msg_buffer_pointer_offset,
+    int32 msg_length_pointer_offset);

--- a/common/interpreter/wawaka_wasm/WasmExtensions.cpp
+++ b/common/interpreter/wawaka_wasm/WasmExtensions.cpp
@@ -186,6 +186,7 @@ static NativeSymbol native_symbols[] =
     EXPORT_WASM_API_WITH_SIG2(crypto_hash,"(iiii)i"),
     EXPORT_WASM_API_WITH_SIG2(random_identifier,"(ii)i"),
     EXPORT_WASM_API_WITH_SIG2(verify_sgx_report,"(iiiiii)i"),
+    EXPORT_WASM_API_WITH_SIG2(parse_sgx_report,"(iiii)i"),
 
     /* Persistent store operations from WasmStateExtensions.h */
     EXPORT_WASM_API_WITH_SIG2(key_value_set,"(i*~*~)i"),

--- a/common/interpreter/wawaka_wasm/WasmExtensions.h
+++ b/common/interpreter/wawaka_wasm/WasmExtensions.h
@@ -169,6 +169,12 @@ bool verify_sgx_report(
     const char* signature_buffer,
     const size_t signature_length);
 
+bool parse_sgx_report(
+    const char* report_buffer_offset,
+    const size_t report_buffer_length,
+    char** msg_buffer,
+    size_t* msg_length);
+
 // From WasmExtensions
 bool contract_log(
     const uint32_t loglevel,

--- a/contracts/wawaka/attestation-test/scripts/attestation-test.psh
+++ b/contracts/wawaka/attestation-test/scripts/attestation-test.psh
@@ -113,16 +113,20 @@ if -e ${_r_} false
    exit -v 1
 fi
 
+echo ${INFO} ${_r_} ${ENDC}
+
+trap_error
+
 attestation -q -f ${save}/contract1.pdo verify_sgx_report -s _r_ -c ${_certificate_} -r ${_report_} -i ${_bad_signature_}
-if -e ${_r_} true
+if -e ${_error_code_} 0
    echo failed to identify invalid SGX signature
-   exit -v 1
+   exit -v -1
 fi
 
 attestation -q -f ${save}/contract1.pdo verify_sgx_report -s _r_ -c ${_certificate_} -r "badreport" -i ${_signature_}
-if -e ${_r_} true
-   echo failed to identify invalid SGX report
-   exit -v 1
+if -e ${_error_code_} 0
+   echo failed to identify invalid SGX signature
+   exit -v -1
 fi
 
-exit
+untrap_error

--- a/contracts/wawaka/common/Attestation.cpp
+++ b/contracts/wawaka/common/Attestation.cpp
@@ -1,0 +1,69 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//#include <malloc.h>
+#include <algorithm>
+#include <stdint.h>
+#include <string>
+
+#include "Attestation.h"
+#include "Util.h"
+#include "Value.h"
+#include "WasmExtensions.h"
+
+/* ----------------------------------------------------------------- *
+ * NAME: ww::attestation::verify_sgx_report
+ * ----------------------------------------------------------------- */
+bool ww::attestation::verify_sgx_report(
+    const std::string& certificate,
+    const std::string& report,
+    const std::string& signature)
+{
+    return ::verify_sgx_report(
+        certificate.c_str(), certificate.length(),
+        report.c_str(), report.length(),
+        signature.c_str(), signature.length());
+}
+
+/* ----------------------------------------------------------------- *
+ * NAME: ww::attestation::parse_sgx_report
+ * ----------------------------------------------------------------- */
+bool ww::attestation::parse_sgx_report(
+    const std::string& report,
+    ww::value::Object& parsed)
+{
+    std::string result;
+    char* data_pointer = NULL;
+    size_t data_size = 0;
+
+    bool status = ::parse_sgx_report(
+        report.c_str(), report.length(),
+        &data_pointer, &data_size);
+
+    if (! status)
+    {
+        CONTRACT_SAFE_LOG(3, "failed to parse sgx report");
+        return false;
+    }
+
+    status = parsed.deserialize(data_pointer);
+    if (! status)
+    {
+        CONTRACT_SAFE_LOG(3, "unexpected error: parse_sgx_report returned invalid");
+        return false;
+    }
+
+    return true;
+}

--- a/contracts/wawaka/common/Attestation.h
+++ b/contracts/wawaka/common/Attestation.h
@@ -1,0 +1,36 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <string>
+
+#include "Value.h"
+
+namespace ww
+{
+namespace attestation
+{
+    bool verify_sgx_report(
+        const std::string& certificate,
+        const std::string& report,
+        const std::string& signature);
+
+    bool parse_sgx_report(
+        const std::string& report,
+        ww::value::Object& parsed);
+};                              /* namespace attestation */
+};                              /* namespac ww */


### PR DESCRIPTION
Add wawaka native function to parse the sgx quote and report
    
Add a function, sgx_parse_report, to convert the binary sgx report into a JSON structure that can be interpreted by the contract. Add a new common function package for processing the sgx attestation. Update the tests for the new values.

Also fix a bug in the error handling of pdo-shell.
