### PR TITLE
More functions to simplify wawaka contract development

### DIFF
--- a/contracts/wawaka/attestation-test/attestation-test.cpp
+++ b/contracts/wawaka/attestation-test/attestation-test.cpp
@@ -16,7 +16,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "Types.h"
 #include "Dispatch.h"
 
 #include "Attestation.h"
@@ -25,65 +24,48 @@
 #include "KeyValue.h"
 #include "Message.h"
 #include "Response.h"
+#include "Secret.h"
+#include "StateReference.h"
+#include "Types.h"
 #include "Util.h"
 #include "Value.h"
 #include "WasmExtensions.h"
 
-static KeyValueStore meta_store("meta");
-static KeyValueStore endpoint_store("endpoint");
+#include "contract/base.h"
+#include "contract/attestation.h"
 
-const std::string code_hash_key("code-hash");
+static KeyValueStore secret_store("secret");
+
 const std::string secret_key("secret-key");
-const std::string ledger_key("ledger-key");
-
-bool set_ledger_key(const std::string& ledger_verifying_key)
-{
-    return meta_store.set(ledger_key, ledger_verifying_key);
-}
-
-bool get_ledger_key(std::string& ledger_verifying_key)
-{
-    if (! meta_store.get(ledger_key, ledger_verifying_key))
-        return false;
-    return true;
-}
-
-bool ledger_key_initialized(void)
-{
-    std::string key;
-    if (! get_ledger_key(key))
-        return false;
-    if (key.length() == 0)
-        return false;
-    return true;
-}
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // NAME: initialize
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 bool initialize_contract(const Environment& env, Response& rsp)
 {
-    if (! set_ledger_key(""))
-        return rsp.error("failed to initialize the meta store");
+    ASSERT_SUCCESS(rsp, ww::contract::base::initialize_contract(env),
+                   "failed to initialize the base contract");
+    ASSERT_SUCCESS(rsp, ww::contract::attestation::initialize_contract(env),
+                   "failed to initialize the attestation contract");
 
-    // compute the our code hash, we'll use it later for verification of endpoints
-    // that must have the same code we do
-    ww::types::ByteArray name;
-    if (! KeyValueStore::privileged_get("ContractCode.Name", name))
-        return rsp.error("failed to initialize code name");
-
-    ww::types::ByteArray code_buffer;
-    if (! KeyValueStore::privileged_get("ContractCode.Code", code_buffer))
-        return rsp.error("failed to initialize code hash");
-
-    std::copy(name.begin(), name.end(), std::back_inserter(code_buffer));
-
+    // save the code hash for verifying attestations
     ww::types::ByteArray code_hash;
-    if (! ww::crypto::crypto_hash(code_buffer, code_hash))
-        return rsp.error("failed to compute code hash");
+    ASSERT_SUCCESS(rsp, ww::contract::attestation::compute_code_hash(code_hash),
+                   "failed to compute the code hash");
+    ASSERT_SUCCESS(rsp, ww::contract::attestation::set_code_hash(code_hash),
+                   "failed to save the code hash");
 
-    if (! meta_store.set(code_hash_key, code_hash))
-        return rsp.error("failed to save the code hash");
+    // generate and store a secret
+    ww::types::ByteArray secret;
+    if (! ww::crypto::random_identifier(secret))
+        return rsp.error("failed to create secret");
+
+    std::string encoded_secret;
+    if (! ww::crypto::b64_encode(secret, encoded_secret))
+        return rsp.error("failed to encode secret");
+
+    if (! secret_store.set(secret_key, encoded_secret))
+        return rsp.error("failed to save secret");
 
     return rsp.success(true);
 }
