### PR TITLE
fix build to make CCF PDO work with the eservice (only) in SGX HW mode

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -25,7 +25,7 @@ DOCKER_COMPOSE_FILES_CCF += ccf-pdo.yaml ccf-pdo.local-code.yaml
 DOCKER_COMPOSE_FILES_CCF_ONLY += ccf.yaml ccf.local-code.yaml
 
 ifeq ($(SGX_MODE),HW)
-   DOCKER_COMPOSE_FILES_CCF += ccf-pdo.sgx.yaml
+   DOCKER_COMPOSE_FILES_CCF += pdo.sgx.yaml
    SGX_DEVICE_PATH=$(shell if [ -e "/dev/isgx" ]; then echo "/dev/isgx"; elif [ -e "/dev/sgx/enclave" ]; then echo "/dev/sgx/enclave"; else echo "ERROR: NO SGX DEVICE FOUND"; fi)
    DOCKER_COMPOSE_COMMAND := env SGX_DEVICE_PATH=${SGX_DEVICE_PATH} ${DOCKER_COMPOSE_COMMAND}
 endif
@@ -96,6 +96,7 @@ test-env-setup-with-no-build-ccf:
 	-$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF) down
 	# - start services
 	$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF) up -d
+	# - configure
 	if [ "$(SGX_MODE)" = "HW" ]; then \
        $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF) \
 		   exec -T pdo-build bash -c 'source /etc/bash.bashrc && export PDO_SGX_KEY_ROOT=/project/pdo/build/opt/pdo/etc/keys/sgx/ && unset PDO_SPID PDO_SPID_API_KEY PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && make -C /project/pdo/src/private-data-objects/build force-conf register'; \

--- a/docker/pdo.sgx.yaml
+++ b/docker/pdo.sgx.yaml
@@ -1,0 +1,51 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# This docker-compose file extends the basic sawtooth-pdo template with support
+# for SGX in hardware mode. To use add a '-f sawtooth-pdo.sgx.yaml' _after_ the
+# '-f sawtooth-pdo.yaml'. This can also be combined with sawtooth-pdo.local-code.yaml.
+
+# Before you can run the containers in hardware mode, you will have to prepare following
+# files in the sgx subdirectory
+# - sgx_spid.txt
+# - sgx_spid_api_key.txt
+# - sgx_ias_key.pem
+# See 'build/common-config -h' for information on the content of these files
+#
+# in the pdo-build shell (see sawtooth-pdo.yaml), before doing any operation
+# you also will have to register sgx-related information in the ledger with
+# following steps
+#    export PDO_SGX_KEY_ROOT=/project/pdo/build/opt/pdo/etc/keys/sgx/
+#    unset PDO_SPID PDO_SPID_API_KEY
+#    source /project/pdo/src/private-data-objects/build/common-config.sh
+#    make -C /project/pdo/src/private-data-objects/build conf register
+
+version: "2.1"
+
+services:
+
+  # PDO EHS, PS and client ...
+  pdo-build:
+    image: pdo-sgx-build
+    container_name: pdo-sgx-build
+    build:
+      args:
+        SGX_MODE: HW
+    volumes:
+      - ${PDO_SGX_KEY_ROOT:-./sgx/}:/project/pdo/build/opt/pdo/etc/keys/sgx/
+      - /var/run/aesmd:/var/run/aesmd
+    devices:
+      - ${SGX_DEVICE_PATH:-/dev/isgx}:${SGX_DEVICE_PATH:-/dev/isgx}
+

--- a/eservice/pdo/eservice/pdo_helper.py
+++ b/eservice/pdo/eservice/pdo_helper.py
@@ -306,10 +306,16 @@ class Enclave(object) :
 
             submitter = create_submitter(ledger_config, pdo_signer = self.txn_keys)
 
