### PR TITLE
Fix build bug in pservice in ubuntu20.04

### DIFF
--- a/pservice/Makefile
+++ b/pservice/Makefile
@@ -66,7 +66,7 @@ $(ENCLAVE_LIB) : build $(ENCLAVE_FILES)
 	@echo Build Enclave
 	$(MAKE) -C build
 
-$(SWIG_TARGET) : $(SWIG_FILES)
+$(SWIG_TARGET) : $(SWIG_FILES) $(ENCLAVE_LIB)
 	python setup.py build_ext
 
 build :


### PR DESCRIPTION
This PR fixes a bug that was causing the pservice build to fail on ubuntu 20.04 machines due to a consistently reproducible race condition between cmake and make expecting enclave_u.c to exist before it was generated. This bug does not occur on ubuntu 18.04 or earlier.

Signed-off-by: Marcela Melara <marcela.melara@intel.com>