@@ -91,188 +73,20 @@ bool initialize_contract(const Environment& env, Response& rsp)
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // NAME: initialize
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-#define INITIALIZE_PARAMETER_SCHEMA "{\"ledger_verifying_key\":\"\"}"
+#define INITIALIZE_PARAMETER_SCHEMA "{" SCHEMA_KW(ledger_verifying_key, "") "}"
 
 bool initialize(const Message& msg, const Environment& env, Response& rsp)
 {
+    ASSERT_UNINITIALIZED(rsp);
     ASSERT_SENDER_IS_CREATOR(env, rsp);
     ASSERT_SUCCESS(rsp, msg.validate_schema(INITIALIZE_PARAMETER_SCHEMA),
                    "invalid request, missing required parameters");
 
-    if (ledger_key_initialized())
-        return rsp.error("contract has already been initialized");
-
     const std::string ledger_verifying_key(msg.get_string("ledger_verifying_key"));
-    if (! set_ledger_key(ledger_verifying_key))
-        return rsp.error("failed to save the ledger verifying key");
+    ASSERT_SUCCESS(rsp, ww::contract::attestation::set_ledger_key(ledger_verifying_key),
+                   "failed to save the ledger verifying key");
 
-    return rsp.success(true);
-}
-
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-// NAME: get_contract_metadata
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-bool get_contract_metadata(const Message& msg, const Environment& env, Response& rsp)
-{
-    ASSERT_SENDER_IS_CREATOR(env, rsp);
-
-    // we really don't need the ledger key for this operation, but
-    // in general we want the initialization to happen first
-    if (! ledger_key_initialized())
-        return rsp.error("contract has not been initialized");
-
-    std::string verifying_key;
-    if (! KeyValueStore::privileged_get("ContractKeys.Verifying", verifying_key))
-        return rsp.error("failed to retreive privileged value for ContractKeys.Verifying");
-
-    std::string encryption_key;
-    if (! KeyValueStore::privileged_get("ContractKeys.Encryption", encryption_key))
-        return rsp.error("failed to retreive privileged value for ContractKeys.Encryption");
-
-    ww::value::Object result;
-    result.set_string("verifying_key", verifying_key.c_str());
-    result.set_string("encryption_key", encryption_key.c_str());
-
-    return rsp.value(result, false);
-}
-
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-// NAME: get_contract_code_metadata
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-bool get_contract_code_metadata(const Message& msg, const Environment& env, Response& rsp)
-{
-    ASSERT_SENDER_IS_CREATOR(env, rsp);
-
-    // we really don't need the ledger key for this operation, but
-    // in general we want the initialization to happen first
-    if (! ledger_key_initialized())
-        return rsp.error("contract has not been initialized");
-
-    // returning all the information for now though only the nonce
-    // should be necessary for the attestation test
-    std::string code_nonce;
-    if (! KeyValueStore::privileged_get("ContractCode.Nonce", code_nonce))
-        return rsp.error("failed to retreive privileged value for ContractCode.Nonce");
-
-    ww::value::Object result;
-    result.set_string("code_nonce", code_nonce.c_str());
-
-    return rsp.value(result, false);
-}
-
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-// NAME: add_endpoint
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-
-#define ADD_ENDPOINT_PARAMETER_SCHEMA                                   \
-     "{"                                                                \
-          "\"contract_id\":\"\","                                       \
-          "\"ledger_attestation\":{ \"contract_code_hash\":\"\", \"metadata_hash\":\"\", \"signature\":\"\" }," \
-          "\"contract_metadata\":{ \"verifying_key\":\"\", \"encryption_key\":\"\" }," \
-          "\"contract_code_metadata\":{ \"code_nonce\":\"\" }" \
-     "}"
-
-bool add_endpoint(const Message& msg, const Environment& env, Response& rsp)
-{
-    // to add an endpoint we do need the ledger key
-    std::string ledger_key;
-    if (! get_ledger_key(ledger_key) && ledger_key.length() > 0)
-        return rsp.error("contract has not been initialized");
-
-    // extract the parameters
-    ASSERT_SUCCESS(rsp, msg.validate_schema(ADD_ENDPOINT_PARAMETER_SCHEMA),
-                   "invalid request, missing required parameters");
-
-    const std::string contract_id(msg.get_string("contract_id"));
-    const std::string ledger_code_hash(msg.get_string("ledger_attestation.contract_code_hash"));
-    const std::string ledger_meta_hash(msg.get_string("ledger_attestation.metadata_hash"));
-    const std::string ledger_signature(msg.get_string("ledger_attestation.signature"));
-    const std::string verifying_key(msg.get_string("contract_metadata.verifying_key"));
-    const std::string encryption_key(msg.get_string("contract_metadata.encryption_key"));
-    const std::string code_nonce(msg.get_string("contract_code_metadata.code_nonce"));
-
-    // we are going to assume that the invoker of this method is the creator
-    // of the contract being added so the creator id will come from the environment
-    const std::string creator(env.originator_id_);
-
-    // verify the ledger's signature on the metadata_hash and code_hash
-    {
-        ww::types::ByteArray buffer;
-        std::copy(contract_id.begin(), contract_id.end(), std::back_inserter(buffer));
-        std::copy(creator.begin(), creator.end(), std::back_inserter(buffer));
-        std::copy(ledger_code_hash.begin(), ledger_code_hash.end(), std::back_inserter(buffer));
-        std::copy(ledger_meta_hash.begin(), ledger_meta_hash.end(), std::back_inserter(buffer));
-
-        ww::types::ByteArray signature;
-        if (! ww::crypto::b64_decode(ledger_signature, signature))
-            return rsp.error("failed to decode ledger signature");
-        if (! ww::crypto::ecdsa::verify_signature(buffer, ledger_key, signature))
-            return rsp.error("failed to verify ledger signature");
-    }
-
-    // verify that the code hash matches the code hash in the ledger
-    {
-        // we compute the merkle root using the hash of our own code
-        // so we know the hash of the other if it matches
-        ww::types::ByteArray decoded_code_hash;
-        if (! meta_store.get(code_hash_key, decoded_code_hash))
-            return rsp.error("failed to retrieve code hash");
-
-        ww::types::ByteArray nonce(code_nonce.begin(), code_nonce.end());
-        ww::types::ByteArray decoded_nonce_hash;
-        if (! ww::crypto::crypto_hash(nonce, decoded_nonce_hash))
-            return rsp.error("failed to hash code nonce");
-
-        ww::types::ByteArray buffer;
-        std::copy(decoded_code_hash.begin(), decoded_code_hash.end(), std::back_inserter(buffer));
-        std::copy(decoded_nonce_hash.begin(), decoded_nonce_hash.end(), std::back_inserter(buffer));
-
-        ww::types::ByteArray decoded_code_hash_root;
-        if (! ww::crypto::crypto_hash(buffer, decoded_code_hash_root))
-            return rsp.error("failed to create the code hash root");
-
-        ww::types::ByteArray decoded_ledger_code_hash;
-        if (! ww::crypto::b64_decode(ledger_code_hash, decoded_ledger_code_hash))
-            return rsp.error("failed to decoded ledger code hash");
-
-        if (decoded_ledger_code_hash != decoded_code_hash_root)
-            return rsp.error("attestation of code hash failed");
-    }
-
-    // verify that the metadata hash matches the metadata hash in the ledger
-    {
-        ww::types::ByteArray idhash;
-        if (! ww::crypto::b64_decode(contract_id, idhash))
-            return rsp.error("failed to decode the contract id");
-
-        ww::types::ByteArray buffer;
-        std::copy(idhash.begin(), idhash.end(), std::back_inserter(buffer));
-        std::copy(verifying_key.begin(), verifying_key.end(), std::back_inserter(buffer));
-        std::copy(encryption_key.begin(), encryption_key.end(), std::back_inserter(buffer));
-
-        ww::types::ByteArray computed_hash;
-        if (! ww::crypto::crypto_hash(buffer, computed_hash))
-            return rsp.error("failed to compute the hash for metadata comparison");
-
-        ww::types::ByteArray decoded_ledger_meta_hash;
-        if (! ww::crypto::b64_decode(ledger_meta_hash, decoded_ledger_meta_hash))
-            return rsp.error("failed to decoded ledger code hash");
-
-        if (computed_hash != decoded_ledger_meta_hash)
-            return rsp.error("computed metadata hash not the same as the stored hash");
-    }
-
-    // now store the information about the endpoint
-    ww::value::Object endpoint_information;
-    endpoint_information.set_string("verifying_key", verifying_key.c_str());
-    endpoint_information.set_string("encryption_key", encryption_key.c_str());
-
-    std::string serialized_endpoint_information;
-    if (! endpoint_information.serialize(serialized_endpoint_information))
-        return rsp.error("failed to serialize endpoint information");
-
-    if (! endpoint_store.set(contract_id, serialized_endpoint_information))
-        return rsp.error("failed to save the endpoint information");
+    ASSERT_SUCCESS(rsp, ww::contract::base::mark_initialized(), "initialization failed");
 
     return rsp.success(true);
 }
