### PR TITLE
Temporary fix to skip checking CCF host certificate. 

### DIFF
--- a/ccf_transaction_processor/scripts/configure_ccf_network.py
+++ b/ccf_transaction_processor/scripts/configure_ccf_network.py
@@ -24,6 +24,7 @@ import os
 import sys
 import toml
 import time
+from requests.adapters import HTTPAdapter
 
 # pick up the logger used by the rest of CCF
 from loguru import logger as LOG
@@ -162,6 +163,10 @@ def Main() :
     except :
         LOG.error('failed to connect to CCF service')
         sys.exit(-1)
+
+    #Temporary fix to skip checking CCF host certificate. Version 0.11.7 CCF certificate expiration was hardcoded to end of 2021
+    member_client.client_impl.session.mount("https://", HTTPAdapter())
+    member_client.client_impl.session.verify=False
 
     open_network_script(member_client, options, config)
     add_user_script(member_client, options, config)

--- a/ccf_transaction_processor/scripts/fetch_ledger_authority.py
+++ b/ccf_transaction_processor/scripts/fetch_ledger_authority.py
@@ -20,6 +20,7 @@ import os
 import sys
 import time
 import toml
+from requests.adapters import HTTPAdapter
 
 # pick up the logger used by the rest of CCF
 from loguru import logger as LOG
@@ -110,6 +111,10 @@ def Main() :
     except :
         LOG.error('failed to connect to CCF service')
         sys.exit(-1)
+
+    #Temporary fix to skip checking CCF host certificate. Version 0.11.7 CCF certificate expiration was hardcoded to end of 2021
+    user_client.client_impl.session.mount("https://", HTTPAdapter())
+    user_client.client_impl.session.verify=False
 
     fetch_ledger_authority(user_client, options, config)
 

--- a/ccf_transaction_processor/scripts/generate_ledger_authority.py
+++ b/ccf_transaction_processor/scripts/generate_ledger_authority.py
@@ -20,6 +20,7 @@ import os
 import sys
 import time
 import toml
+from requests.adapters import HTTPAdapter
 
 # pick up the logger used by the rest of CCF
 from loguru import logger as LOG
@@ -102,6 +103,10 @@ def Main() :
     except :
         LOG.error('failed to connect to CCF service')
         sys.exit(-1)
+
+    #Temporary fix to skip checking CCF host certificate. Version 0.11.7 CCF certificate expiration was hardcoded to end of 2021
+    user_client.client_impl.session.mount("https://", HTTPAdapter())
+    user_client.client_impl.session.verify=False
 
     generate_ledger_authority(user_client, options, config)
 

--- a/ccf_transaction_processor/scripts/ping_test.py
+++ b/ccf_transaction_processor/scripts/ping_test.py
@@ -21,6 +21,7 @@ import sys
 import time
 import toml
 from urllib.parse import urlparse
+from requests.adapters import HTTPAdapter
 
 # pick up the logger used by the rest of CCF
 from loguru import logger as LOG
@@ -102,6 +103,10 @@ def Main() :
     except Exception as e :
         LOG.error('failed to connect to CCF service: {}'.format(str(e)))
         sys.exit(-1)
+
+    #Temporary fix to skip checking CCF host certificate. Version 0.11.7 CCF certificate expiration was hardcoded to end of 2021
+    user_client.client_impl.session.mount("https://", HTTPAdapter())
+    user_client.client_impl.session.verify=False
 
     ping_test(user_client, options)
 

--- a/python/pdo/submitter/ccf/ccf_submitter.py
+++ b/python/pdo/submitter/ccf/ccf_submitter.py
@@ -18,6 +18,7 @@ import time
 import os
 import sys
 import socket
+from requests.adapters import HTTPAdapter
 
 CCF_BASE = os.environ.get("CCF_BASE")
 CCF_Bin = os.path.join(CCF_BASE, "bin")
@@ -70,6 +71,10 @@ class CCFClientWrapper(CCFClient) :
             connection_timeout=3,
             request_timeout=3,
             )
+
+        #Temporary fix to skip checking CCF host certificate. Version 0.11.7 CCF certificate expiration was hardcoded to end of 2021
+        self.client_impl.session.mount("https://", HTTPAdapter())
+        self.client_impl.session.verify=False
 
         self.rpc_loggers = () #avoid the default logging to screen
 


### PR DESCRIPTION
Temporary fix to skip checking CCF host certificate. . Version 0.11.7 CCF certificate expiration was hardcoded to the end of 2021. 

Signed-off-by: Prakash Narayana Moorthy <prakash.narayana.moorthy@intel.com>