### PR TITLE
Blockstore and configuration updates

### DIFF
--- a/build/opt/pdo/etc/template/pcontract.toml
+++ b/build/opt/pdo/etc/template/pcontract.toml
@@ -47,6 +47,7 @@ Duration=120 #seconds
 [Contract]
 DataDirectory = "${data}"
 SourceSearchPath = [ ".", "./contracts", "${home}/contracts" ]
+BlockStore = "${data}/${identity}.mdb"
 Interpreter = "${interpreter}"
 
 # --------------------------------------------------

--- a/client/pdo/client/controller/commands/create.py
+++ b/client/pdo/client/controller/commands/create.py
@@ -195,7 +195,6 @@ def command_create(state, bindings, pargs) :
     try :
         __create_contract(ledger_config, client_keys, preferred_eservice_client, eservice_clients, contract)
 
-        contract.contract_state.save_to_cache(data_dir = data_directory)
         contract.save_to_file(contract_file, data_dir=data_directory)
     except Exception as e :
         raise Exception('failed to create the initial contract state; {0}'.format(str(e)))

--- a/client/pdo/client/controller/commands/send.py
+++ b/client/pdo/client/controller/commands/send.py
@@ -122,11 +122,6 @@ def send_to_contract(state, save_file, message, eservice_url=None, quiet=False, 
         except Exception as e:
             raise Exception("Error while waiting for commit: %s", str(e))
 
-        try :
-            contract.contract_state.save_to_cache(data_dir = data_directory)
-        except Exception as e :
-            logger.exception('failed to save the new state in the cache')
-
     return update_response.invocation_response
 
 ## -----------------------------------------------------------------

--- a/client/pdo/client/scripts/ShellCLI.py
+++ b/client/pdo/client/scripts/ShellCLI.py
@@ -24,6 +24,7 @@ from pdo.client.controller.contract_controller import ContractController
 import pdo.common.utility as putils
 import pdo.common.config as pconfig
 from pdo.contract.response import ContractResponse
+import pdo.common.block_store_manager as pblocks
 
 ## -----------------------------------------------------------------
 ## -----------------------------------------------------------------
@@ -168,6 +169,7 @@ def Main() :
     if config.get('Contract') is None :
         config['Contract'] = {
             'DataDirectory' : ContractData,
+            'BlockStore' : os.path.join(ContractData, "local_cache.mdb"),
             'SourceSearchPath' : [ ".", "./contract", os.path.join(ContractHome,'contracts') ]
         }
 
@@ -176,10 +178,12 @@ def Main() :
     if options.source_dir :
         config['Contract']['SourceSearchPath'] = options.source_dir
 
+    if config['Contract'].get('BlockStore') is None :
+        config['Contract']['BlockStore'] = os.path.join(config['Contract']['DataDirectory'], "local_cache.mdb"),
+
     # make the configuration available to all of the PDO modules
     pconfig.initialize_shared_configuration(config)
 
-    # move local options into the configuration
     if script :
         config["ScriptFile"] = script.pop(0)
 

--- a/client/pdo/client/scripts/ShellCLI.py
+++ b/client/pdo/client/scripts/ShellCLI.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 
 from pdo.client.controller.contract_controller import ContractController
 import pdo.common.utility as putils
+import pdo.common.config as pconfig
 from pdo.contract.response import ContractResponse
 
 ## -----------------------------------------------------------------
@@ -175,8 +176,10 @@ def Main() :
     if options.source_dir :
         config['Contract']['SourceSearchPath'] = options.source_dir
 
-    putils.set_default_data_directory(config['Contract']['DataDirectory'])
+    # make the configuration available to all of the PDO modules
+    pconfig.initialize_shared_configuration(config)
 
+    # move local options into the configuration
     if script :
         config["ScriptFile"] = script.pop(0)
 

--- a/eservice/MANIFEST
+++ b/eservice/MANIFEST
@@ -14,7 +14,6 @@ pdo/eservice/wsgi/__init__.py
 pdo/eservice/wsgi/verify.py
 pdo/sservice/scripts/SServiceCLI.py
 pdo/sservice/scripts/__init__.py
-pdo/sservice/block_store_manager.py
 pdo/sservice/__init__.py
 pdo/sservice/wsgi/check_blocks.py
 pdo/sservice/wsgi/list_blocks.py

--- a/eservice/pdo/sservice/__init__.py
+++ b/eservice/pdo/sservice/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__all__ = [ 'block_store_manager', 'scripts']
+__all__ = [ 'scripts', 'wsgi' ]

--- a/eservice/pdo/sservice/wsgi/__init__.py
+++ b/eservice/pdo/sservice/wsgi/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Intel Corporation
+# Copyright 2022 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,3 +26,11 @@ __all__ = [
            'ListBlocksApp',
            'StoreBlocksApp',
            ]
+
+wsgi_block_operation_map = {
+    'get' : GetBlockApp,
+    'gets' : GetBlocksApp,
+    'store' : StoreBlocksApp,
+    'list' : ListBlocksApp,
+    'check' : CheckBlocksApp,
+}

--- a/eservice/pdo/sservice/wsgi/check_blocks.py
+++ b/eservice/pdo/sservice/wsgi/check_blocks.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 ## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 class CheckBlocksApp(object) :
-    def __init__(self, block_store) :
+    def __init__(self, config, block_store, service_keys) :
         self.block_store = block_store
 
     def __call__(self, environ, start_response) :

--- a/eservice/pdo/sservice/wsgi/get_block.py
+++ b/eservice/pdo/sservice/wsgi/get_block.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 ## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 class GetBlockApp(object) :
-    def __init__(self, block_store) :
+    def __init__(self, config, block_store, service_keys) :
         self.block_store = block_store
 
     def __call__(self, environ, start_response) :
@@ -67,7 +67,7 @@ class GetBlockApp(object) :
 ## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 class GetBlocksApp(object) :
-    def __init__(self, block_store) :
+    def __init__(self, config, block_store, service_keys) :
         self.block_store = block_store
 
     def __call__(self, environ, start_response) :

--- a/eservice/pdo/sservice/wsgi/info.py
+++ b/eservice/pdo/sservice/wsgi/info.py
@@ -30,14 +30,14 @@ logger = logging.getLogger(__name__)
 ## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 class InfoApp(object) :