@@ -280,71 +94,99 @@ bool add_endpoint(const Message& msg, const Environment& env, Response& rsp)
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // NAME: send_secret
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-#define SEND_SECRET_PARAMETER_SCHEMA "{\"contract_id\":\"\"}"
+#define SEND_SECRET_PARAMETER_SCHEMA "{" SCHEMA_KW(contract_id,"") "}"
 
 bool send_secret(const Message& msg, const Environment& env, Response& rsp)
 {
-    return rsp.success(false);
+    ASSERT_INITIALIZED(rsp);
+    ASSERT_SUCCESS(rsp, msg.validate_schema(SEND_SECRET_PARAMETER_SCHEMA),
+                   "invalid request, missing required parameters");
+
+    const std::string contract_id(msg.get_string("contract_id"));
+    std::string verifying_key, encryption_key;
+    ASSERT_SUCCESS(rsp, ww::contract::attestation::get_endpoint(contract_id, verifying_key, encryption_key),
+                   "unknown contract");
+
+    std::string encoded_secret;
+    if (! secret_store.get(secret_key, encoded_secret))
+        return rsp.error("failed to get the secret");
+
+    ww::value::Object result;
+
+    ww::value::StateReference reference(env);
+    ww::value::Object serialized_reference;
+    ASSERT_SUCCESS(rsp, reference.serialize(serialized_reference), "failed to serialize state reference");
+    ASSERT_SUCCESS(rsp, result.set_value("reference", serialized_reference), "failed to save state reference");
+
+    ww::value::Object secret;
+    ASSERT_SUCCESS(rsp, ww::secret::send_secret(encryption_key, encoded_secret, secret), "failed to encrypt secret");
+    ASSERT_SUCCESS(rsp, result.set_value("secret", secret), "failed to save secret");
+
+    return rsp.value(result, false);
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // NAME: receive_secret
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-#define RECV_SECRET_PARAMETER_SCHEMA "{\"ledger_verifying_key\":\"\"}"
+#define RECV_SECRET_PARAMETER_SCHEMA                    \
+    "{"                                                 \
+        "\"reference\":" STATE_REFERENCE_SCHEMA ","     \
+        "\"secret\":" CONTRACT_SECRET_SCHEMA            \
+    "}"
 
 bool recv_secret(const Message& msg, const Environment& env, Response& rsp)
 {
-    return rsp.success(false);
-}
+    std::string s;
+    msg.serialize(s);
+    CONTRACT_SAFE_LOG(3, "SECRET: %s", s.c_str());
 
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-// NAME: generate_secret
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-bool generate_secret(const Message& msg, const Environment& env, Response& rsp)
-{
-    ASSERT_SENDER_IS_CREATOR(env, rsp);
+    ASSERT_INITIALIZED(rsp);
+    ASSERT_SUCCESS(rsp, msg.validate_schema(RECV_SECRET_PARAMETER_SCHEMA),
+                   "invalid request, missing required parameters");
+
+    ww::value::Object secret;
+    ASSERT_SUCCESS(rsp, msg.get_value("secret", secret), "failed to get secret parameter");
+
+    ww::value::StateReference reference;
+    ww::value::Object serialized_reference;
+    ASSERT_SUCCESS(rsp, msg.get_value("reference", serialized_reference), "failed to get reference");
+    ASSERT_SUCCESS(rsp, reference.deserialize(serialized_reference), "failed to deserialize reference");
+
+    std::string decryption_key;
+    ASSERT_SUCCESS(rsp, KeyValueStore::privileged_get("ContractKeys.Decryption", decryption_key),
+                   "failed to retreive privileged value for ContractKeys.Deccryption");
 
     std::string encoded_secret;
-    if (meta_store.get(secret_key, encoded_secret))
-        return rsp.error("the secret has already been generated");
+    ASSERT_SUCCESS(rsp, ww::secret::recv_secret(decryption_key, secret, encoded_secret),
+                   "failed to decrypt the secret");
 
-    ww::types::ByteArray secret;
-    if (! ww::crypto::random_identifier(secret))
-        return rsp.error("failed to create secret");
+    ASSERT_SUCCESS(rsp, secret_store.set(secret_key, encoded_secret),
+                   "failed to save secret");
 
-    if (! ww::crypto::b64_encode(secret, encoded_secret))
-        return rsp.error("failed to encode secret");
-
-    if (! meta_store.set(secret_key, encoded_secret))
-        return rsp.error("failed to save secret");
-
+    reference.add_to_response(rsp);
     return rsp.success(true);
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // NAME: reveal_secret
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-#define REVEAL_SECRET_PARAMETER_SCHEMA          \
-     "{"                                        \
-          "\"ledger_signature\":\"\""           \
-     "}"
+#define REVEAL_SECRET_PARAMETER_SCHEMA "{" SCHEMA_KW(ledger_signature,"") "}"
 
 bool reveal_secret(const Message& msg, const Environment& env, Response& rsp)
 {
+    ASSERT_INITIALIZED(rsp);
+    ASSERT_SENDER_IS_CREATOR(env, rsp);
+
     // two conditions must be met to reveal the secret:
     // 1) the secret must have been generated and stored in state
     // 2) the state must have been committed to the ledger
 
     std::string ledger_key;
-    if (! get_ledger_key(ledger_key) && ledger_key.length() > 0)
+    if (! ww::contract::attestation::get_ledger_key(ledger_key) && ledger_key.length() > 0)
         return rsp.error("contract has not been initialized");
 
     ASSERT_SUCCESS(rsp, msg.validate_schema(REVEAL_SECRET_PARAMETER_SCHEMA),
                    "invalid request, missing required parameters");
-
-    std::string encoded_secret;
-    if (! meta_store.get(secret_key, encoded_secret))
-        return rsp.error("no secret has been generated");
 
     const std::string ledger_signature(msg.get_string("ledger_signature"));
 
@@ -358,6 +200,10 @@ bool reveal_secret(const Message& msg, const Environment& env, Response& rsp)
     if (! ww::crypto::ecdsa::verify_signature(buffer, ledger_key, signature))
         return rsp.error("failed to verify ledger signature");
 
+    std::string encoded_secret;
+    ASSERT_SUCCESS(rsp, secret_store.get(secret_key, encoded_secret),
+                   "failed to retrieve the stored secret");
+
     ww::value::String result(encoded_secret.c_str());
     return rsp.value(result, false);
 }
@@ -367,13 +213,16 @@ bool reveal_secret(const Message& msg, const Environment& env, Response& rsp)
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #define VERIFY_SGX_REPORT_PARAMETER_SCHEMA      \
      "{"                                        \
-          "\"certificate\":\"\","               \
-          "\"report\":\"\","                    \
-          "\"signature\":\"\""                  \
+         SCHEMA_KW(certificate, "") ","         \
+         SCHEMA_KW(report, "") ","              \
+         SCHEMA_KW(signature, "")               \
      "}"
 
 bool verify_sgx_report(const Message& msg, const Environment& env, Response& rsp)
 {
+    ASSERT_INITIALIZED(rsp);
+    ASSERT_SENDER_IS_CREATOR(env, rsp);
+
     ASSERT_SUCCESS(rsp, msg.validate_schema(VERIFY_SGX_REPORT_PARAMETER_SCHEMA),
                    "invalid request, missing required parameters");
 
@@ -401,10 +250,9 @@ bool verify_sgx_report(const Message& msg, const Environment& env, Response& rsp
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 contract_method_reference_t contract_method_dispatch_table[] = {
     CONTRACT_METHOD(initialize),
-    CONTRACT_METHOD(get_contract_metadata),
-    CONTRACT_METHOD(get_contract_code_metadata),
-    CONTRACT_METHOD(add_endpoint),
-    CONTRACT_METHOD(generate_secret),
+    CONTRACT_METHOD2(get_contract_metadata, ww::contract::attestation::get_contract_metadata),
+    CONTRACT_METHOD2(get_contract_code_metadata, ww::contract::attestation::get_contract_code_metadata),
+    CONTRACT_METHOD2(add_endpoint, ww::contract::attestation::add_endpoint),
     CONTRACT_METHOD(recv_secret),
     CONTRACT_METHOD(send_secret),
     CONTRACT_METHOD(reveal_secret),

--- a/contracts/wawaka/attestation-test/plugins/attestation-test.py
+++ b/contracts/wawaka/attestation-test/plugins/attestation-test.py
@@ -54,13 +54,12 @@ def __command_attestation__(state, bindings, pargs) :
     subparser.add_argument('-m', '--contract-metadata',
                            help='contract metadata', type=invocation_parameter, required=True)
 
-    subparser = subparsers.add_parser('generate_secret')
-    subparser.add_argument('-s', '--symbol', help='binding symbol for result', type=str)
-
     subparser = subparsers.add_parser('send_secret')
+    subparser.add_argument('-i', '--contract-id', help='contract identifier', type=str, required=True)
     subparser.add_argument('-s', '--symbol', help='binding symbol for result', type=str)
 
     subparser = subparsers.add_parser('recv_secret')
+    subparser.add_argument('--secret', help='contract secret', type=invocation_parameter, required=True)
     subparser.add_argument('-s', '--symbol', help='binding symbol for result', type=str)
 
     subparser = subparsers.add_parser('reveal_secret')
@@ -120,10 +119,18 @@ def __command_attestation__(state, bindings, pargs) :
 
     # -------------------------------------------------------
     if options.command == 'send_secret' :
+        message = invocation_request('send_secret', contract_id=options.contract_id)
+        result = send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+        if result and options.symbol :
+            bindings.bind(options.symbol, result)
+
         return
 
     # -------------------------------------------------------
     if options.command == 'recv_secret' :
+        message = invocation_request('recv_secret', **options.secret)
+        send_to_contract(state, options.save_file, message, eservice_url=options.enclave, **extraparams)
+
         return
 
     # -------------------------------------------------------

--- a/contracts/wawaka/attestation-test/scripts/attestation-test.psh
+++ b/contracts/wawaka/attestation-test/scripts/attestation-test.psh
@@ -86,21 +86,36 @@ identity -n user2
 attestation -q -f ${save}/contract1.pdo add_endpoint -i ${_id2_} -c "${_mdc2_}" -m "${_md2_}" -l "${_info2_}"
 
 ## =================================================================
-echo ${INFO} create a signature ${ENDC}
+echo ${INFO} create a secret and share it with the other contracts ${ENDC}
 identity -n user1
-attestation -w -q -f ${save}/contract1.pdo generate_secret
+attestation -w -q -f ${save}/contract1.pdo send_secret -i ${_id2_} -s _secret_
+attestation -w -q -f ${save}/contract2.pdo recv_secret --secret "${_secret_}"
 
 ## wait for the generate_secret operation to commit otherwise the
 ## current_state command will return an old version of state, or
 ## at least might return an old version of state
 sleep -q -t 1
 
-ledger -q -s _sig_ current-state -i ${_id1_} -p signature
-attestation -q -f ${save}/contract1.pdo reveal_secret -s _secret_ -a ${_sig_}
-echo ${HEADER} secret is ${_secret_} ${ENDC}
+identity -n user1
+ledger -q -s _sig1_ current-state -i ${_id1_} -p signature
+attestation -q -f ${save}/contract1.pdo reveal_secret -s _secret1_ -a ${_sig1_}
+##echo ${HEADER} secret stored in contract 1 is ${_secret1_} ${ENDC}
+
+identity -n user2
+ledger -q -s _sig2_ current-state -i ${_id2_} -p signature
+attestation -q -f ${save}/contract2.pdo reveal_secret -s _secret2_ -a ${_sig2_}
+##echo ${HEADER} secret stored in contract 2 is ${_secret2_} ${ENDC}
+
+if --not -e ${_secret1_} ${_secret2_}
+   echo Secrets did not match
+   exit -v 1
+fi
+
+echo ${HEADER} secrets matched ${ENDC}
 
 ## =================================================================
 echo ${INFO} test sgx report verification ${ENDC}
+identity -n user1
 
 set -q -s _report_ -f ${test_data}/report.json
 set -q -s _certificate_ -f ${test_data}/certificate.pem

--- a/contracts/wawaka/common/Dispatch.h
+++ b/contracts/wawaka/common/Dispatch.h
@@ -31,3 +31,4 @@ extern bool initialize_contract(const Environment& env, Response& rsp);
 extern contract_method_reference_t contract_method_dispatch_table[];
 
 #define CONTRACT_METHOD(m) { #m, m }
+#define CONTRACT_METHOD2(n, m) { #n, m }

--- a/contracts/wawaka/common/Secret.cpp
+++ b/contracts/wawaka/common/Secret.cpp
@@ -1,0 +1,190 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//#include <malloc.h>
+#include <algorithm>
+#include <stdint.h>
+#include <string>
+
+#include "Cryptography.h"
+#include "Secret.h"
+#include "Util.h"
+#include "Value.h"
+
+#include "WasmExtensions.h"
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// NAME: send_secret
+//
+// returns a JSON encoded object:
+//
+// {
+//    "encrypted_session_key": <base64 encoded encrypted session key>
+//    "session_key_iv": <base64 encoded AES IV>
+//    "encrypted_message": <base64 encode encrypted message>
+// }
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+bool ww::secret::send_secret(
+    const std::string& encryption_key,
+    const std::string& message_string,
+    std::string& encrypted_message_string)
+{
+    ww::value::Object secret_object;
+    if (! send_secret(encryption_key, message_string, secret_object))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to encrypt secret");
+        return false;
+    }
+
+    if (! secret_object.serialize(encrypted_message_string))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to serialize message");
+        return false;
+    }
+
+    return true;
+}
+
+bool ww::secret::send_secret(
+    const std::string& encryption_key,
+    const std::string& message_string,
+    ww::value::Object& secret_object)
+{
+    // ---------- encrypt message ----------
+    ww::types::ByteArray iv;
+    ww::types::ByteArray session_key;
+    if (! ww::crypto::aes::generate_key(session_key) || ! ww::crypto::aes::generate_iv(iv))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to generate session key");
+        return false;
+    }
+
+    ww::types::ByteArray message(message_string.begin(), message_string.end());
+    ww::types::ByteArray cipher;
+    if (! ww::crypto::aes::encrypt_message(message, session_key, iv, cipher))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to encrypt the secret");
+        return false;
+    }
+
+    std::string encoded_cipher;
+    if (! ww::crypto::b64_encode(cipher, encoded_cipher))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to encode cipher text");
+        return false;
+    }
+
+    // ---------- encrypt the session key ----------
+    ww::types::ByteArray encrypted_session_key;
+    if (! ww::crypto::rsa::encrypt_message(session_key, encryption_key, encrypted_session_key))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to encrypt session key");
+        return false;
+    }
+
+    std::string encoded_session_key;
+    if (! ww::crypto::b64_encode(encrypted_session_key, encoded_session_key))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to encode session key");
+        return false;
+    }
+
+    // ---------- encode the IV ----------
+    std::string encoded_iv;
+    if (! ww::crypto::b64_encode(iv, encoded_iv))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to encode session key");
+        return false;
+    }
+
+    // ---------- build the object ----------
+    secret_object.set_string("encrypted_session_key", encoded_session_key.c_str());
+    secret_object.set_string("session_key_iv", encoded_iv.c_str());
+    secret_object.set_string("encrypted_message", encoded_cipher.c_str());
+
+    return true;
+}
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// NAME: recv_secret
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+bool ww::secret::recv_secret(
+    const std::string& decryption_key,
+    const std::string& encrypted_message_string,
+    std::string& message_string)
+{
+    ww::value::Object secret_object;
+    if (! secret_object.deserialize(encrypted_message_string.c_str()))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to deserialize secret");
+        return false;
+    }
+
+    return ww::secret::recv_secret(decryption_key, secret_object, message_string);
+}
+
+bool ww::secret::recv_secret(
+    const std::string& decryption_key,
+    const ww::value::Object& secret_object,
+    std::string& message_string)
+{
+    if (! secret_object.validate_schema(CONTRACT_SECRET_SCHEMA))
+    {
+        CONTRACT_SAFE_LOG(3, "invalid secret");
+        return false;
+    }
+
+    const std::string encoded_session_key(secret_object.get_string("encrypted_session_key"));
+    const std::string encoded_iv(secret_object.get_string("session_key_iv"));
+    const std::string encoded_cipher(secret_object.get_string("encrypted_message"));
+
+    ww::types::ByteArray iv;
+    if (! ww::crypto::b64_decode(encoded_iv, iv))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to decode session iv");
+        return false;
+    }
+
+    ww::types::ByteArray encrypted_session_key;
+    if (! ww::crypto::b64_decode(encoded_session_key, encrypted_session_key))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to decode session key");
+        return false;
+    }
+
+    ww::types::ByteArray session_key;
+    if (! ww::crypto::rsa::decrypt_message(encrypted_session_key, decryption_key, session_key))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to decrypt session key");
+        return false;
+    }
+
+    ww::types::ByteArray cipher;
+    if (! ww::crypto::b64_decode(encoded_cipher, cipher))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to decode cipher");
+        return false;
+    }
+
+    ww::types::ByteArray message;
+    if (! ww::crypto::aes::decrypt_message(cipher, session_key, iv, message))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to decrypt cipher");
+        return false;
+    }
+
+    message_string = ww::types::ByteArrayToString(message);
+    return true;
+}

