### PR TITLE
Make building wawaka common library configurable

### DIFF
--- a/contracts/wawaka/CMakeLists.txt
+++ b/contracts/wawaka/CMakeLists.txt
@@ -15,6 +15,10 @@
 cmake_minimum_required (VERSION 3.5 FATAL_ERROR)
 
 INCLUDE(contract-build.cmake)
+INCLUDE(wawaka_common.cmake)
+
+LIST(APPEND WASM_LIBRARIES ${WW_COMMON_LIB})
+LIST(APPEND WASM_INCLUDES ${WW_COMMON_INCLUDES})
 
 ADD_SUBDIRECTORY(mock-contract)
 ADD_SUBDIRECTORY(interface-test)

--- a/contracts/wawaka/Makefile
+++ b/contracts/wawaka/Makefile
@@ -102,9 +102,6 @@ attestation-test:
 			-m eservice_dbfile $(ESERVICE_DB) \
 			-m test_data $(SCRIPTDIR)/attestation-test/scripts
 
-.PHONY: test interface-test mock-contract-test interpreter-test memory-test
-.PHONY: system-test eservice-db attestation-test
-
 install : build
 	@echo install contracts
 	@cd build && make install
@@ -115,4 +112,10 @@ build :
 	mkdir -p $@
 	cd $@ && cmake .. -DCMAKE_TOOLCHAIN_FILE=$(WAMR_TOOLCHAIN)
 
+.PHONY: test interface-test mock-contract-test interpreter-test memory-test
+.PHONY: system-test eservice-db attestation-test
 .PHONY : all clean debug install test
+
+# Note: build is NOT a phony in this case; we make the directory and
+# then build the makefile using cmake. This only needs to be re-done
+# if build goes away.

--- a/contracts/wawaka/contract-build.cmake
+++ b/contracts/wawaka/contract-build.cmake
@@ -95,49 +95,14 @@ LIST(APPEND WASM_LINK_OPTIONS "-Wl,--export=ww_initialize")
 # from WASI_SDK. With the specified options, this should provide
 # access to many of the functions from the standard c++ library.
 # ---------------------------------------------
+SET (WASM_INCLUDES)
+SET (WASM_SOURCE)
 SET (WASM_LIBRARIES)
 LIST(APPEND WASM_LIBRARIES "${WASI_SDK_DIR}/share/wasi-sysroot/lib/wasm32-wasi/libc++.a")
 
 # ---------------------------------------------
-# Set up the include list
-# ---------------------------------------------
-SET (WASM_INCLUDES)
-LIST(APPEND WASM_INCLUDES ${PDO_SOURCE_ROOT}/contracts/wawaka/common)
-LIST(APPEND WASM_INCLUDES ${PDO_SOURCE_ROOT}/contracts/wawaka/common/contract)
-LIST(APPEND WASM_INCLUDES ${PDO_SOURCE_ROOT}/common/interpreter/wawaka_wasm)
-LIST(APPEND WASM_INCLUDES ${PDO_SOURCE_ROOT}/common/packages/parson)
-LIST(APPEND WASM_INCLUDES ${PDO_SOURCE_ROOT}/common/packages/base64)
-LIST(APPEND WASM_INCLUDES ${PDO_SOURCE_ROOT}/common)
-
-# ---------------------------------------------
 # Set up the default source list
 # ---------------------------------------------