-    def __init__(self, block_store) :
-        self.block_store = block_store
+    def __init__(self, config, service_keys) :
+        self.service_keys = service_keys
 
     def __call__(self, environ, start_response) :
         """Return blockstore information
         """
         try :
-            response = self.block_store.get_service_info()
+            response = {'verifying_key' : self.service_keys.verifying_key }
             result = json.dumps(response).encode()
 
         except Exception as e :

--- a/eservice/pdo/sservice/wsgi/list_blocks.py
+++ b/eservice/pdo/sservice/wsgi/list_blocks.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 ## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ## XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 class ListBlocksApp(object) :
-    def __init__(self, block_store) :
+    def __init__(self, config, block_store, service_keys) :
         self.block_store = block_store
 
     def __call__(self, environ, start_response) :

--- a/eservice/tests/test-secrets.py
+++ b/eservice/tests/test-secrets.py
@@ -20,7 +20,7 @@ import hashlib
 import random
 import json
 
-from pdo.sservice.block_store_manager import BlockStoreManager
+from pdo.common.block_store_manager import BlockStoreManager
 
 import pdo.test.helpers.secrets as secret_helper
 import pdo.eservice.pdo_helper as enclave_helper

--- a/python/pdo/common/block_store_manager.py
+++ b/python/pdo/common/block_store_manager.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Intel Corporation
+# Copyright 2022 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,18 +23,33 @@ import hashlib
 import lmdb
 import struct
 import time
+import json
 
-import pdo.common.keys as keys
+import pdo.common.config as pconfig
 from pdo.service_client.storage import StorageException
 
 import logging
 logger = logging.getLogger(__name__)
 
+# XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+# XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+__local_block_manager__ = None
+
+def local_block_manager() :
+    global __local_block_manager__
+    if __local_block_manager__ is None :
+        block_store_file = pconfig.shared_configuration(['Contract','BlockStore'], "./blockstore.mdb")
+
+        __local_block_manager__ = BlockStoreManager(block_store_file, True)
+    return __local_block_manager__
+
+# XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+# XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 class BlockMetadata(object) :
     """Implements a wrapper for block metadata.
     """
 
-    minimum_expiration_time = 60
+    minimum_duration_time = 60
 
     @classmethod
     def unpack(cls, value) :
@@ -58,6 +73,8 @@ class BlockMetadata(object) :
         value = struct.pack('LLLL', self.block_size, self.create_time, self.expiration_time, self.mark)
         return value
 
+# XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+# XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 class BlockStoreManager(object) :
     """Implements the storage service operations in a way that provides
     symmetry with the storage service client.
@@ -65,17 +82,14 @@ class BlockStoreManager(object) :
 
     map_size = 1 << 40
 
-    def __init__(self, block_store_file, service_keys = None, create_block_store=False) :
+    # --------------------------------------------------
+    def __init__(self, block_store_file, create_block_store=False) :
         """Initialize storage service class instance
 
         :param block_store_file string: name of the lmdb file used for block storage
         :param service_keys ServiceKeys: ECDSA keys used to sign storage contracts
         :param create_block_store boolean: flag to note that missing blockstore file should be created
         """
-        self.service_keys = service_keys
-        if self.service_keys is None :
-            self.service_keys = keys.ServiceKeys.create_service_keys()
-
         self.block_store_env = lmdb.open(
             block_store_file,
             create=create_block_store,
@@ -84,6 +98,7 @@ class BlockStoreManager(object) :
             sync=False,
             map_size=self.map_size)
 
+    # --------------------------------------------------
     def close(self) :
         """Sync the database to disk and close the handles
         """
@@ -91,13 +106,7 @@ class BlockStoreManager(object) :
         self.block_store_env.close()
         self.block_store_env = None
 
-    def get_service_info(self) :
-        """Return useful information about the service
-
-        :return dict: dictionary of information about the storage service
-        """
-        return {'verifying_key' : self.service_keys.verifying_key }
-
+    # --------------------------------------------------
     def list_blocks(self, encoding='b64') :
         """Return a list of all block identifiers currently
         stored in the database; mostly for debugging purposes
@@ -119,7 +128,8 @@ class BlockStoreManager(object) :
 
         return block_ids
 
-    def get_block(self, block_id, encoding='b64') :
+    # --------------------------------------------------
+    def __get_block__(self, block_id, encoding='b64') :
         """Return the data for a block given the hash of the block
 
         :param block_id string: block identifier
@@ -137,42 +147,67 @@ class BlockStoreManager(object) :
 
         return block_data
 
-    # return block_data_list
+    # --------------------------------------------------
     def __block_iterator__(self, block_ids, encoding) :
-        for block_id in block_ids :
-            yield self.get_block(block_id, encoding)
+        """Create an iterator that is more memory efficient because it
+        only reads the block when necessary
 
+        :param block_ids list of string: block identifiers
+        :param encoding string: encoding to use for block identifiers, raw/b64
+        """
+
+        for block_id in block_ids :
+            block_data = self.__get_block__(block_id, encoding)
+            if block_data is None :
+                raise Exception('unable to locate required block; {}'.format(block_id))
+            yield block_data
+
+    # --------------------------------------------------
+    def get_block(self, block_id, encoding='b64') :
+        return self.__get_block__(block_id, encoding)
+
+    # --------------------------------------------------
     def get_blocks(self, block_ids, encoding='b64') :
         """Return the data for a list of blocks
+
+        :param block_ids list of string: block identifiers
+        :param encoding string: encoding to use for block identifiers, raw/b64
+        :return iterable: list of block data
         """
+
         # the iterator means that we don't have to use as much memory
         # for operations that can process the blocks one at a time
         return self.__block_iterator__(block_ids, encoding)
 
-    def store_block(self, block_data, expiration=60, encoding='b64') :
+    # --------------------------------------------------
+    def store_block(self, block_data, duration=60, encoding='b64') :
         """Add a new data block to the store
 
         :param block_data string: binary content of the block
         :param encoding string: encoding to use for block identifiers, raw/b64
         :return string: block identifier
         """
-        return self.store_blocks([block_data], expiration, encoding)
+        return self.store_blocks([block_data], duration, encoding)
 
-    def store_blocks(self, block_data_list, expiration=60, encoding='b64') :
+    # --------------------------------------------------
+    def store_blocks(self, block_data_list, duration=60, encoding='b64') :
         """Save a list of blocks in the store
 
         :param iterable block_data_list: iterable collection of blocks to store