--- a/contracts/wawaka/common/Secret.cpp
+++ b/contracts/wawaka/common/Secret.cpp
@@ -105,7 +105,7 @@ bool ww::secret::send_secret(
     std::string encoded_iv;
     if (! ww::crypto::b64_encode(iv, encoded_iv))
     {
-        CONTRACT_SAFE_LOG(3, "failed to encode session key");
+        CONTRACT_SAFE_LOG(3, "failed to encode iv");
         return false;
     }
 

--- a/contracts/wawaka/common/Secret.h
+++ b/contracts/wawaka/common/Secret.h
@@ -1,0 +1,55 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <string>
+
+#include "Util.h"
+#include "Value.h"
+
+#define CONTRACT_SECRET_SCHEMA                  \
+    "{"                                         \
+        SCHEMA_KW(encrypted_session_key,"") "," \
+        SCHEMA_KW(session_key_iv,"") ","        \
+        SCHEMA_KW(encrypted_message,"")         \
+    "}"
+
+namespace ww
+{
+namespace secret
+{
+    bool send_secret(
+        const std::string& encryption_key,
+        const std::string& message_string,
+        std::string& encrypted_message_string);
+
+    bool send_secret(
+        const std::string& encryption_key,
+        const std::string& message_string,
+        ww::value::Object& secret_object);
+
+    bool recv_secret(
+        const std::string& decryption_key,
+        const std::string& encrypted_message_string,
+        std::string& message_string);
+
+    bool recv_secret(
+        const std::string& decryption_key,
+        const ww::value::Object& secret_object,
+        std::string& message_string);
+};                              /* namespace secret */
+};                              /* namespac ww */

--- a/contracts/wawaka/common/StateReference.cpp
+++ b/contracts/wawaka/common/StateReference.cpp
@@ -16,7 +16,7 @@
 #include "StateReference.h"
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-// Class: ww::exchange::StateReference
+// Class: ww::value::StateReference
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 // -----------------------------------------------------------------

--- a/contracts/wawaka/common/StateReference.cpp
+++ b/contracts/wawaka/common/StateReference.cpp
@@ -1,0 +1,50 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "StateReference.h"
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// Class: ww::exchange::StateReference
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+// -----------------------------------------------------------------
+bool ww::value::StateReference::deserialize(const ww::value::Object& reference)
+{
+    if (! reference.validate_schema(STATE_REFERENCE_SCHEMA))
+        return false;
+
+    contract_id_ = reference.get_string("contract_id");
+    state_hash_ = reference.get_string("state_hash");
+    return true;
+}
+
+// -----------------------------------------------------------------
+bool ww::value::StateReference::serialize(ww::value::Value& serialized_reference) const
+{
+    ww::value::Structure reference(STATE_REFERENCE_SCHEMA);
+    if (! reference.set_string("contract_id", contract_id_.c_str()))
+        return false;
+    if (! reference.set_string("state_hash", state_hash_.c_str()))
+        return false;
+
+    serialized_reference.set(reference);
+    return true;
+}
+
+// -----------------------------------------------------------------
+bool ww::value::StateReference::add_to_response(Response& rsp) const
+{
+    return rsp.add_dependency(contract_id_, state_hash_);
+}

--- a/contracts/wawaka/common/StateReference.h
+++ b/contracts/wawaka/common/StateReference.h
@@ -1,0 +1,71 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+#include "Environment.h"
+#include "Response.h"
+#include "Util.h"
+#include "Value.h"
+
+#define STATE_REFERENCE_SCHEMA                  \
+    "{"                                         \
+        SCHEMA_KW(contract_id,"") ","           \
+        SCHEMA_KW(state_hash,"")                \
+    "}"
+
+namespace ww
+{
+namespace value
+{
+
+    class StateReference
+    {
+    public:
+        std::string contract_id_;
+        std::string state_hash_; // base64 encoded hash
+
+        bool deserialize(const ww::value::Object& reference);
+        bool serialize(ww::value::Value& serialized_reference) const;
+
+        // StateReference methods
+        bool add_to_response(Response& rsp) const;
+        bool set_from_environment(const Environment& env)
+        {
+            contract_id_ = env.contract_id_;
+            state_hash_ = env.state_hash_;
+            return true;
+        }
+
+
+        StateReference(
+            const StateReference& reference)
+            : contract_id_(reference.contract_id_), state_hash_(reference.state_hash_) {};
+
+        StateReference(
+            const std::string& contract_id = "",
+            const std::string& state_hash = "")
+            : contract_id_(contract_id), state_hash_(state_hash) {};
+
+        StateReference(
+            const Environment& env)
+            : contract_id_(env.contract_id_), state_hash_(env.state_hash_) {};
+
+    };
+
+};
+}

--- a/contracts/wawaka/common/Util.h
+++ b/contracts/wawaka/common/Util.h
@@ -19,6 +19,9 @@
 
 #include "Types.h"
 
+#define SCHEMA_KW(kw,v) "\"" #kw "\":" #v
+#define SCHEMA_KWS(kw, s) "\"" #kw "\":" s
+
 #define ASSERT_SUCCESS(_rsp_, _condition_, _message_)   \
     do {                                                \
         if (! ( _condition_) ) {                        \

--- a/contracts/wawaka/common/contract/attestation.cpp
+++ b/contracts/wawaka/common/contract/attestation.cpp
@@ -1,0 +1,363 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "Types.h"
+#include "Dispatch.h"
+
+#include "Attestation.h"
+#include "Cryptography.h"
+#include "Environment.h"
+#include "KeyValue.h"
+#include "Message.h"
+#include "Response.h"
+#include "Util.h"
+#include "Value.h"
+#include "WasmExtensions.h"
+
+#include "contract/base.h"
+#include "contract/attestation.h"
+
+static KeyValueStore contract_attestation_store("meta");
+static KeyValueStore contract_endpoint_store("endpoint");
+
+const std::string code_hash_key("code-hash");
+const std::string ledger_key("ledger-key");
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// NAME: initialize
+//
+// Method to call during contract initialization to incorporate
+// the methods necessary for the attestation functions.
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+bool ww::contract::attestation::initialize_contract(const Environment& env)
+{
+    if (! set_ledger_key(""))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to initialize the meta store");
+        return false;
+    }
+
+    ww::types::ByteArray code_hash;
+    if (! set_code_hash(code_hash))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to initialize the meta store");
+        return false;
+    }
+
+    return true;
+}
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// NAME: set_ledger_key
+//
+// Contract method to set the ledger key that will serve as the root
+// of trust for verifying contract object attestations.
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+bool ww::contract::attestation::set_ledger_key(
+    const Message& msg,
+    const Environment& env,
+    Response& rsp)
+{
+    ASSERT_SENDER_IS_CREATOR(env, rsp);
+    ASSERT_SUCCESS(rsp, msg.validate_schema(SET_LEDGER_KEY_PARAM_SCHEMA),
+                   "invalid request, missing required parameters");
+
+    const std::string ledger_verifying_key(msg.get_string("ledger_verifying_key"));
+    if (! set_ledger_key(ledger_verifying_key))
+        return rsp.error("failed to save the ledger verifying key");
+
+    return rsp.success(true);
+}
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// NAME: get_ledger_key
+//
+// Contract method to get the ledger key that has been set as the
+// contract object root of trust.
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+bool ww::contract::attestation::get_ledger_key(
+    const Message& msg,
+    const Environment& env,
+    Response& rsp)
+{
+    ASSERT_SENDER_IS_CREATOR(env, rsp);
+
+    std::string ledger_verifying_key;
+    if (! get_ledger_key(ledger_verifying_key))
+        return rsp.error("failed to get the ledger verifying key");
+
+    ww::value::String result(ledger_verifying_key.c_str());
+    return rsp.value(result, false);
+}
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// NAME: get_contract_metadata
+//
+// Contract method to get encryption and verifying key associated
+// with the contract.
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+bool ww::contract::attestation::get_contract_metadata(
+    const Message& msg,
+    const Environment& env,
+    Response& rsp)
+{
+    std::string verifying_key;
+    if (! KeyValueStore::privileged_get("ContractKeys.Verifying", verifying_key))
+        return rsp.error("failed to retreive privileged value for ContractKeys.Verifying");
+
+    std::string encryption_key;
+    if (! KeyValueStore::privileged_get("ContractKeys.Encryption", encryption_key))
+        return rsp.error("failed to retreive privileged value for ContractKeys.Encryption");
+
+    ww::value::Structure result(CONTRACT_METADATA_SCHEMA);
+    result.set_string("verifying_key", verifying_key.c_str());
+    result.set_string("encryption_key", encryption_key.c_str());
+
+    return rsp.value(result, false);
+}
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// NAME: get_contract_code_metadata
+//
+// Contract method to get the code metadata associated with the
+// contract. Note that only the creator can get this information.
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+bool ww::contract::attestation::get_contract_code_metadata(
+    const Message& msg,
+    const Environment& env,
+    Response& rsp)
+{
+    ASSERT_SENDER_IS_CREATOR(env, rsp);
+
+    // returning all the information for now though only the nonce
+    // should be necessary for the attestation test
+    std::string code_nonce;
+    if (! KeyValueStore::privileged_get("ContractCode.Nonce", code_nonce))
+        return rsp.error("failed to retreive privileged value for ContractCode.Nonce");
+
+    ww::value::Structure result(CONTRACT_CODE_METADATA_SCHEMA);
+    result.set_string("code_nonce", code_nonce.c_str());
+
+    return rsp.value(result, false);
+}
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// NAME: add_endpoint
+//
+// Contract method to verify the attestation of a contract object
+// and add it to the set of "trusted endpoints"
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+bool ww::contract::attestation::add_endpoint(
+    const Message& msg,
+    const Environment& env,
+    Response& rsp)
+{
+    // to add an endpoint we do need the ledger key
+    std::string ledger_key;
+    if (! get_ledger_key(ledger_key) && ledger_key.length() > 0)
+        return rsp.error("contract has not been initialized");
+
+    // extract the parameters
+    ASSERT_SUCCESS(rsp, msg.validate_schema(ADD_ENDPOINT_PARAM_SCHEMA),
+                   "invalid request, missing required parameters");
+
+    const std::string contract_id(msg.get_string("contract_id"));
+    const std::string ledger_code_hash(msg.get_string("ledger_attestation.contract_code_hash"));
+    const std::string ledger_meta_hash(msg.get_string("ledger_attestation.metadata_hash"));
+    const std::string ledger_signature(msg.get_string("ledger_attestation.signature"));
+    const std::string verifying_key(msg.get_string("contract_metadata.verifying_key"));
+    const std::string encryption_key(msg.get_string("contract_metadata.encryption_key"));
+    const std::string code_nonce(msg.get_string("contract_code_metadata.code_nonce"));
+
+    // we are going to assume that the invoker of this method is the creator
+    // of the contract being added so the creator id will come from the environment
+    const std::string creator(env.originator_id_);
+
+    // verify the ledger's signature on the metadata_hash and code_hash
+    {
+        ww::types::ByteArray buffer;
+        std::copy(contract_id.begin(), contract_id.end(), std::back_inserter(buffer));
+        std::copy(creator.begin(), creator.end(), std::back_inserter(buffer));
+        std::copy(ledger_code_hash.begin(), ledger_code_hash.end(), std::back_inserter(buffer));
+        std::copy(ledger_meta_hash.begin(), ledger_meta_hash.end(), std::back_inserter(buffer));
+
+        ww::types::ByteArray signature;
+        if (! ww::crypto::b64_decode(ledger_signature, signature))
+            return rsp.error("failed to decode ledger signature");
+        if (! ww::crypto::ecdsa::verify_signature(buffer, ledger_key, signature))
+            return rsp.error("failed to verify ledger signature");
+    }
+
+    // verify that the code hash matches the code hash in the ledger
+    {
+        // we compute the merkle root using the hash of our own code
+        // so we know the hash of the other if it matches
+        ww::types::ByteArray decoded_code_hash;
+        if (! contract_attestation_store.get(code_hash_key, decoded_code_hash))
+            return rsp.error("failed to retrieve code hash");
+
+        ww::types::ByteArray nonce(code_nonce.begin(), code_nonce.end());
+        ww::types::ByteArray decoded_nonce_hash;
+        if (! ww::crypto::crypto_hash(nonce, decoded_nonce_hash))
+            return rsp.error("failed to hash code nonce");
+
+        ww::types::ByteArray buffer;
+        std::copy(decoded_code_hash.begin(), decoded_code_hash.end(), std::back_inserter(buffer));
+        std::copy(decoded_nonce_hash.begin(), decoded_nonce_hash.end(), std::back_inserter(buffer));
+
+        ww::types::ByteArray decoded_code_hash_root;
+        if (! ww::crypto::crypto_hash(buffer, decoded_code_hash_root))
+            return rsp.error("failed to create the code hash root");
+
+        ww::types::ByteArray decoded_ledger_code_hash;
+        if (! ww::crypto::b64_decode(ledger_code_hash, decoded_ledger_code_hash))
+            return rsp.error("failed to decoded ledger code hash");
+
+        if (decoded_ledger_code_hash != decoded_code_hash_root)
+            return rsp.error("attestation of code hash failed");
+    }
+
+    // verify that the metadata hash matches the metadata hash in the ledger
+    {
+        ww::types::ByteArray idhash;
+        if (! ww::crypto::b64_decode(contract_id, idhash))
+            return rsp.error("failed to decode the contract id");
+
+        ww::types::ByteArray buffer;
+        std::copy(idhash.begin(), idhash.end(), std::back_inserter(buffer));
+        std::copy(verifying_key.begin(), verifying_key.end(), std::back_inserter(buffer));
+        std::copy(encryption_key.begin(), encryption_key.end(), std::back_inserter(buffer));
+
+        ww::types::ByteArray computed_hash;
+        if (! ww::crypto::crypto_hash(buffer, computed_hash))
+            return rsp.error("failed to compute the hash for metadata comparison");
+
+        ww::types::ByteArray decoded_ledger_meta_hash;
+        if (! ww::crypto::b64_decode(ledger_meta_hash, decoded_ledger_meta_hash))
+            return rsp.error("failed to decoded ledger code hash");
+
+        if (computed_hash != decoded_ledger_meta_hash)
+            return rsp.error("computed metadata hash not the same as the stored hash");
+    }
+
+    // now store the information about the endpoint
+    if (! add_endpoint(contract_id, verifying_key, encryption_key))
+        return rsp.error("unexpected error, failed to store endpoint information");
+
+    return rsp.success(true);
+}
+
+// -----------------------------------------------------------------
+// Some functions for managing the ledger key
+// -----------------------------------------------------------------
+bool ww::contract::attestation::set_ledger_key(const std::string& ledger_verifying_key)
+{
+    return contract_attestation_store.set(ledger_key, ledger_verifying_key);
+}
+
+bool ww::contract::attestation::get_ledger_key(std::string& ledger_verifying_key)
+{
+    return contract_attestation_store.get(ledger_key, ledger_verifying_key);
+}
+
+// -----------------------------------------------------------------
+// Some functions for managing the code hash
+// -----------------------------------------------------------------
+bool ww::contract::attestation::set_code_hash(const ww::types::ByteArray& code_hash)
+{
+    return contract_attestation_store.set(code_hash_key, code_hash);
+}
+
+bool ww::contract::attestation::get_code_hash(ww::types::ByteArray& code_hash)
+{
+    return contract_attestation_store.get(code_hash_key, code_hash);
+}
+
+bool ww::contract::attestation::compute_code_hash(ww::types::ByteArray& code_hash)
+{
+    ww::types::ByteArray code_buffer;
+    if (! KeyValueStore::privileged_get("ContractCode.Code", code_buffer))
+        return false;
+
+    ww::types::ByteArray name;
+    if (! KeyValueStore::privileged_get("ContractCode.Name", name))
+        return false;
+
+    std::copy(name.begin(), name.end(), std::back_inserter(code_buffer));
+
+    if (! ww::crypto::crypto_hash(code_buffer, code_hash))
+        return false;
+
+    return true;
+}
+
+// -----------------------------------------------------------------
+// Some functions for managing the endpoint registry
+// -----------------------------------------------------------------
+static const std::string ep_verifying_key("verifying_key");
+static const std::string ep_encryption_key("encryption_key");
+
+bool ww::contract::attestation::add_endpoint(
+    const std::string& contract_id,
+    const std::string& verifying_key,
+    const std::string& encryption_key)
+{
+    // now store the information about the endpoint
+    ww::value::Object endpoint_information;
+    endpoint_information.set_string("verifying_key", verifying_key.c_str());
+    endpoint_information.set_string("encryption_key", encryption_key.c_str());
+
+    std::string serialized_endpoint_information;
+    if (! endpoint_information.serialize(serialized_endpoint_information))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to serialize endpoint information");
+        return false;
+    }
+
+    if (! contract_endpoint_store.set(contract_id, serialized_endpoint_information))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to save the endpoint information");
+        return false;
+    }
+
+    return true;
+}
+
+bool ww::contract::attestation::get_endpoint(
+    const std::string& contract_id,
+    std::string& verifying_key,
+    std::string& encryption_key)
+{
+    std::string serialized_endpoint_information;
+    if (! contract_endpoint_store.get(contract_id, serialized_endpoint_information))
+    {
+        CONTRACT_SAFE_LOG(1, "endpoint not registered");
+        return false;
+    }
+
+    ww::value::Object endpoint_information;
+    if (! endpoint_information.deserialize(serialized_endpoint_information.c_str()))
+    {
+        CONTRACT_SAFE_LOG(3, "unexpected error, failed to deserialize endpoint information");
+        return false;
+    }
+
+    verifying_key = endpoint_information.get_string(ep_verifying_key.c_str());
+    encryption_key = endpoint_information.get_string(ep_encryption_key.c_str());
+    return true;
+}