+            if self.proof_data != "" and ledger_config.get('LedgerType', "none") == "ccf":
+                logger.warning("Zeroing proof_data field since PDO-TP in CCF does not currently support SGX HW mode")
+                proof_data = ""
+            else:
+                proof_data = self.proof_data
+
             txnsignature = submitter.register_encalve(
                 self.verifying_key,
                 self.encryption_key,
-                self.proof_data,
+                proof_data,
                 self.nonce, # registration block content
                 ledger_config.get('Organization', "EMPTY")) # Eservice Organization Info
         except Exception as e :

--- a/pservice/CMakeLists.txt
+++ b/pservice/CMakeLists.txt
@@ -38,6 +38,12 @@ if("${SGX_MODE} " STREQUAL " ")
 endif()
 IF("${SGX_MODE}" STREQUAL "SIM")
     OPTION(SGX_USE_SIMULATOR "Use the sgx simulator" TRUE)
+ELSEIF("$ENV{PDO_LEDGER_TYPE}" STREQUAL "ccf")
+    # Note: we force SIM mode in the pservice when using ccf,
+    #       because ccf currently does not accept/verify/return the proof_data field,
+    #       which is verified by the pservice in HW mode
+    message(WARNING, "Forcing SIM mode at PService because CCF is being used")
+    OPTION(SGX_USE_SIMULATOR "Use the sgx simulator" TRUE)
 ELSE()
     OPTION(SGX_USE_SIMULATOR "Use the sgx simulator" FALSE)
     If(NOT EXISTS ${PDO_TOP_DIR}pservice/lib/libpdo_enclave/contract_enclave_mrenclave.cpp)

--- a/pservice/setup.py
+++ b/pservice/setup.py
@@ -88,10 +88,18 @@ libraries = [
     'updo-common'
 ]
 
-if sgx_mode_env == "HW":
+if sgx_mode_env == "HW" and os.environ.get('PDO_LEDGER_TYPE', "none") != "ccf":
     libraries.append('sgx_urts')
     libraries.append('sgx_uae_service')
     SGX_SIMULATOR_value = '0'
+
+if sgx_mode_env == "HW" and os.environ.get('PDO_LEDGER_TYPE', "none") == "ccf":
+    # Forcing SIM mode since ccf does not support PDO HW mode
+    libraries.append('sgx_urts_sim')
+    libraries.append('sgx_uae_service_sim')
+    print("Forcing SIM mode in PService since ccf does not support PDO HW mode")
+    SGX_SIMULATOR_value = '1'
+
 if sgx_mode_env == "SIM":
     libraries.append('sgx_urts_sim')
     libraries.append('sgx_uae_service_sim')

--- a/python/pdo/submitter/ccf/ccf_submitter.py
+++ b/python/pdo/submitter/ccf/ccf_submitter.py
@@ -467,7 +467,7 @@ class PayloadBuilder(object):
         payloadblob['encryption_key'] = encryption_key
         payloadblob['proof_data'] = proof_data
         if proof_data:
-            payloadblob['enclave_persistent_id'] = get_epid_pseudonym_from_proof_data(proof_data)
+            payloadblob['enclave_persistent_id'] = sub.get_epid_pseudonym_from_proof_data(proof_data)
         else:
             payloadblob['enclave_persistent_id'] = "ignored field, no proof data"
         payloadblob['registration_block_context'] = registration_block_context


### PR DESCRIPTION
As we remove Sawtooth, we have a problem: CCF does not support PDO in HW mode.
This means that there is no alternative available to run PDO in SGX HW mode.

This PR partially addresses this problem:
1. it provide the docker compose material to run the CI in HW mode
2. it fixes a bug in the CCF submitters
3. in HW mode, it compiles the eservice as expected, but it forces: the pservice in sim mode, and the proof_data field to be empty. This is necessary to run (at least) the eservice in HW mode and avoid signature/field verification issues, probably due to unintended formatting. The changes (about 20 lines in 3 files) can be easily reverted as the other issues are solved.

More details of these issues are in #262 , here https://github.com/hyperledger-labs/private-data-objects/issues/262#issuecomment-1278684081.





Signed-off-by: Bruno Vavala <bruno.vavala@intel.com>