-SET (WASM_SOURCE)
-FILE(GLOB WAWAKA_COMMON_SOURCE ${PDO_SOURCE_ROOT}/contracts/wawaka/common/*.cpp)
-FILE(GLOB WAWAKA_CONTRACT_SOURCE  ${PDO_SOURCE_ROOT}/contracts/wawaka/common/contract/*.cpp)
-LIST(APPEND WASM_SOURCE ${WAWAKA_COMMON_SOURCE})
-LIST(APPEND WASM_SOURCE ${WAWAKA_CONTRACT_SOURCE})
-LIST(APPEND WASM_SOURCE ${PDO_SOURCE_ROOT}/common/packages/parson/parson.cpp)
-
-# ---------------------------------------------
-# Build the wawaka contract common library
-# ---------------------------------------------
-SET(WW_CONTRACT_COMMON_LIB ww-contract-common)
-
-ADD_LIBRARY(${WW_CONTRACT_COMMON_LIB} STATIC ${WASM_SOURCE})
-
-STRING(REPLACE ";" " " WASM_BUILD_OPTIONS "${WASM_BUILD_OPTIONS}")
-STRING(REPLACE ";" " " WASM_LINK_OPTIONS "${WASM_LINK_OPTIONS}")
-SET(CMAKE_CXX_FLAGS ${WASM_BUILD_OPTIONS} CACHE INTERNAL "")
-SET(CMAKE_CXX_COMPILER_TARGET "wasm32-wasi")
-
-TARGET_INCLUDE_DIRECTORIES(${WW_CONTRACT_COMMON_LIB} PUBLIC ${WASM_INCLUDES})
-TARGET_LINK_LIBRARIES(${WW_CONTRACT_COMMON_LIB} LINK_PUBLIC ${WASM_LIBRARIES})
-
-SET_PROPERTY(TARGET ${WW_CONTRACT_COMMON_LIB} APPEND_STRING PROPERTY LINK_FLAGS "${WASM_LINK_OPTIONS}")
-
-LIST(APPEND WASM_LIBRARIES "${PDO_SOURCE_ROOT}/contracts/wawaka/build/libww-contract-common.a")
-
 ## -----------------------------------------------------------------
 # Define the function for building contracts
 #

--- a/contracts/wawaka/contract-build.cmake
+++ b/contracts/wawaka/contract-build.cmake
@@ -103,6 +103,7 @@ LIST(APPEND WASM_LIBRARIES "${WASI_SDK_DIR}/share/wasi-sysroot/lib/wasm32-wasi/l
 # ---------------------------------------------
 SET (WASM_INCLUDES)
 LIST(APPEND WASM_INCLUDES ${PDO_SOURCE_ROOT}/contracts/wawaka/common)
+LIST(APPEND WASM_INCLUDES ${PDO_SOURCE_ROOT}/contracts/wawaka/common/contract)
 LIST(APPEND WASM_INCLUDES ${PDO_SOURCE_ROOT}/common/interpreter/wawaka_wasm)
 LIST(APPEND WASM_INCLUDES ${PDO_SOURCE_ROOT}/common/packages/parson)
 LIST(APPEND WASM_INCLUDES ${PDO_SOURCE_ROOT}/common/packages/base64)
@@ -118,6 +119,25 @@ LIST(APPEND WASM_SOURCE ${WAWAKA_COMMON_SOURCE})
 LIST(APPEND WASM_SOURCE ${WAWAKA_CONTRACT_SOURCE})
 LIST(APPEND WASM_SOURCE ${PDO_SOURCE_ROOT}/common/packages/parson/parson.cpp)
 
+# ---------------------------------------------
+# Build the wawaka contract common library
+# ---------------------------------------------
+SET(WW_CONTRACT_COMMON_LIB ww-contract-common)
+
+ADD_LIBRARY(${WW_CONTRACT_COMMON_LIB} STATIC ${WASM_SOURCE})
+
+STRING(REPLACE ";" " " WASM_BUILD_OPTIONS "${WASM_BUILD_OPTIONS}")
+STRING(REPLACE ";" " " WASM_LINK_OPTIONS "${WASM_LINK_OPTIONS}")
+SET(CMAKE_CXX_FLAGS ${WASM_BUILD_OPTIONS} CACHE INTERNAL "")
+SET(CMAKE_CXX_COMPILER_TARGET "wasm32-wasi")
+
+TARGET_INCLUDE_DIRECTORIES(${WW_CONTRACT_COMMON_LIB} PUBLIC ${WASM_INCLUDES})
+TARGET_LINK_LIBRARIES(${WW_CONTRACT_COMMON_LIB} LINK_PUBLIC ${WASM_LIBRARIES})
+
+SET_PROPERTY(TARGET ${WW_CONTRACT_COMMON_LIB} APPEND_STRING PROPERTY LINK_FLAGS "${WASM_LINK_OPTIONS}")
+
+LIST(APPEND WASM_LIBRARIES "${PDO_SOURCE_ROOT}/contracts/wawaka/build/libww-contract-common.a")
+
 ## -----------------------------------------------------------------
 # Define the function for building contracts
 #
@@ -129,10 +149,10 @@ FUNCTION(BUILD_CONTRACT contract)
   STRING(REPLACE ";" " " WASM_BUILD_OPTIONS "${WASM_BUILD_OPTIONS}")
   STRING(REPLACE ";" " " WASM_LINK_OPTIONS "${WASM_LINK_OPTIONS}")
 
-  ADD_EXECUTABLE( ${contract} ${ARGN} ${WASM_SOURCE} )
+  ADD_EXECUTABLE( ${contract} ${ARGN})
 
   SET(CMAKE_CXX_FLAGS ${WASM_BUILD_OPTIONS} CACHE INTERNAL "")
-  SET(CMAKE_CXX_COMPILER_TARGET "wasm32")
+  SET(CMAKE_CXX_COMPILER_TARGET "wasm32-wasi")
 
   TARGET_INCLUDE_DIRECTORIES(${contract} PUBLIC ${WASM_INCLUDES})
   TARGET_LINK_LIBRARIES(${contract} LINK_PUBLIC ${WASM_LIBRARIES})
@@ -146,7 +166,7 @@ FUNCTION(BUILD_CONTRACT contract)
   SET_SOURCE_FILES_PROPERTIES(${b64contract} PROPERTIES GENERATED TRUE)
   SET_DIRECTORY_PROPERTIES(PROPERTY ADDITIONAL_MAKE_CLEAN_FILES ${b64contract})
 
-  # this can be replaced in later versions of CMAKE with target_link_properties
+  # this can be replaced in later versions of CMAKE with target_link_options
   SET_PROPERTY(TARGET ${contract} APPEND_STRING PROPERTY LINK_FLAGS "${WASM_LINK_OPTIONS}")
   INSTALL(FILES ${b64contract} DESTINATION ${CONTRACT_INSTALL_DIRECTORY})
 ENDFUNCTION()

--- a/contracts/wawaka/wawaka_common.cmake
+++ b/contracts/wawaka/wawaka_common.cmake
@@ -1,3 +1,17 @@
+# Copyright 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # ---------------------------------------------
 # Set up the include list
 # ---------------------------------------------

--- a/contracts/wawaka/wawaka_common.cmake
+++ b/contracts/wawaka/wawaka_common.cmake
@@ -1,0 +1,33 @@
+# ---------------------------------------------
+# Set up the include list
+# ---------------------------------------------
+SET (WW_COMMON_INCLUDES)
+LIST(APPEND WW_COMMON_INCLUDES ${PDO_SOURCE_ROOT}/contracts/wawaka/common)
+LIST(APPEND WW_COMMON_INCLUDES ${PDO_SOURCE_ROOT}/contracts/wawaka/common/contract)
+LIST(APPEND WW_COMMON_INCLUDES ${PDO_SOURCE_ROOT}/common/interpreter/wawaka_wasm)
+LIST(APPEND WW_COMMON_INCLUDES ${PDO_SOURCE_ROOT}/common/packages/parson)
+LIST(APPEND WW_COMMON_INCLUDES ${PDO_SOURCE_ROOT}/common/packages/base64)
+LIST(APPEND WW_COMMON_INCLUDES ${PDO_SOURCE_ROOT}/common)
+
+# ---------------------------------------------
+# Set up the default source list
+# ---------------------------------------------
+FILE(GLOB WAWAKA_COMMON_SOURCE ${PDO_SOURCE_ROOT}/contracts/wawaka/common/*.cpp)
+FILE(GLOB WAWAKA_CONTRACT_SOURCE  ${PDO_SOURCE_ROOT}/contracts/wawaka/common/contract/*.cpp)
+
+SET (WW_COMMON_SOURCES)
+LIST(APPEND WW_COMMON_SOURCES ${WAWAKA_COMMON_SOURCE})
+LIST(APPEND WW_COMMON_SOURCES ${WAWAKA_CONTRACT_SOURCE})
+LIST(APPEND WW_COMMON_SOURCES ${PDO_SOURCE_ROOT}/common/packages/parson/parson.cpp)
+
+# ---------------------------------------------
+# Build the wawaka contract common library
+# ---------------------------------------------
+SET(WW_COMMON_LIB ww_contract_common)
+
+ADD_LIBRARY(${WW_COMMON_LIB} STATIC ${WW_COMMON_SOURCES})
+TARGET_INCLUDE_DIRECTORIES(${WW_COMMON_LIB} PUBLIC ${WW_COMMON_INCLUDES})
+
+SET_PROPERTY(TARGET ${WW_COMMON_LIB} APPEND_STRING PROPERTY COMPILE_OPTIONS "${WASM_BUILD_OPTIONS}")
+SET_PROPERTY(TARGET ${WW_COMMON_LIB} APPEND_STRING PROPERTY LINK_OPTIONS "${WASM_LINK_OPTIONS}")
+SET_TARGET_PROPERTIES(${WW_COMMON_LIB} PROPERTIES EXCLUDE_FROM_ALL TRUE)


### PR DESCRIPTION
Extends PR from @marcelamelara to separate contract compilation from building the common wawaka contract library. This should make it easier for others to build/extend the library.