--- a/contracts/wawaka/common/contract/attestation.h
+++ b/contracts/wawaka/common/contract/attestation.h
@@ -38,6 +38,7 @@
 
 #define CONTRACT_CODE_METADATA_SCHEMA           \
     "{"                                         \
+        SCHEMA_KW(code_hash,"") ","             \
         SCHEMA_KW(code_nonce,"")                \
     "}"
 

--- a/contracts/wawaka/common/contract/attestation.h
+++ b/contracts/wawaka/common/contract/attestation.h
@@ -1,0 +1,89 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+#include "Environment.h"
+#include "Message.h"
+#include "Response.h"
+#include "Types.h"
+#include "Util.h"
+
+#define LEDGER_ATTESTATION_SCHEMA               \
+    "{"                                         \
+        SCHEMA_KW(contract_code_hash,"") ","    \
+        SCHEMA_KW(metadata_hash,"") ","         \
+        SCHEMA_KW(signature,"")                 \
+    "}"
+
+#define CONTRACT_METADATA_SCHEMA                \
+    "{"                                         \
+        SCHEMA_KW(verifying_key,"") ","         \
+        SCHEMA_KW(encryption_key,"")            \
+    "}"
+
+#define CONTRACT_CODE_METADATA_SCHEMA           \
+    "{"                                         \
+        SCHEMA_KW(code_nonce,"")                \
+    "}"
+
+#define SET_LEDGER_KEY_PARAM_SCHEMA             \
+    "{"                                         \
+        SCHEMA_KW(ledger_verifying_key,"")      \
+    "}"
+
+#define ADD_ENDPOINT_PARAM_SCHEMA                                       \
+     "{"                                                                \
+         SCHEMA_KW(contract_id,"") ","                                  \
+         SCHEMA_KWS(ledger_attestation, LEDGER_ATTESTATION_SCHEMA) ","  \
+         SCHEMA_KWS(contract_metadata, CONTRACT_METADATA_SCHEMA) ","    \
+         SCHEMA_KWS(contract_code_metadata, CONTRACT_CODE_METADATA_SCHEMA) \
+     "}"
+
+namespace ww
+{
+namespace contract
+{
+namespace attestation
+{
+    // this module defines several contract methods and associated utility functions
+    // that are shared between asset contracts, specifically, the methods create
+    // an ecdsa key pair
+
+    // common function to initialize state for issuer authority use
+    bool initialize_contract(const Environment& env);
+
+    // common contract methods
+    bool set_ledger_key(const Message& msg, const Environment& env, Response& rsp);
+    bool get_ledger_key(const Message& msg, const Environment& env, Response& rsp);
+    bool get_contract_metadata(const Message& msg, const Environment& env, Response& rsp);
+    bool get_contract_code_metadata(const Message& msg, const Environment& env, Response& rsp);
+    bool add_endpoint(const Message& msg, const Environment& env, Response& rsp);
+
+    // utility functions
+    bool set_ledger_key(const std::string& ledger_verifying_key);
+    bool get_ledger_key(std::string& ledger_verifying_key);
+
+    bool compute_code_hash(ww::types::ByteArray& code_hash);
+    bool set_code_hash(const ww::types::ByteArray& code_hash);
+    bool get_code_hash(ww::types::ByteArray& code_hash);
+
+    bool add_endpoint(const std::string& contract_id, const std::string& verifying_key, const std::string& encryption_key);
+    bool get_endpoint(const std::string& contract_id, std::string& verifying_key, std::string& encryption_key);
+}; // attestation
+}; // contract
+}; // ww