-        :param expiration int: number of seconds to use for expiration
+        :param duration int: number of seconds to store data
         :param encoding string: encoding to use for block identifiers, raw/b64
         :return list of string: list of block identifiers
         """
+
+        if duration < BlockMetadata.minimum_duration_time :
+            duration = BlockMetadata.minimum_duration_time
 
         encoding_fn = lambda x : x
         if encoding == 'b64' :
             encoding_fn = lambda x : base64.urlsafe_b64encode(x).decode()
 
         current_time = int(time.time())
-        expiration_time = current_time + expiration
+        expiration_time = current_time + duration
 
         mdb = self.block_store_env.open_db(b'meta_data')
         bdb = self.block_store_env.open_db(b'block_data')
@@ -211,25 +246,13 @@ class BlockStoreManager(object) :
                 if not txn.put(block_hash, block_data, db=bdb) :
                     raise StorageException("failed to save block data")
 
-        try :
-            # going to just concatenate all hashes, safe since these are all fixed size
-            signing_hash_accumulator = expiration.to_bytes(32, byteorder='big', signed=False)
-            signing_hash_accumulator += b''.join(block_hashes)
+        return block_hashes
 
-            signing_hash = hashlib.sha256(signing_hash_accumulator).digest()
-            signature = self.service_keys.sign(signing_hash, encoding=encoding)
-        except Exception as e :
-            logger.error("unknown exception packing response (BlockStatus); %s", str(e))
-            return StorageException('signature failed')
-
-        result = dict()
-        result['signature'] = signature
-        result['block_ids'] = list(map(encoding_fn, block_hashes))
-        return result
-
+    # --------------------------------------------------
     def check_block(self, block_id, encoding='b64') :
-        pass
+        return self.check_blocks([block_id], encoding)
 
+    # --------------------------------------------------
     def check_blocks(self, block_ids, encoding='b64') :
         """Check status of a list of block
 
@@ -249,21 +272,22 @@ class BlockStoreManager(object) :
         with self.block_store_env.begin() as txn :
             for block_id in block_ids :
                 # use the input format for the output block identifier
-                block_status = { 'block_id' : block_id, 'size' : 0, 'expiration' : 0 }
+                block_status = { 'block_id' : block_id, 'size' : 0, 'duration' : 0 }
                 block_hash = decoding_fn(block_id)
 
                 raw_metadata = txn.get(block_hash, db=mdb)
                 if raw_metadata :
                     metadata = BlockMetadata.unpack(raw_metadata)
                     block_status['size'] = metadata.block_size
-                    block_status['expiration'] = metadata.expiration_time - current_time
-                    if block_status['expiration'] < 0 :
-                        block_status['expiration'] = 0
+                    block_status['duration'] = metadata.expiration_time - current_time
+                    if block_status['duration'] < 0 :
+                        block_status['duration'] = 0
 
                 block_status_list.append(block_status)
 
         return block_status_list
 
+    # --------------------------------------------------
     def expire_blocks(self) :
         """Delete data and metadata for blocks that have expired
         """
@@ -279,7 +303,6 @@ class BlockStoreManager(object) :
                 for key, value in cursor :
                     metadata = BlockMetadata.unpack(value)
                     if metadata.expiration_time < current_time :
-                        logger.debug('expire block %s',base64.urlsafe_b64encode(key).decode())
                         count += 1
                         with self.block_store_env.begin(write=True) as dtxn :
                             assert dtxn.delete(key, db=bdb)
@@ -291,3 +314,84 @@ class BlockStoreManager(object) :
             return None
 
         return count
+
+# --------------------------------------------------
+def decode_root_block(root_block) :
+    """decode the raw root block and parse the JSON
+    """
+
+    if root_block is None :
+        raise StorageExecption("invalid root block")
+
+    # backward compatibility with json parser
+    try :
+        root_block = root_block.decode('utf8')
+    except AttributeError :
+        pass
+
+    try :
+        root_block = root_block.rstrip('\0')
+        root_data = json.loads(root_block)
+    except json.JSONDecodeError :
+        raise StorageException("invalid root block")
+
+    return root_data
+
+# --------------------------------------------------
+def sync_block_store(src_block_store, dst_block_store, root_block_id, root_block = None, **kwargs) :
+    """
+    ensure that required blocks are stored in the storage service
+
+    assumes that all of the blocks referenced by root_block_id are in the source
+    block manager
+
+    :param src_block_store object implementing the block_store_manager interface
+    :param dst_block_store object implementing the block_store_manager interface
+    :param root_block_id string: block identifier for the root block
+    :param root_block string: block data for the root block
+    """
+
+    if root_block is None :
+        root_block = src_block_store.get_block(root_block_id)
+
+    block_ids = [root_block_id]
+
+    try :
+        root_block = root_block.decode('utf8')
+    except AttributeError :
+        pass
+
+    root_block = root_block.rstrip('\0')
+    root_block_json = json.loads(root_block)
+    block_ids.extend(root_block_json['BlockIds'])
+
+    minimum_duration = kwargs.get('minimum_duration', pconfig.shared_configuration(['Replication', 'MinimumDuration'], 5))
+    duration = kwargs.get('duration', pconfig.shared_configuration(['Replication', 'Duration'], 60))
+
+    # check to see which blocks need to be pushed
+    blocks_to_push = []
+    blocks_to_extend = []
+    block_status_list = dst_block_store.check_blocks(block_ids)
+    for block_status in block_status_list :
+        # if the size is 0 then the block is unknown to the storage service
+        if block_status['size'] == 0 :
+            blocks_to_push.append(block_status['block_id'])
+        # if the expiration is nearing, then add to the list to extend, the
+        # policy here is to extend if the block is within 5 seconds of expiring
+        elif block_status['duration'] < minimum_duration :
+            blocks_to_extend.append(block_status['block_id'])
+
+    # there is currently no operation to simply extend the expiration of
+    # an existing block, so for now just add the blocks to extend onto
+    # the end of the blocks to push
+    blocks_to_push += blocks_to_extend
+
+    if len(blocks_to_push) == 0 :
+        return 0
+
+    block_data_list = src_block_store.get_blocks(blocks_to_push)
+    block_store_list = dst_block_store.store_blocks(block_data_list, duration=duration)
+    if block_store_list is None :
+        raise Exception('failed to push blocks to block_store')
+
+    return len(blocks_to_push)

