### PR TITLE
Remove the redundant WASM_MEM config from github workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,4 +27,4 @@ jobs:
                   # this command, CI tests work on the main branch and on local
                   # branches. However, they fail as a PR is created.
                   git checkout -b we-need-a-branch-for-below-to-work
-                  make WASM_MEM_CONFIG=MEDIUM -C docker test
+                  make -C docker test


### PR DESCRIPTION
The common config sets the default memory configuration
so we don't need to set it from here.

Signed-off-by: Mic Bowman <mic.bowman@intel.com>