--- a/contracts/wawaka/common/contract/base.cpp
+++ b/contracts/wawaka/common/contract/base.cpp
@@ -1,0 +1,211 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "Dispatch.h"
+#include "Types.h"
+
+#include "Cryptography.h"
+#include "Environment.h"
+#include "KeyValue.h"
+#include "Message.h"
+#include "Response.h"
+#include "Types.h"
+#include "Util.h"
+#include "Value.h"
+#include "WasmExtensions.h"
+
+#include "contract/base.h"
+
+static KeyValueStore contract_base_store("contract_base");
+
+static const std::string md_owner_key("owner");
+static const std::string md_initialized_key("initialized");
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// CONTRACT METHODS
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+// -----------------------------------------------------------------
+// METHOD: initialize_contract
+//   contract initialization function, this is not a method but rather
+//   the function called when the contract object is first initialized,
+//   creates an ecdsa key pair that can be used to sign messages from
+//   the contract
+//
+// JSON PARAMETERS:
+//   none
+//
+// ENVIRONMENT:
+//   creator_id_
+//
+// RETURNS:
+//   true if successfully initialized
+// -----------------------------------------------------------------
+bool ww::contract::base::initialize_contract(const Environment& env)
+{
+    // ---------- Mark as uninitialized ----------
+    const int initialized = 0;
+    if (! contract_base_store.set(md_initialized_key, initialized))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to save initialization state");
+        return false;
+    }
+
+    // ---------- Save owner information ----------
+    if (! set_owner(env.creator_id_))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to save creator metadata");
+        return false;
+    }
+
+    // ---------- RETURN ----------
+    return true;
+}
+
+// -----------------------------------------------------------------
+// METHOD: get_verifying_key
+//   contract method to retrieve the ecdsa verifying key that was
+//   created during initialization
+//
+// JSON PARAMETERS:
+//   none
+//
+// RETURNS:
+//   ecdsa verifying key
+// -----------------------------------------------------------------
+bool ww::contract::base::get_verifying_key(
+    const Message& msg,
+    const Environment& env,
+    Response& rsp)
+{
+    std::string verifying_key;
+    if (! ww::contract::base::get_verifying_key(verifying_key))
+        return rsp.error("corrupted state; verifying key not found");
+
+    ww::value::String v(verifying_key.c_str());
+    return rsp.value(v, false);
+}
+
+// -----------------------------------------------------------------
+// METHOD: get_encryption_key
+//   contract method to retrieve the rsa encryption key that was
+//   created during initialization
+//
+// JSON PARAMETERS:
+//   none
+//
+// RETURNS:
+//   rsa encryption key
+// -----------------------------------------------------------------
+bool ww::contract::base::get_encryption_key(
+    const Message& msg,
+    const Environment& env,
+    Response& rsp)
+{
+    std::string encryption_key;
+    if (! ww::contract::base::get_encryption_key(encryption_key))
+        return rsp.error("corrupted state; encryption key not found");
+
+    ww::value::String v(encryption_key.c_str());
+    return rsp.value(v, false);
+}
+
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// UTILITY FUNCTIONS
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+// -----------------------------------------------------------------
+bool ww::contract::base::get_verifying_key(std::string& verifying_key)
+{
+    if (! KeyValueStore::privileged_get("ContractKeys.Verifying", verifying_key))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to retreive privileged value for ContractKeys.Verifying");
+        return false;
+    }
+
+    return true;
+}
+
+// -----------------------------------------------------------------
+bool ww::contract::base::get_signing_key(std::string& signing_key)
+{
+    if (! KeyValueStore::privileged_get("ContractKeys.Signing", signing_key))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to retreive privileged value for ContractKeys.Signing");
+        return false;
+    }
+
+    return true;
+}
+
+// -----------------------------------------------------------------
+bool ww::contract::base::get_encryption_key(std::string& encryption_key)
+{
+    if (! KeyValueStore::privileged_get("ContractKeys.Encryption", encryption_key))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to retreive privileged value for ContractKeys.Encryption");
+        return false;
+    }
+
+    return true;
+}
+
+// -----------------------------------------------------------------
+bool ww::contract::base::get_decryption_key(std::string& decryption_key)
+{
+    if (! KeyValueStore::privileged_get("ContractKeys.Decryption", decryption_key))
+    {
+        CONTRACT_SAFE_LOG(3, "failed to retreive privileged value for ContractKeys.Decryption");
+        return false;
+    }
+
+    return true;
+}
+
+// -----------------------------------------------------------------
+bool ww::contract::base::mark_initialized(void)
+{
+    // Mark as initialized
+    const uint32_t initialized = 1;
+    if (! contract_base_store.set(md_initialized_key, initialized))
+        return false;
+
+    return true;
+}
+
+// -----------------------------------------------------------------
+bool ww::contract::base::is_initialized(void)
+{
+    uint32_t initialized = 0;
+    if (! contract_base_store.get(md_initialized_key, initialized))
+        return false;
+
+    return (initialized == 1);
+}
+
+// -----------------------------------------------------------------
+bool ww::contract::base::set_owner(const std::string& owner)
+{
+    return contract_base_store.set(md_owner_key, owner);
+}
+
+// -----------------------------------------------------------------
+bool ww::contract::base::get_owner(std::string& owner)
+{
+    return contract_base_store.get(md_owner_key, owner);
+}