--- a/python/pdo/common/config.py
+++ b/python/pdo/common/config.py
@@ -33,6 +33,24 @@ __all__ = [ "ConfigurationException", "parse_configuration_files", "parse_config
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
+__shared_configuration__ = None
+
+def initialize_shared_configuration(config) :
+    global __shared_configuration__
+    if __shared_configuration__ is not None :
+        raise RuntimeError("duplicate initialization of shared configuration")
+
+    __shared_configuration__ = config     # may need deep copy, leave it shallow for now
+    return __shared_configuration__
+
+def shared_configuration() :
+    global __shared_configuration__
+    if __shared_configuration__ is None :
+        raise RuntimeError("shared configuration is not initialized")
+    return __shared_configuration__
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
 class ConfigurationException(Exception) :
     """
     A class to capture configuration exceptions.

--- a/python/pdo/common/config.py
+++ b/python/pdo/common/config.py
@@ -23,6 +23,7 @@ before logging is enabled.
 import os
 import sys
 import warnings
+from functools import reduce
 
 import re
 import toml
@@ -43,10 +44,16 @@ def initialize_shared_configuration(config) :
     __shared_configuration__ = config     # may need deep copy, leave it shallow for now
     return __shared_configuration__
 
-def shared_configuration() :
+def shared_configuration(keylist=[], default=None) :
     global __shared_configuration__
     if __shared_configuration__ is None :
         raise RuntimeError("shared configuration is not initialized")
+
+    try :
+        return reduce(dict.get, keylist, __shared_configuration__) or default
+    except TypeError :
+        return None
+
     return __shared_configuration__
 
 # -----------------------------------------------------------------

--- a/python/pdo/common/utility.py
+++ b/python/pdo/common/utility.py
@@ -86,11 +86,8 @@ def build_file_name(basename, data_dir = None, data_sub = None, extension = '') 
     global __default_data_directory__
     if data_dir is None :
         if __default_data_directory__ is None :
-            try :
-                import pdo.common.config as pconfig
-                __default_data_directory__ = pconfig.shared_configuration()['Contract']['DataDirectory']
-            except KeyError :
-                __default_data_directory__ = "./data"
+            import pdo.common.config as pconfig
+            __default_data_directory__ = pconfig.shared_configuration(['Contract', 'DataDirectory'],"./data")
 
         data_dir = __default_data_directory__
 

--- a/python/pdo/common/utility.py
+++ b/python/pdo/common/utility.py
@@ -27,7 +27,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 __all__ = [
-    'set_default_data_directory',
     'build_simple_file_name',
     'build_file_name',
     'find_file_in_path',
@@ -35,7 +34,7 @@ __all__ = [
     'are_the_urls_same'
     ]
 
-__DefaultDataDirectory__ = './data'
+__default_data_directory__ = None
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
@@ -53,12 +52,6 @@ def deprecated(func):
         return func(*args, **kwargs)
 
     return new_func
-
-# -----------------------------------------------------------------
-# -----------------------------------------------------------------
-def set_default_data_directory(data_dir) :
-    global __DefaultDataDirectory__
-    __DefaultDataDirectory__ = data_dir
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
@@ -90,8 +83,16 @@ def build_file_name(basename, data_dir = None, data_sub = None, extension = '') 
     :param str extension: the extension to add to the file if it doesnt have one
     """
 
+    global __default_data_directory__
     if data_dir is None :
-        data_dir = __DefaultDataDirectory__
+        if __default_data_directory__ is None :
+            try :
+                import pdo.common.config as pconfig
+                __default_data_directory__ = pconfig.shared_configuration()['Contract']['DataDirectory']
+            except KeyError :
+                __default_data_directory__ = "./data"
+
+        data_dir = __default_data_directory__
 
     if data_sub is not None :
         data_dir = os.path.join(data_dir, data_sub)

--- a/python/pdo/contract/contract.py
+++ b/python/pdo/contract/contract.py
@@ -68,10 +68,9 @@ class Contract(object) :
             raise Exception('invalid contract file; {}'.format(filename))
 
         try :
-            state = ContractState.read_from_cache(contract_id, current_state_hash, data_dir=data_dir)
+            state = ContractState.read_from_cache(contract_id, current_state_hash)
             if state is None :
                 state = ContractState.get_from_ledger(ledger_config, contract_id, current_state_hash)
-                state.save_to_cache(data_dir=data_dir)
         except Exception as e :
             logger.error('error occurred retreiving contract state; %s', str(e))
             raise Exception("invalid contract file; {}".format(filename))
@@ -118,16 +117,10 @@ class Contract(object) :
         # pull the defaults from the configuration if they are not
         # otherwise set by the caller
         if num_provable_replicas is None :
-            try :
-                num_provable_replicas = pconfig.shared_configuration()['Replication']['NumProvableReplicas']
-            except KeyError :
-                num_provable_replicas = 1
+            num_provable_replicas = pconfig.shared_configuration(['Replication','NumProvableReplicas'], 1)
 
         if availability_duration is None :
-            try :
-                availability_duration = pconfig.shared_configuration()['Replication']['Duration']
-            except KeyError :
-                availability_duration = 120
+            availability_duration = pconfig.shared_configuration(['Replication','Duration'], 120)
 
         self.replication_params = dict()
         self.replication_params['max_num_replicas'] = len(self.enclave_map.keys())

--- a/python/pdo/contract/contract.py
+++ b/python/pdo/contract/contract.py
@@ -21,6 +21,7 @@ from pdo.submitter.create import create_submitter
 from pdo.contract.request import UpdateStateRequest, InitializeStateRequest
 from pdo.contract.state import ContractState
 from pdo.contract.code import ContractCode
+import pdo.common.config as pconfig
 
 import logging
 logger = logging.getLogger(__name__)
@@ -96,7 +97,7 @@ class Contract(object) :
         self.creator_id = creator_id
         self.extra_data = kwargs.get('extra_data', {})
         self.enclave_map = kwargs.get('enclave_map',{})
-        self.set_replication_parameters()
+        self.set_replication_parameters(**kwargs)
 
     # -------------------------------------------------------
     def set_state_encryption_key(self, enclave_id, encrypted_state_encryption_key) :
@@ -113,7 +114,20 @@ class Contract(object) :
         return hex(abs(hash(self.contract_id)))[2:]
 
     # -------------------------------------------------------
-    def set_replication_parameters(self, num_provable_replicas=1, availability_duration=120):
+    def set_replication_parameters(self, num_provable_replicas=None, availability_duration=None, **kwargs):
+        # pull the defaults from the configuration if they are not
+        # otherwise set by the caller
+        if num_provable_replicas is None :
+            try :
+                num_provable_replicas = pconfig.shared_configuration()['Replication']['NumProvableReplicas']
+            except KeyError :
+                num_provable_replicas = 1
+
+        if availability_duration is None :
+            try :
+                availability_duration = pconfig.shared_configuration()['Replication']['Duration']
+            except KeyError :
+                availability_duration = 120
 
         self.replication_params = dict()
         self.replication_params['max_num_replicas'] = len(self.enclave_map.keys())

--- a/python/pdo/contract/replication.py
+++ b/python/pdo/contract/replication.py
@@ -16,7 +16,7 @@ import concurrent.futures
 import queue
 import threading
 
-from pdo.contract.state import ContractState
+import pdo.common.block_store_manager as pblocks
 import pdo.service_client.service_data.eservice as service_db
 
 import logging
@@ -176,8 +176,7 @@ def __replication_worker__(service_id, pending_tasks_queue, condition_variable_f
                 continue
 
             # replicate now!
-            block_data_list = ContractState.block_data_generator(replication_request.contract_id, \
-                replication_request.blocks_to_replicate, replication_request.data_dir)
+            block_data_list = pblocks.local_block_manager().get_blocks(replication_request.blocks_to_replicate)
             expiration = replication_request.availability_duration
             request_id = response.commit_id[2]
             try:

--- a/python/pdo/contract/response.py
+++ b/python/pdo/contract/response.py
@@ -200,7 +200,7 @@ class InitializeStateResponse(ContractResponse) :
         self.new_state_object.pull_state_from_eservice(self.enclave_service)
 
         # compute ids of blocks in the change set (used for replication)
-        self.new_state_object.compute_ids_of_newblocks(request.contract_state.component_block_ids)
+        self.new_state_object.compute_new_block_ids(request.contract_state.component_block_ids)
         self.replication_params = request.replication_params
 
     # -------------------------------------------------------
@@ -237,7 +237,7 @@ class UpdateStateResponse(ContractResponse) :
         # save the information we will need for the transaction
         state_hash_b64 = response['StateHash']
         self.new_state_hash = crypto.base64_to_byte_array(state_hash_b64)
-        self.old_state_hash = ContractState.compute_hash(request.contract_state.raw_state)
+        self.old_state_hash = ContractState.compute_state_hash(request.contract_state.raw_state)
 
         message = self.serialize_for_signing()
         if not self.verify_enclave_signature(message, request.enclave_keys) :
@@ -248,7 +248,7 @@ class UpdateStateResponse(ContractResponse) :
         self.new_state_object.pull_state_from_eservice(self.enclave_service)
 
         # compute ids of blocks in the change set (used for replication)
-        self.new_state_object.compute_ids_of_newblocks(request.contract_state.component_block_ids)
+        self.new_state_object.compute_new_block_ids(request.contract_state.component_block_ids)
         self.replication_params = request.replication_params
 
     # -------------------------------------------------------

--- a/python/pdo/contract/state.py
+++ b/python/pdo/contract/state.py
@@ -122,7 +122,7 @@ class ContractState(object) :
                 self.changed_block_ids.append(block_id)
 
         # add state hash (not sure if this is part of component block_ids, if so we can skip the following)
-        # if there is any change, make sure that state hash is part of chaged_block_ids
+        # if there is any change, make sure that state hash is part of changed_block_ids
         if len(self.changed_block_ids) > 0 :
             state_hash = self.get_state_hash(encoding='b64')
             if state_hash not in self.changed_block_ids:

--- a/python/pdo/contract/state.py
+++ b/python/pdo/contract/state.py
@@ -17,6 +17,7 @@ import json
 import pdo.common.crypto as crypto
 import pdo.common.utility as putils
 from pdo.submitter.create import create_submitter
+import pdo.common.block_store_manager as pblocks
 
 import logging
 logger = logging.getLogger(__name__)
@@ -25,12 +26,9 @@ stat_logger = logger.getChild('stats')
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
 class ContractState(object) :
-    __path__ = '__state_cache__'
-    __extension__ = '.ctx'
-
     # --------------------------------------------------
     @staticmethod
-    def compute_hash(raw_state, encoding = 'raw') :
+    def compute_state_hash(raw_state, encoding = 'raw') :
         """ compute the hash of the contract state
 
         :param raw_state string: root block of contract state, json string
@@ -44,184 +42,6 @@ class ContractState(object) :
             return crypto.byte_array_to_hex(state_hash)
 
         raise ValueError('unknown encoding; {}'.format(encoding))
-
-    # --------------------------------------------------
-    @staticmethod
-    def safe_filename(b64name) :
-        """the base64 encoding we use for contract_id and state_hash make
-        them very poor file names; convert to hex for better behavior
-        """
-        decoded = crypto.base64_to_byte_array(b64name)
-        encoded = crypto.byte_array_to_hex(decoded)
-        return encoded[:16]
-
-    # --------------------------------------------------
-    @staticmethod
-    def block_data_generator(contract_id, block_ids, data_dir) :
-        for block_id in block_ids :
-            raw_data = ContractState.__read_data_block_from_cache__(contract_id, block_id, data_dir)
-            if raw_data is None :
-                raise Exception('unable to locate required block; {}'.format(block_id))
-            yield raw_data
-
-    # --------------------------------------------------
-    @classmethod
-    def __cache_filename__(cls, contract_id, state_hash, data_dir) :
-        """
-        state_hash = base64 encoded
-
-        """
-        contract_id = ContractState.safe_filename(contract_id)
-        state_hash = ContractState.safe_filename(state_hash)
-
-        subdirectory = os.path.join(cls.__path__, contract_id, state_hash[0:2])
-        return putils.build_file_name(state_hash, data_dir, subdirectory, cls.__extension__)
-
-    # --------------------------------------------------
-    @classmethod
-    def __cache_data_block__(cls, contract_id, raw_data, data_dir = None) :
-        """
-        save a data block into the local cache
-
-        :param contract_id str: contract identifier, base64 encoded
-        :param raw_data str: base64 encoded string
-        """
-
-        state_hash = ContractState.compute_hash(raw_data, encoding='b64')
-        filename = ContractState.__cache_filename__(contract_id, state_hash, data_dir)
-        if not os.path.exists(os.path.dirname(filename)):
-            os.makedirs(os.path.dirname(filename))
-
-        try :
-            logger.debug('save state block to file %s', filename)
-            with open(filename, 'wb') as statefile :
-                statefile.write(raw_data)
-        except Exception as e :
-            logger.info('failed to save state; %s', str(e))
-            raise Exception('unable to cache state {}'.format(filename))
-
-    # --------------------------------------------------
-    @classmethod
-    def __read_data_block_from_cache__(cls, contract_id, state_hash, data_dir = None) :
-        """
-        read a data block from the local cache
-
-        :param contract_id str: contract identifier, base64 encoded
-        :param state_hash str: b64 encoded string
-        """
-
-        filename = ContractState.__cache_filename__(contract_id, state_hash, data_dir)
-
-        try :
-            logger.debug('read state block from file %s', filename)
-            with open(filename, "rb") as statefile :
-                raw_data = statefile.read()
-        except FileNotFoundError as fe :
-            logger.error('file not found; %s', filename)
-            return None
-        except Exception as e :
-            logger.info('error reading state; %s', str(e))
-            raise Exception('failed to read state from cache; {}'.format(contract_id))
-
-        return raw_data
-
-    # --------------------------------------------------
-    @staticmethod
-    def __push_blocks_to_eservice__(eservice, contract_id, block_ids, data_dir = None) :
-        """
-        ensure that required blocks are stored in the storage service
-
-        :param eservice EnclaveServiceClient object:
-        :param contract_id str: contract identifier
-        :param block_ids list of strings: base64 encoded hash of the block
-        """
-
-        # check to see which blocks need to be pushed
-        blocks_to_push = []
-        blocks_to_extend = []
-        block_status_list = eservice.check_blocks(block_ids)
-        for block_status in block_status_list :
-            # if the size is 0 then the block is unknown to the storage service
-            if block_status['size'] == 0 :
-                blocks_to_push.append(block_status['block_id'])
-            # if the expiration is nearing, then add to the list to extend, the
-            # policy here is to extend if the block is within 5 seconds of expiring
-            elif block_status['expiration'] < 5 :
-                blocks_to_extend.append(block_status['block_id'])
-
-        # there is currently no operation to simply extend the expiration of
-        # an existing block, so for now just add the blocks to extend onto
-        # the end of the blocks to push
-        blocks_to_push += blocks_to_extend
-
-        if len(blocks_to_push) == 0 :
-            logger.debug('enclave service has state')
-            return 0
-
-        logger.debug('push blocks to service: %s', blocks_to_push)
-
-        block_data_list = ContractState.block_data_generator(contract_id, blocks_to_push, data_dir)
-        block_store_list = eservice.store_blocks(block_data_list, expiration=60)
-        if block_store_list is None :
-            raise Exception('failed to push blocks to eservice')
-
-        return len(blocks_to_push)
-
-    # --------------------------------------------------
-    @classmethod
-    def __pull_blocks_from_eservice__(cls, eservice, contract_id, block_ids, data_dir = None) :
-        """
-        ensure that a list of blocks is cached locally
-
-        :param eservice EnclaveServiceClient object:
-        :param contract_id str: contract identifier
-        :param block_ids list: base64 encoded hash of the blocks required
-        """
-
-        # first see if the block is already in the cache
-        blocks_to_pull = set()
-        for block_id in block_ids :
-            filename = ContractState.__cache_filename__(contract_id, block_id, data_dir)
-            if not os.path.isfile(filename) :
-                blocks_to_pull.add(block_id)
-
-        block_count = len(blocks_to_pull)
-        if block_count == 0 :
-            logger.debug('no blocks to pull')
-            return 0
-
-        # it is not in the cache so grab it from the eservice
-        block_data_iterator = eservice.get_blocks(list(blocks_to_pull))
-
-        # since we don't really trust the eservice, make sure that the
-        # block it sent us is really the one that we were supposed to get
-        for raw_block in block_data_iterator :
-            raw_block_hash = ContractState.compute_hash(raw_block, encoding='b64')
-            if raw_block_hash not in blocks_to_pull :
-                raise Exception('unknown block pulled from storage service; {0}'.format(raw_block_hash))
-
-            ContractState.__cache_data_block__(contract_id, raw_block, data_dir)
-            blocks_to_pull.remove(raw_block_hash)
-
-        # make sure that the storage service gave us all the blocks we asked for
-        if len(blocks_to_pull) != 0 :
-            raise Exception('failed to pull blocks from storage service; %s', list(blocks_to_pull))
-
-        logger.debug("Pulled %d new blocks after contract update", block_count + 1) # + 1 to add the root block
-
-        return len(blocks_to_pull)
-
-    # --------------------------------------------------
-    @classmethod
-    def read_from_cache(cls, contract_id, state_hash, data_dir = None) :
-        """
-        read a block from the local cache and create contract state for it
-
-        :param contract_id str: contract identifier, base64 encoded
-        :param state_hash str: b64 encoded string
-        """
-        raw_data = ContractState.__read_data_block_from_cache__(contract_id, state_hash, data_dir)
-        return cls(contract_id, raw_data)
 
     # --------------------------------------------------
     @staticmethod
@@ -249,13 +69,15 @@ class ContractState(object) :
 
     # --------------------------------------------------
     @classmethod
-    def get_from_ledger(cls, ledger_config, contract_id, current_state_hash = None) :
-        """This method tries to get the root block from the ledger.  This method will be replaced
-        with get_from_storage_service in a separate (not so trivial) PR, since the root block is no
-        longer stored in the ledger. For now, raising an exception."""
+    def read_from_cache(cls, contract_id, state_hash) :
+        """
+        read a block from the local cache and create contract state for it
 
-        raise Exception("Attempting to read root block from ledger. \
-            Root block is no longer stored in the ledger")
+        :param contract_id str: contract identifier, base64 encoded
+        :param state_hash str: b64 encoded string
+        """
+        raw_data = pblocks.local_block_manager().get_block(state_hash)
+        return cls(contract_id, raw_data)
 
     # --------------------------------------------------
     @classmethod
@@ -269,23 +91,10 @@ class ContractState(object) :
 
     # --------------------------------------------------
     def decode_state(self) :
-        """decode the raw root block and parse the JSON
-        """
-
         if self.raw_state is None :
-            return {}
+            return None
 
-        logger.debug('contract state: %s', self.raw_state)
-        state = self.raw_state
-
-        # backward compatibility with json parser
-        try :
-            state = state.decode('utf8')
-        except AttributeError :
-            pass
-
-        state = state.rstrip('\0')
-        return json.loads(state)
+        return pblocks.decode_root_block(self.raw_state)
 
     # --------------------------------------------------
     def update_state(self, raw_state) :
@@ -297,20 +106,24 @@ class ContractState(object) :
         self.component_block_ids = []
 
         if self.raw_state :
-            json_main_state_block = self.decode_state()
+            json_main_state_block = pblocks.decode_root_block(self.raw_state)
             self.component_block_ids = json_main_state_block['BlockIds']
 
     # --------------------------------------------------
-    def compute_ids_of_newblocks(self, old_block_ids):
-        """ Compute the blocks in the change set : Used for replication. The change set includes the root block if there is any change.
+    def compute_new_block_ids(self, old_block_ids):
+        """ Compute the blocks in the change set
+        Used for replication. The change set includes the root block
+        if there is any change.
         """
+
         self.changed_block_ids = []
         for block_id in self.component_block_ids:
             if block_id not in old_block_ids :
                 self.changed_block_ids.append(block_id)
 
         # add state hash (not sure if this is part of component block_ids, if so we can skip the following)
-        if len(self.changed_block_ids) > 0: # if there is any change, make sure that state hash is part of chaged_block_ids
+        # if there is any change, make sure that state hash is part of chaged_block_ids
+        if len(self.changed_block_ids) > 0 :
             state_hash = self.get_state_hash(encoding='b64')
             if state_hash not in self.changed_block_ids:
                 self.changed_block_ids.append(state_hash)
@@ -322,7 +135,8 @@ class ContractState(object) :
         returns None if no contract state exists
         """
         if self.raw_state:
-            return ContractState.compute_hash(self.raw_state, encoding)
+            return ContractState.compute_state_hash(self.raw_state, encoding)
+
         return None
 
     # --------------------------------------------------
@@ -334,7 +148,7 @@ class ContractState(object) :
         result = dict()
         result['ContractID'] = self.contract_id
         if self.raw_state :
-            result['StateHash'] = ContractState.compute_hash(self.raw_state, encoding='b64')
+            result['StateHash'] = ContractState.compute_state_hash(self.raw_state, encoding='b64')
 
         return result
 
@@ -349,11 +163,9 @@ class ContractState(object) :
         if not self.raw_state :
             return
 
-        block_ids = [ self.get_state_hash(encoding='b64') ]
-        block_ids.extend(self.component_block_ids)
-
-        pushed_blocks = ContractState.__push_blocks_to_eservice__(eservice, self.contract_id, block_ids, data_dir)
-
+        block_manager = pblocks.local_block_manager()
+        root_block_id = self.get_state_hash(encoding='b64')
+        pushed_blocks = pblocks.sync_block_store(block_manager, eservice, root_block_id, self.raw_state)
         logger.debug("Pushed %d new blocks before contract update", pushed_blocks)
 
         stat_logger.debug('state length is %d, pushed %d new blocks', len(self.component_block_ids), pushed_blocks)
@@ -369,17 +181,9 @@ class ContractState(object) :
         if not self.raw_state :
             return
 
-        # raw state already contains the data for the root block, just write it out
-        ContractState.__cache_data_block__(self.contract_id, self.raw_state, data_dir)
-
-        # and then make sure we have everything else we need for the state
-        pulled_blocks = ContractState.__pull_blocks_from_eservice__(
-            eservice, self.contract_id, self.component_block_ids, data_dir)
+        block_manager = pblocks.local_block_manager()
+        root_block_id = self.get_state_hash(encoding='b64')
+        pulled_blocks = pblocks.sync_block_store(eservice, block_manager, root_block_id, self.raw_state)
+        logger.debug("Pulled %d new blocks before contract update", pulled_blocks)
 
         stat_logger.debug('state length is %d, pulled %d new blocks', len(self.component_block_ids), pulled_blocks)
-
-    # --------------------------------------------------
-    def save_to_cache(self, data_dir = None) :
-        ContractState.__cache_data_block__(self.contract_id, self.raw_state, data_dir)
-
-    #---------------------------------------------------

--- a/python/pdo/service_client/storage.py
+++ b/python/pdo/service_client/storage.py
@@ -153,15 +153,15 @@ class StorageServiceClient(GenericServiceClient) :
             raise StorageException(str(e)) from e
 
     # -----------------------------------------------------------------
-    def store_block(self, block_data, expiration=60) :
-        return self.store_blocks([block_data], expiration)
+    def store_block(self, block_data, duration=60) :
+        return self.store_blocks([block_data], duration)
 
     # -----------------------------------------------------------------
-    def store_blocks(self, block_data_list, expiration=60) :
+    def store_blocks(self, block_data_list, duration=60) :
         """Store a list of blocks on the storage server
 
         :param block_data_list: list of blocks represented as byte strings (iterator)
-        :param expiration: number of seconds to request storage
+        :param duration: number of seconds to request storage
         :returns dictionary: decoded result of the request
         """
         request_identifier = self.request_identifier
@@ -171,7 +171,7 @@ class StorageServiceClient(GenericServiceClient) :
 
         try :
             request_data = dict()
-            request_data['operation'] = (None, json.dumps({'expiration' : expiration}), 'application/json')
+            request_data['operation'] = (None, json.dumps({'duration' : duration}), 'application/json')
             count = 0                     # just needed to uniquify the keys
             for block_data in block_data_list :
                 request_data['block{0}'.format(count)] = ('block{0}'.format(count), block_data, 'application/octet-stream')

--- a/python/pdo/test/contract.py
+++ b/python/pdo/test/contract.py
@@ -688,8 +688,6 @@ def Main() :
     if options.source_dir :
         config['Contract']['SourceSearchPath'] = options.source_dir
 
-    putils.set_default_data_directory(config['Contract']['DataDirectory'])
-
     # set up the storage service configuration
     if config.get('StorageService') is None :
         config['StorageService'] = {
@@ -698,6 +696,10 @@ def Main() :
     if options.block_store :
         config['StorageService']['BlockStore'] = options.block_store
 
+    # make the configuration available to all of the PDO modules
+    pconfig.initialize_shared_configuration(config)
+
+    # move local options into the configuration
     config['secrets'] = options.secret_count
 
     if options.expressions :

--- a/python/pdo/test/helpers/state.py
+++ b/python/pdo/test/helpers/state.py
@@ -15,6 +15,7 @@
 import os
 import json
 import pdo.common.crypto as crypto
+import pdo.common.block_store_manager as pblocks
 
 import logging
 logger = logging.getLogger(__name__)
@@ -39,4 +40,4 @@ def TamperWithStateBlockOrder(state_object) :
     #re-store the tampered main state block
     state_object.raw_state = json.dumps(decoded_state).encode('utf8')
     state_object.component_block_ids = block_ids
-    state_object.save_to_cache()
+    pblocks.local_block_manager().store_blocks([state_object.raw_state])

--- a/python/pdo/test/request.py
+++ b/python/pdo/test/request.py
@@ -24,7 +24,7 @@ from string import Template
 import pdo.test.helpers.secrets as secret_helper
 import pdo.test.helpers.state as test_state
 
-from pdo.sservice.block_store_manager import BlockStoreManager
+from pdo.common.block_store_manager import BlockStoreManager
 
 import pdo.eservice.pdo_helper as enclave_helper
 import pdo.service_client.enclave as eservice_helper
@@ -39,6 +39,7 @@ import pdo.common.secrets as secrets
 import pdo.common.utility as putils
 import pdo.common.config as pconfig
 import pdo.common.logger as plogger
+import pdo.common.block_store_manager as pblocks
 
 import logging
 logger = logging.getLogger(__name__)
@@ -317,9 +318,6 @@ def CreateAndRegisterContract(config, enclaves, contract_creator_keys) :
         logger.error("Error while waiting for initial commit: %s", str(e))
         ErrorShutdown()
 
-    logger.debug('update state')
-    contract.contract_state.save_to_cache(data_dir=data_dir)
-
     return contract
 
 # -----------------------------------------------------------------
@@ -595,6 +593,7 @@ def Main() :
     if config.get('Contract') is None :
         config['Contract'] = {
             'DataDirectory' : ContractData,
+            'BlockStore' : os.path.join(ContractData, "local_cache.mdb"),
             'SourceSearchPath' : [ ".", "./contract", os.path.join(ContractHome,'contracts') ]
         }
 
@@ -606,6 +605,9 @@ def Main() :
         config['Contract']['DataDirectory'] = options.data_dir
     if options.source_dir :
         config['Contract']['SourceSearchPath'] = options.source_dir
+
+    if config['Contract'].get('BlockStore') is None :
+        config['Contract']['BlockStore'] = os.path.join(config['Contract']['DataDirectory'], "local_cache.mdb"),
 
     # set up the storage service configuration
     if config.get('StorageService') is None :

--- a/python/pdo/test/request.py
+++ b/python/pdo/test/request.py
@@ -37,6 +37,8 @@ import pdo.common.crypto as crypto
 import pdo.common.keys as keys
 import pdo.common.secrets as secrets
 import pdo.common.utility as putils
+import pdo.common.config as pconfig
+import pdo.common.logger as plogger
 
 import logging
 logger = logging.getLogger(__name__)
@@ -426,7 +428,7 @@ def LocalMain(config) :
     except Exception as e :
         logger.exception('contract execution failed; %s', str(e))
         ErrorShutdown()
-    
+
     enclave_helper.shutdown_enclave()
     sys.exit(0)
 
@@ -466,9 +468,6 @@ def Main() :
     global use_eservice
     global use_pservice
     global tamper_block_order
-
-    import pdo.common.config as pconfig
-    import pdo.common.logger as plogger
 
     # parse out the configuration file first
     conffiles = [ 'pcontract.toml', 'enclave.toml', 'eservice1.toml' ]
@@ -608,8 +607,6 @@ def Main() :
     if options.source_dir :
         config['Contract']['SourceSearchPath'] = options.source_dir
 
-    putils.set_default_data_directory(config['Contract']['DataDirectory'])
-
     # set up the storage service configuration
     if config.get('StorageService') is None :
         config['StorageService'] = {
@@ -618,6 +615,10 @@ def Main() :
     if options.block_store :
         config['StorageService']['BlockStore'] = options.block_store
 
+    # make the configuration available to all of the PDO modules
+    pconfig.initialize_shared_configuration(config)
+
+    # move local options into the configuration
     config['secrets'] = options.secret_count
     config['iterations'] = options.iterations
 


### PR DESCRIPTION
PR includes two commits. 

The first makes the configuration globally accessible. A PDO client builds the configuration from files & command line switches and then pushes it into the global configuration. Services like the block store, file lookup, and replication manager can use it. Several strange defaults have been replaced with references to the global configuration.

The second commit moves the block store manager out of the storage service so that it can be used more generally. Specifically, the file system-based cache used by the client has been replaced with a cache based on the block store manager. This should simplify the process of managing the cache *as a cache*. Replaced several constants (that were overriding configuration file settings) with calls to the configuration manager. Generalized the block store to block store synchronization to make it easier to move blocks between various servers (may want to look at simplifying the replication service with this). The local block store cache will also simplify development of the client-side kv store management.