--- a/contracts/wawaka/common/contract/base.h
+++ b/contracts/wawaka/common/contract/base.h
@@ -1,0 +1,78 @@
+/* Copyright 2019 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+#include "Environment.h"
+#include "Message.h"
+#include "Response.h"
+#include "Types.h"
+#include "Util.h"
+
+#define ASSERT_INITIALIZED(_rsp)                                \
+    do {                                                        \
+        if (! ww::contract::base::is_initialized())    \
+            return _rsp.error("contract is not initialized");   \
+    } while (0)
+
+#define ASSERT_UNINITIALIZED(_rsp)                                      \
+    do {                                                                \
+        if (ww::contract::base::is_initialized())              \
+            return _rsp.error("contract is already initialized");       \
+    } while (0)
+
+#define ASSERT_SENDER_IS_OWNER(_env, _rsp)                              \
+    do {                                                                \
+        std::string owner;                                              \
+        ASSERT_SUCCESS(_rsp, ww::contract::base::get_owner(owner), "failed to retrieve owner"); \
+        if (_env.originator_id_ != owner)                               \
+            return _rsp.error("only the owner may invoke this method"); \
+    } while (0)
+
+namespace ww
+{
+namespace contract
+{
+namespace base
+{
+    // this module defines several contract methods and associated utility functions
+    // that are shared between asset contracts, specifically, the methods create
+    // an ecdsa key pair
+
+    // common function to initialize state for issuer authority use
+    bool initialize_contract(const Environment& env);
+
+    // common contract methods
+    bool get_verifying_key(const Message& msg, const Environment& env, Response& rsp);
+    bool get_encryption_key(const Message& msg, const Environment& env, Response& rsp);
+
+    // utility functions
+    bool mark_initialized(void);
+    bool is_initialized(void);
+
+    bool get_verifying_key(std::string& verifying_key);
+    bool get_signing_key(std::string& signing_key);
+
+    bool get_encryption_key(std::string& encryption_key);
+    bool get_decryption_key(std::string& decryption_key);
+
+    bool set_owner(const std::string& owner);
+    bool get_owner(std::string& owner);
+
+}; // contract_base
+}; // asset
+}; // ww

--- a/contracts/wawaka/contract-build.cmake
+++ b/contracts/wawaka/contract-build.cmake
@@ -113,7 +113,9 @@ LIST(APPEND WASM_INCLUDES ${PDO_SOURCE_ROOT}/common)
 # ---------------------------------------------
 SET (WASM_SOURCE)
 FILE(GLOB WAWAKA_COMMON_SOURCE ${PDO_SOURCE_ROOT}/contracts/wawaka/common/*.cpp)
+FILE(GLOB WAWAKA_CONTRACT_SOURCE  ${PDO_SOURCE_ROOT}/contracts/wawaka/common/contract/*.cpp)
 LIST(APPEND WASM_SOURCE ${WAWAKA_COMMON_SOURCE})
+LIST(APPEND WASM_SOURCE ${WAWAKA_CONTRACT_SOURCE})
 LIST(APPEND WASM_SOURCE ${PDO_SOURCE_ROOT}/common/packages/parson/parson.cpp)
 
 ## -----------------------------------------------------------------


### PR DESCRIPTION
Two new classes of functions for the Wawaka common library:
 - Secrets -- simplify (and standardize) generating messages that can be shared between contracts; a message is encrypted with the contracts encryption key.
- Attestation -- wrappers for the sgx report verification and processing functions
    
Add library of common wawaka contract methods.
    
There are several methods that are common to many contracts. This update provides a base implementation for those methods in order to simplify contract development.

Add common contracts methods for attestations.  Provides a wrapper for managing attested contract endpoints. Contract object provides an attestation package that is verified registering the encryption & verification keys for the contract. Useful for building contracts that share secrets.

Update attestation test to use the new helpers. Replace the code in the attestation test with calls packaged in the attestation common contract code. Complete the implementation of the send/recv secret. Complete testing of the new methods.
