### PR TITLE
Sawtooth in-depth removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,12 @@ smart contracts policies are enforced through execution in a Trusted Execution
 Environment (TEE).
 
 PDO uses a distributed ledger, in this case the
-[Hyperledger Sawtooth](https://sawtooth.hyperledger.org/)
+[Microsoft Confidential Consortium Framework (CCF)](https://microsoft.github.io/CCF/)
 distributed ledger, to ensure that there is a single, authoritative
 instance of the object, and to provide a means of guaranteeing atomicity of
 updates across interacting objects. PDO performs contract execution and storage off the blockchain, with only a hash of
 blockchain state stored on the distributed ledger.
-
-There is also an ongoing experimental effort to add support for
-[Microsoft Confidential Consortium Framework (CCF)](https://microsoft.github.io/CCF/) based ledger.
-Currently, the PDO/CCF combo is restricted to virtual enclaves, and lacks docker as well as
-automated test support.
+Currently, the PDO/CCF combo is restricted to virtual enclaves.
 
 PDO provides benefits for both application developers seeking to define and
 implement privacy-preserving distributed ledgers, and for service providers

--- a/build/Makefile
+++ b/build/Makefile
@@ -90,7 +90,6 @@ $(PYTHON_DIR) :
 	. $(abspath $(DSTDIR)/bin/activate) && pip install --upgrade twisted
 	. $(abspath $(DSTDIR)/bin/activate) && pip install --upgrade pyyaml
 	. $(abspath $(DSTDIR)/bin/activate) && pip install --upgrade google
-	. $(abspath $(DSTDIR)/bin/activate) && pip install --upgrade protobuf==3.19.0
 	. $(abspath $(DSTDIR)/bin/activate) && pip install secp256k1==0.13.2
 	. $(abspath $(DSTDIR)/bin/activate) && pip install --upgrade cryptography
 	. $(abspath $(DSTDIR)/bin/activate) && pip install --upgrade pyparsing

--- a/build/Makefile
+++ b/build/Makefile
@@ -127,10 +127,7 @@ ${PDO_ENCLAVE_CODE_SIGN_PEM} :
 
 service_indexes := 1 2 3 4 5
 
-ifeq ($(PDO_LEDGER_TYPE),sawtooth)
-	ESERVICE_KEYS := $(addprefix $(KEYDIR),$(foreach i,$(service_indexes),eservice$(i)_private.skf))
-	ecdsa_curve := secp256k1
-else
+ifeq ($(PDO_LEDGER_TYPE),ccf)
 	ESERVICE_KEYS := $(addprefix $(KEYDIR),$(foreach i,$(service_indexes),eservice$(i)_private.pem))
 	ecdsa_curve := secp384r1
 endif
@@ -140,9 +137,6 @@ PSERVICE_PEM := $(addprefix $(KEYDIR),$(foreach i,$(service_indexes),pservice$(i
 
 user_indexes := 1 2 3 4 5 6 7 8 9 10
 USER_PEM := $(addprefix $(KEYDIR),$(foreach i,$(user_indexes),user$(i)_private.pem))
-
-%.skf :
-	. $(abspath $(DSTDIR)/bin/activate) && $(KEYGEN) --keyfile $(subst _private,,$*) --format skf
 
 %.pem :
 	. $(abspath $(DSTDIR)/bin/activate) && $(KEYGEN) --keyfile $(subst _private,,$*) --format pem --curve $(ecdsa_curve)

--- a/build/__tools__/expand-config
+++ b/build/__tools__/expand-config
@@ -83,12 +83,10 @@ except KeyError as ke :
     sys.exit(-1)
 
 #deduce eservice key format based on ledger type
-if LedgerType == 'sawtooth':
-    EserviceKeyFormat = 'skf'
-elif LedgerType == 'ccf':
+if LedgerType == 'ccf':
     EserviceKeyFormat = 'pem'
 else:
-    print("Cannot configure eservice keys. Invalid ledger type, Must be 'sawtooth' or 'ccf'" )
+    print("Cannot configure eservice keys. Invalid ledger type, Must be 'ccf'" )
     sys.exit(-1)
 
 ContractHost = os.environ.get("PDO_HOSTNAME", os.environ.get("HOSTNAME", "localhost"))
@@ -147,7 +145,7 @@ def expand_multiple(options, n) :
 # -----------------------------------------------------------------
 import argparse
 
-parser = argparse.ArgumentParser(description='Script to generate sawtooth configuration files from a template')
+parser = argparse.ArgumentParser(description='Script to generate configuration files from a template')
 
 parser.add_argument('--template', help='Name of the base configuration file to use', default='template.js')
 parser.add_argument('--template-directory', help='Directory in which the template configuration will be found', default='etc/templates')

--- a/build/__tools__/make-keys
+++ b/build/__tools__/make-keys
@@ -17,23 +17,11 @@
 import argparse
 parser = argparse.ArgumentParser()
 parser.add_argument('--keyfile', help='name of the file to write', default='keyfile')
-parser.add_argument('--format', help='format of the key to generate', choices=['skf', 'pem'])
+parser.add_argument('--format', help='format of the key to generate', choices=['pem'])
 parser.add_argument('--curve', help='ecdsa curve to use for pem keys', default = 'secp256k1', choices=['secp256k1', 'secp384r1'])
 options = parser.parse_args()
 
-if options.format == 'skf' :
-    import secp256k1
-    stl_private_key = secp256k1.PrivateKey()
-
-    private_file_name = "{0}_private.skf".format(options.keyfile)
-    with open(private_file_name, "w") as pf :
-        pf.write(stl_private_key.serialize())
-
-    public_file_name = "{0}_public.skf".format(options.keyfile)
-    with open(public_file_name, "w") as pf :
-        pf.write(stl_private_key.pubkey.serialize().hex())
-
-elif options.format == 'pem' :
+if options.format == 'pem' :
     import pdo.common.crypto as crypto
 
     if options.curve == 'secp384r1':

--- a/build/__tools__/verify-pre-build.sh
+++ b/build/__tools__/verify-pre-build.sh
@@ -48,12 +48,6 @@ yell --------------- CONFIG AND ENVIRONMENT PRE-BUILD CHECK ---------------
 
 $(pkg-config --atleast-version=1.1.0g openssl) || warn "WARNING: Openssl version found in PKG_CONFIG_PATH must be 1.1.0g or greater"
 
-try command -v protoc
-PROTOC_VERSION=$(protoc --version | sed 's/libprotoc \([0-9]\).*/\1/')
-if [[ "$PROTOC_VERSION" -lt 3 ]]; then
-    warn "protoc must be version3 or higher"
-fi
-
 try command -v python3
 try command -v cmake
 try command -v swig

--- a/build/common-config.sh
+++ b/build/common-config.sh
@@ -68,7 +68,7 @@ var_set() {
 	"
 	env_key_sort[$i]="SGX_MODE"; i=$i+1; export SGX_MODE=${env_val[SGX_MODE]}
 
-	env_val[PDO_LEDGER_URL]="${PDO_LEDGER_URL:-http://127.0.0.1:8008}"
+	env_val[PDO_LEDGER_URL]="${PDO_LEDGER_URL:-http://127.0.0.1:6600}"
 	env_desc[PDO_LEDGER_URL]="
 		PDO_LEDGER_URL is the URL is to submit transactions to the ledger.
 	"
@@ -76,7 +76,7 @@ var_set() {
 
 	env_val[PDO_LEDGER_TYPE]="${PDO_LEDGER_TYPE:-ccf}"
 	env_desc[PDO_LEDGER_TYPE]="
-		PDO_LEDGER_TYPE is the ledger used by PDO. Choose either sawtooth or ccf
+		PDO_LEDGER_TYPE is the ledger used by PDO. Available options: ccf
 	"
 	env_key_sort[$i]="PDO_LEDGER_TYPE"; i=$i+1; export PDO_LEDGER_TYPE=${env_val[PDO_LEDGER_TYPE]}
 
@@ -85,7 +85,7 @@ var_set() {
 		env_val[PDO_DEFAULT_SIGCURVE]="${PDO_DEFAULT_SIGCURVE:-SECP384R1}"
 		env_desc[PDO_DEFAULT_SIGCURVE]="
 			PDO_DEFAULT_SIGCURVE is the ECDSA curve used by PDO for generating signatures.
-			Choose SECP384R1 for ccf. If not set, cyrpto library uses SECP256K1 as default which works for sawtooth"
+			Choose SECP384R1 for ccf. If not set, the crypto library uses SECP256K1 by default."
 		env_key_sort[$i]="PDO_DEFAULT_SIGCURVE"; i=$i+1; export PDO_DEFAULT_SIGCURVE=${env_val[PDO_DEFAULT_SIGCURVE]}
 	fi
 
@@ -154,15 +154,6 @@ var_set() {
 		placed under this folder. These keys get generated during ccf deployment.
 	"
 	env_key_sort[$i]="PDO_LEDGER_KEY_ROOT"; i=$i+1; export PDO_LEDGER_KEY_ROOT=${env_val[PDO_LEDGER_KEY_ROOT]}
-
-	env_val[PDO_LEDGER_KEY_SKF]="${PDO_LEDGER_KEY_SKF:-${PDO_LEDGER_KEY_ROOT}/pdo_validator.priv}"
-	env_desc[PDO_LEDGER_KEY_SKF]="
-		PDO_LEDGER_KEY_SKF is used to update settings in the Sawtooth validator.
-		This is the key used by the Sawtooth ledger and is generally
-		found in the file .sawtooth/keys/ledger.priv in the
-		Sawtooth installation directory hiearchy.
-	"
-	env_key_sort[$i]="PDO_LEDGER_KEY_SKF"; i=$i+1; export PDO_LEDGER_KEY_SKF=${env_val[PDO_LEDGER_KEY_SKF]}
 	}
 
 do_export() {
@@ -198,8 +189,8 @@ local configuration file may be constructed as:
 
    export PDO_LEDGER_KEY_ROOT=${HOME}/keys/ledger
    export PDO_INSTALL_ROOT=${HOME}/pdo-test-env
-   export PDO_LEDGER_URL=http://127.0.0.1:8008
-   export PDO_LEDGER_TYPE=sawtooth
+   export PDO_LEDGER_URL=http://127.0.0.1:6600
+   export PDO_LEDGER_TYPE=ccf
    export WASM_SRC=${HOME}/wasm
 
 and before buidling it you call script as
@@ -210,7 +201,7 @@ If passed the parameter --evalable-export it will
 return a list of export commands of the variables
 instead of directly exporting them to the environment.
 Passing parameter --reset-keys will unset keying variables
-PDO_ENCLAVE_CODE_SIGN_PEM, PDO_LEDGER_KEY_SKF,
+PDO_ENCLAVE_CODE_SIGN_PEM,
 PDO_SPID and PDO_SPID_API_KEY before setting variables.
 
 The list of variables set (in order they are defined, their defaults
@@ -238,7 +229,6 @@ do
             # depend on those variables
 	    # -----------------------------------------------------------------
 	    unset PDO_ENCLAVE_CODE_SIGN_PEM
-	    unset PDO_LEDGER_KEY_SKF
 	    unset PDO_SPID
 	    unset PDO_SPID_API_KEY
             ;;

--- a/client/etc/auction-test.toml
+++ b/client/etc/auction-test.toml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-[Sawtooth]
+[Ledger]
 LedgerURL = "${ledger}"
 
 [Logging]

--- a/client/pdo/client/scripts/EServiceDatabaseCLI.py
+++ b/client/pdo/client/scripts/EServiceDatabaseCLI.py
@@ -194,7 +194,7 @@ ContractEtc = os.path.join(ContractHome, "etc")
 ContractKeys = os.path.join(ContractHome, "keys")
 ContractLogs = os.path.join(ContractHome, "logs")
 ContractData = os.path.join(ContractHome, "data")
-LedgerURL = os.environ.get("PDO_LEDGER_URL", "http://127.0.0.1:8008/")
+LedgerURL = os.environ.get("PDO_LEDGER_URL", "http://127.0.0.1:6600/")
 ScriptBase = os.path.splitext(os.path.basename(sys.argv[0]))[0]
 
 config_map = {
@@ -270,7 +270,7 @@ def Main() :
     # set up the ledger configuration
     if config.get('Ledger') is None :
         config['Ledger'] = {
-            'LedgerURL' : 'http://localhost:8008',
+            'LedgerURL' : 'http://localhost:6600',
         }
     if options.ledger :
         config['Ledger']['LedgerURL'] = options.ledger

--- a/client/pdo/client/scripts/ShellCLI.py
+++ b/client/pdo/client/scripts/ShellCLI.py
@@ -55,7 +55,7 @@ ContractEtc = os.path.join(ContractHome, "etc")
 ContractKeys = os.path.join(ContractHome, "keys")
 ContractLogs = os.path.join(ContractHome, "logs")
 ContractData = os.path.join(ContractHome, "data")
-LedgerURL = os.environ.get("PDO_LEDGER_URL", "http://127.0.0.1:8008/")
+LedgerURL = os.environ.get("PDO_LEDGER_URL", "http://127.0.0.1:6600/")
 ScriptBase = os.path.splitext(os.path.basename(sys.argv[0]))[0]
 ContractInterpreter = os.environ.get("PDO_INTERPRETER", "gipsy")
 
@@ -91,7 +91,7 @@ def Main() :
     parser.add_argument('--logfile', help='Name of the log file, __screen__ for standard output', type=str)
     parser.add_argument('--loglevel', help='Logging level', type=str)
 
-    parser.add_argument('--ledger', help='URL for the Sawtooth ledger', type=str)
+    parser.add_argument('--ledger', help='URL for the ledger', type=str)
 
     parser.add_argument('--data-dir', help='Directory for storing generated files', type=str)
     parser.add_argument('--source-dir', help='Directories to search for contract source', nargs='+', type=str)
@@ -140,7 +140,7 @@ def Main() :
     # set up the ledger configuration
     if config.get('Ledger') is None :
         config['Ledger'] = {
-            'LedgerURL' : 'http://localhost:8008',
+            'LedgerURL' : 'http://localhost:6600',
         }
     if options.ledger :
         config['Ledger']['LedgerURL'] = options.ledger

--- a/client/setup.py
+++ b/client/setup.py
@@ -48,7 +48,7 @@ version = subprocess.check_output(
 
 setup(name='pdo_client',
       version=version,
-      description='Client utilities for Sawtooth private contracts',
+      description='Client utilities for private contracts',
       author='Mic Bowman, Intel Labs',
       author_email='mic.bowman@intel.com',
       url='http://www.intel.com',

--- a/common/crypto/sig_public_key.cpp
+++ b/common/crypto/sig_public_key.cpp
@@ -235,7 +235,7 @@ void pcrypto::sig::PublicKey::Deserialize(const std::string& encoded)
 }  // pcrypto::sig::PublicKey::Deserialize
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-// Deserialize EC point (X,Y) hex string for Sawtooth compatibility
+// Deserialize EC point (X,Y) hex string
 // throws RuntimeError, ValueError
 void pcrypto::sig::PublicKey::DeserializeXYFromHex(const std::string& hexXY)
 {
@@ -329,7 +329,7 @@ std::string pcrypto::sig::PublicKey::Serialize() const
 }  // pcrypto::sig::PublicKey::Serialize
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // throws RuntimeError
-// Serialize EC point (X,Y) to hex string for Sawtooth compatibility
+// Serialize EC point (X,Y) to hex string
 std::string pcrypto::sig::PublicKey::SerializeXYToHex() const
 {
     if (key_ == nullptr)

--- a/common/crypto/sig_public_key.h
+++ b/common/crypto/sig_public_key.h
@@ -54,10 +54,10 @@ namespace crypto
             // throws RuntimeError
             std::string Serialize() const;
             // throws RuntimeError
-            // Serialize EC point (X,Y) to hex string for Sawtooth compatibility
+            // Serialize EC point (X,Y) to hex string
             // throws RuntimeError
             std::string SerializeXYToHex() const;
-            // Deserialize EC point (X,Y) hex string for Sawtooth compatibility
+            // Deserialize EC point (X,Y) hex string
             // throws RuntimeError, ValueError
             void DeserializeXYFromHex(const std::string& hexXY);
             // Verify signature signature.data() on message.data() and return 1 if signature is

--- a/contracts/exchange/docs/exchange.md
+++ b/contracts/exchange/docs/exchange.md
@@ -112,7 +112,7 @@ marbles, and the escrow claim. The escrow proof is set in the context of a parti
 the state of the BMC contract object. That is, the proof of escrow holds if and only if the current
 state of the BMC (which captures that Alice's holding has been escrowed) has been committed to the
 ledger. This requirement is captured by transaction dependencies that are enforced by the
-Coordination and Commit transaction processor in Sawtooth. Figure 2 shows the dependencies between
+Coordination and Commit transaction processor in the ledger. Figure 2 shows the dependencies between
 state update transactions that must be enforced by the TP.
 
 5. Once Alice finishes, Bob can examine the exchange object and see that Alice is offering 100 blue

--- a/docker/Dockerfile.pdo-build
+++ b/docker/Dockerfile.pdo-build
@@ -44,7 +44,7 @@
 #     Note: your host SGX PSW runtime should be at a similar level than the one in the container
 #     or the PSW/aesmd might cause enclave launch problems
 #   - Regardless of SGX_MODE, we build with the default fake SGX values and some
-#     default PDO_LEDGER_URL (http://rest-api:8008). If these are different at runtime, e.g.,
+#     default PDO_LEDGER_URL (http://127.0.0.1:6600). If these are different at runtime, e.g.,
 #     because the ledger changes and/or you run in SGX HW mode and your sgx keys are at a
 #     different place and not mapped via docker volumes to the default location
 #     '/project/pdo/src/private-data-objects/build/keys/sgx_mode_${SGX_MODE,,}'
@@ -63,7 +63,7 @@
 
 ARG PDO_DEV_IMAGE=pdo-dev
 
-# Get source of PDO and Sawtooth for the corresponding protobufs
+# Get source of PDO
 # to allow using local development branch we copy whatever docker directory is passed
 # (and so would contain .git if we call it as docker build . -f docker/.... which then
 # can be used via PDO_REPO_BRANCH build-arg) but also do that via multi-stage so we don't load
@@ -98,7 +98,7 @@ ENV PDO_DEBUG_BUILD=${PDO_DEBUG_BUILD}
 ARG PDO_INTERPRETER=gipsy
 ENV PDO_INTERPRETER=${PDO_INTERPRETER}
 
-ARG PDO_LEDGER_URL=http://rest-api:8008
+ARG PDO_LEDGER_URL=http://pdo-tp-ccf:6600
 ENV PDO_LEDGER_URL=${PDO_LEDGER_URL}
 
 ARG PDO_LEDGER_TYPE=ccf
@@ -133,22 +133,15 @@ RUN \
 # - build script install in virtualenv. For docker this seems a bit overkill but easier than to
 #   duplicate all build instructions.
  && cd /project/pdo/src/private-data-objects \
-# && sawtooth/bin/build_sawtooth_proto \
  && cd python \
  && python3 setup.py build_ext \
  && python3 setup.py install \
-# && cd ../sawtooth \
-# && python3 setup.py install \
 #
-# Build sawtooth interface.
+# Build ledger interface.
  && cd /project/pdo/src/private-data-objects/eservice/ \
  && sed -i 's/python /python3 /g' Makefile \
  && make \
  && make install \
  && python3 setup.py install \
- && cd .. \
-# && sawtooth/bin/build_sawtooth_proto \
- && cd python/ \
- && python3 setup.py install
 
 # TODO (eventually): clean-up /project/pdo/src (but for now keep it as some tests are still there ...)

--- a/docker/Dockerfile.pdo-dev
+++ b/docker/Dockerfile.pdo-dev
@@ -70,7 +70,6 @@ ARG SGXSSL=2.10_1.1.1g
 ARG ADD_APT_PKGS=
 
 # Add necessary packages
-# TODO(xenial): we need to manually install protobuf 3 as xenial has v2
 # Note: ocamlbuild is required by PREREQ but does not exist for xenial. However, the relevant componets are part of 'ocaml' package, later ubuntu split up that package ...
 RUN apt-get update \
  && DEBIAN_FRONTEND="noninteractive" \
@@ -87,7 +86,6 @@ RUN apt-get update \
     gnupg \
     libcurl4-openssl-dev \
     liblmdb-dev \
-    libprotobuf-dev \
     libsecp256k1-dev \
     libssl-dev \
     libtool \
@@ -96,7 +94,6 @@ RUN apt-get update \
     ocaml \
     ocamlbuild \
     pkg-config \
-    protobuf-compiler \
     python \
     python3-dev \
     python3-venv \

--- a/docker/Dockerfile.pdo-tp-ccf
+++ b/docker/Dockerfile.pdo-tp-ccf
@@ -49,7 +49,7 @@ COPY . /tmp/build-src
 # get the pdo tp source code
 RUN mkdir -p /pdo/dev
 RUN cd /pdo \
-	&& git clone --single-branch --branch ${PDO_REPO_BRANCH} --recurse-submodules ${PDO_REPO_URL} private-data-objects
+	&& git clone --single-branch --branch ${PDO_REPO_BRANCH} ${PDO_REPO_URL} private-data-objects
 WORKDIR /pdo/
 
 # Env variables needed to build pdo-tp-ccf. Also generate the enclave signing key

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -15,20 +15,17 @@
 
 DOCKER_BUILD_OPTS=
 DOCKER_COMPOSE_COMMAND=docker-compose
-DOCKER_COMPOSE_FILES_STL=
 DOCKER_COMPOSE_FILES_CCF=
-DOCKER_COMPOSE_OPTS_STL=
 DOCKER_COMPOSE_OPTS_CCF=
 
 # optionally allow local overriding defaults
 -include make.loc
 
-DOCKER_COMPOSE_FILES_STL += sawtooth-pdo.yaml sawtooth-pdo.local-code.yaml
 DOCKER_COMPOSE_FILES_CCF += ccf-pdo.yaml ccf-pdo.local-code.yaml
 DOCKER_COMPOSE_FILES_CCF_ONLY += ccf.yaml ccf.local-code.yaml
 
 ifeq ($(SGX_MODE),HW)
-   DOCKER_COMPOSE_FILES_STL += sawtooth-pdo.sgx.yaml
+   DOCKER_COMPOSE_FILES_CCF += ccf-pdo.sgx.yaml
    SGX_DEVICE_PATH=$(shell if [ -e "/dev/isgx" ]; then echo "/dev/isgx"; elif [ -e "/dev/sgx/enclave" ]; then echo "/dev/sgx/enclave"; else echo "ERROR: NO SGX DEVICE FOUND"; fi)
    DOCKER_COMPOSE_COMMAND := env SGX_DEVICE_PATH=${SGX_DEVICE_PATH} ${DOCKER_COMPOSE_COMMAND}
 endif
@@ -45,15 +42,13 @@ ifdef no_proxy
    DO_PROXY = 1
 endif
 ifdef DO_PROXY
-   DOCKER_COMPOSE_FILES_STL += sawtooth-pdo.proxy.yaml
    DOCKER_COMPOSE_FILES_CCF += ccf-pdo.proxy.yaml
    DOCKER_COMPOSE_FILES_CCF_ONLY += ccf.proxy.yaml
 endif
 ifdef PDO_DEBUG_BUILD
-   DOCKER_COMPOSE_FILES_STL += sawtooth-pdo.debugging.yaml
+   DOCKER_COMPOSE_FILES_CCF += ccf-pdo.debugging.yaml
 endif
 
-DOCKER_COMPOSE_OPTS_STL += $(foreach cf, $(DOCKER_COMPOSE_FILES_STL), -f $(cf))
 DOCKER_COMPOSE_OPTS_CCF += $(foreach cf, $(DOCKER_COMPOSE_FILES_CCF), -f $(cf))
 DOCKER_COMPOSE_OPTS_CCF_ONLY += $(foreach cf, $(DOCKER_COMPOSE_FILES_CCF_ONLY), -f $(cf))
 
@@ -63,10 +58,10 @@ pdo-dev-image:
 	# unconditionally build, count on docker caching to not rebuild if not necessary
 	docker build $(DOCKER_BUILD_OPTS) -f Dockerfile.pdo-dev -t pdo-dev .
 
-pdo-composition: pdo-dev-image
-	env PDO_REPO_BRANCH=$$(git rev-parse --abbrev-ref HEAD) $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_STL) build
+pdo-composition-ccf: pdo-dev-image
+	env PDO_REPO_BRANCH=$$(git rev-parse --abbrev-ref HEAD) $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF) build
 	# Note:
-	# - using `sawtooth-pdo.local-code.yaml` in above will cause the docker context to be `../`.
+	# - using `ccf-pdo.local-code.yaml` in above will cause the docker context to be `../`.
 	#   To make sure that we do not pull in (too much) unnecessary stuff, we explicitly excludes
 	#   various files/dirs in `../.dockerignore`.
 	#   There are two negative effect for not excluding enough
@@ -79,34 +74,16 @@ pdo-composition: pdo-dev-image
 	#     sparse but docker expands to them to their nominal size (several gb) and could cause
 	#     running out of disk space during the build...
 
-pdo-composition-ccf: pdo-dev-image
-	env PDO_REPO_BRANCH=$$(git rev-parse --abbrev-ref HEAD) $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF) build
 
 ccf-only:
 	env PDO_REPO_BRANCH=$$(git rev-parse --abbrev-ref HEAD) $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF_ONLY) build
 
 
-test-stl: pdo-composition test-with-no-build
 test-ccf: pdo-composition-ccf test-with-no-build-ccf
 test: test-ccf
 
-test-env-setup: pdo-composition test-env-setup-with-no-build
 test-env-setup-ccf: pdo-composition-ccf test-env-setup-with-no-build-ccf
 test-env-setup-ccf-only: ccf-only test-env-setup-with-no-build-ccf-only
-
-test-env-setup-with-no-build:
-	# just to be on safe side, make sure environment is not still up (e.g.,from previous failed attempt)
-	-$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_STL) down
-	# - start services
-	$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_STL) up -d
-	# MAYBE: test , e.g., with 'ps', whether all services are up properly
-	# - insitialize the ledger
-	$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_STL) \
-	   exec -T validator sawset proposal create --url http://rest-api:8008 --key /root/.sawtooth/keys/my_key.priv sawtooth.validator.transaction_families='[{"family": "intkey", "version": "1.0"}, {"family":"sawtooth_settings", "version":"1.0"}, {"family": "pdo_contract_enclave_registry", "version": "1.0"}, {"family":  "pdo_contract_instance_registry", "version": "1.0"}, {"family": "ccl_contract", "version": "1.0"}]'
-	if [ "$(SGX_MODE)" = "HW" ]; then \
-	   $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_STL) \
-	      exec -T pdo-build bash -c 'source /etc/bash.bashrc && export PDO_SGX_KEY_ROOT=/project/pdo/build/opt/pdo/etc/keys/sgx/ && unset PDO_SPID PDO_SPID_API_KEY PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && make -C /project/pdo/src/private-data-objects/build force-conf register'; \
-	fi
 
 test-env-setup-with-no-build-ccf-only:
 	# just to be on safe side, make sure environment is not still up (e.g.,from previous failed attempt)
@@ -119,19 +96,10 @@ test-env-setup-with-no-build-ccf:
 	-$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF) down
 	# - start services
 	$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF) up -d
-
-test-with-no-build: test-env-setup-with-no-build
-	# 'sawtooth-pdo.debugging.yaml' doesn't start pdo-tp, so we will have to manually start it
-	if [ ! -z "$(PDO_DEBUG_BUILD)" ]; then  \
-	   $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_STL) \
-	      exec -T -d pdo-tp bash -c "/project/pdo/src/private-data-objects/sawtooth/bin/pdo-tp -v -v --connect tcp://validator:4004 --debug-on"; \
-	fi
-	# - run automated tests
-	$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_STL) \
-	   exec -T pdo-build bash -i -c /project/pdo/src/private-data-objects/build/__tools__/run-tests.sh
-	# - teardown
-	$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_STL) down
-
+	if [ "$(SGX_MODE)" = "HW" ]; then \
+       $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF) \
+		   exec -T pdo-build bash -c 'source /etc/bash.bashrc && export PDO_SGX_KEY_ROOT=/project/pdo/build/opt/pdo/etc/keys/sgx/ && unset PDO_SPID PDO_SPID_API_KEY PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && make -C /project/pdo/src/private-data-objects/build force-conf register'; \
+    fi
 
 test-with-no-build-ccf: test-env-setup-with-no-build-ccf
 	# - run automated tests
@@ -150,8 +118,5 @@ test-with-no-build-ccf: test-env-setup-with-no-build-ccf
 
 # target to run docker-compose with same files on arbitrary docker-compose command passed as ARGS...
 # to pass multiple arguments, you will have to pass it as env-variablse, e.g., "env ARGS='arg1 arg2 arg3' make run"
-run-stl:
-	$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_STL) $(ARGS)
-
 run-ccf:
 	$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF) $(ARGS)

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,8 +8,7 @@ https://creativecommons.org/licenses/by/4.0/
 This directory contains configurations to run PDO with docker and docker-compose.
 This allows you to develop easily on non-ubuntu 18.04/20.04 machines
 without "polluting" your install.  Additionally, it also enables easy
-end-to-end setups with a local sawtooth or CCF ledger and automated end to
-end tests.
+end-to-end setups with a local CCF ledger and automated end-to-end tests.
 
 
 # Preparation
@@ -82,7 +81,7 @@ The easiest way to get started is to run
 	make test
 ```
 which will build your current locally committed branch and run the
-end-to-end tests based on a completely freshly setup sawtooth ledger
+end-to-end tests based on a completely freshly setup ccf ledger
 in default configuration.  Starting from a good branch, this should
 also normally successfully run and hence allows also making sure that
 the docker setup is ok.
@@ -124,7 +123,7 @@ e.g.  run `make run ARGS='exec pdo-build bash'` to start a shell in
 the pdo-build container.
 
 If you define the `PDO_DEBUG_BUILD` environment variable, the make
-commands will (with help of [`sawtooth.debugging.yaml`](sawtooth.debugging.yaml)) build
+commands will (with help of [`ccf.debugging.yaml`](ccf.debugging.yaml)) build
 the code with debugging and and run docker containers such that
 gdb/sgx-gdb-based debugging is possible.
 Note though, that due to some docker(-compose)ism, terminating daemon
@@ -138,19 +137,19 @@ be easier to test outside so you can, e.g., monitor localhost traffic
 with `wireshark` which is challenging within docker. Note that with
 `make test-env-setup` (or `make test-env-setup-with-no-build` if you
 are sure container images for PDO-TP and other components are already
-properly built) you get a fresh sawtooth setup where ledger rest API
+properly built) you get a fresh ccf setup where ledger rest API
 is also exposed to the host, i.e., the default url
-`http://localhost:8008` does also work from the host and you can test
+`http://localhost:6600` does also work from the host and you can test
 client and {e,s,p}services on the host with a fresh and
 self-contained/single machine installation.
 
 For more advanced docker-compose usage, check the headers in the yaml
 files:
-  - [sawtooth-pdo.yaml](sawtooth-pdo.yaml)
-  - [sawtooth-pdo.local-code.yaml](sawtooth-pdo.local-code.yaml)
-  - [sawtooth-pdo.proxy.yaml](sawtooth-pdo.proxy.yaml)
-  - [sawtooth-pdo.sgx.yaml](sawtooth-pdo.sgx.yaml)
-  - [sawtooth-pdo.debugging.yaml](sawtooth-pdo.debugging.yaml)
+  - [ccf-pdo.yaml](ccf-pdo.yaml)
+  - [ccf-pdo.local-code.yaml](ccf-pdo.local-code.yaml)
+  - [ccf-pdo.proxy.yaml](ccf-pdo.proxy.yaml)
+  - [ccf-pdo.sgx.yaml](ccf-pdo.sgx.yaml)
+  - [ccf-pdo.debugging.yaml](ccf-pdo.debugging.yaml)
 
 Similarly, the Dockerfiles also have additional information in the header if you want
 to use them separately:

--- a/docker/ccf-pdo.debugging.yaml
+++ b/docker/ccf-pdo.debugging.yaml
@@ -1,0 +1,47 @@
+# Copyright 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# Use this docker-compose file together with sawtoth-pdo.yaml to build in debug mode
+# and enable debugging with gdb/sgx-gdb and alike ...
+
+
+version: "2.1"
+
+services:
+
+  # PDO EHS, PS and client ...
+  pdo-build:
+    # Note: the default entrypoint will result in zombie processes when daemons such as ps-start/es-start terminate
+    # as the shell doesn't clean up, which will make run-tests fail!. Changing entrypoint to bash solves that but
+    # alas this doesn't not work in general here as it makes docker-compse up fail for this combponent and has to be done
+    # on individual basis
+    build:
+      args:
+        PDO_DEBUG_BUILD: 1
+    environment:
+      - PDO_DEBUG_BUILD=1
+    security_opt:
+      - seccomp=unconfined
+    cap_add:
+      - SYS_PTRACE
+
+  # PDO Transaction processor
+  pdo-tp-ccf:
+    environment:
+      - PDO_DEBUG_BUILD=1
+    security_opt:
+      - seccomp=unconfined
+    cap_add:
+      - SYS_PTRACE

--- a/docker/ccf-pdo.local-code.yaml
+++ b/docker/ccf-pdo.local-code.yaml
@@ -13,10 +13,10 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-# This docker-compose file extends the basic sawtooth-pdo template with support
+# This docker-compose file extends the basic ccf-pdo template with support
 # to build from code _committed_ to workspace.
-# To use add a '-f sawtooth-pdo.local-code.yaml' _after_ the
-# '-f sawtooth-pdo.yaml'. This can also be combined with sawooth-pdo.sgx.yaml.
+# To use add a '-f ccf-pdo.local-code.yaml' _after_ the
+# '-f ccf-pdo.yaml'. This can also be combined with ccf-pdo.sgx.yaml.
 # To get latest code, you might want to run 'docker-compose .... build' before
 # running 'docker-compose ... up'
 

--- a/docker/ccf.local-code.yaml
+++ b/docker/ccf.local-code.yaml
@@ -13,10 +13,10 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-# This docker-compose file extends the basic sawtooth-pdo template with support
+# This docker-compose file extends the basic ccf-pdo template with support
 # to build from code _committed_ to workspace.
-# To use add a '-f sawtooth-pdo.local-code.yaml' _after_ the
-# '-f sawtooth-pdo.yaml'. This can also be combined with sawooth-pdo.sgx.yaml.
+# To use add a '-f ccf-pdo.local-code.yaml' _after_ the
+# '-f ccf-pdo.yaml'. This can also be combined with ccf-pdo.sgx.yaml.
 # To get latest code, you might want to run 'docker-compose .... build' before
 # running 'docker-compose ... up'
 

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -13,7 +13,7 @@ default values, four variables are commonly set to reflect specifics of
 the installation:
 
   * [`PDO_INSTALL_ROOT`](#pdo_install_root) -- the path to the directory where PDO is installed
-  * [`PDO_LEDGER_TYPE`](#pdo_ledger_type) -- the ledger type to be used (sawtooth or ccf)
+  * [`PDO_LEDGER_TYPE`](#pdo_ledger_type) -- the ledger type to be used (ccf)
   * [`PDO_LEDGER_URL`](#pdo_ledger_url) -- the URL for the ledger
   * [`PDO_LEDGER_KEY_ROOT`](#pdo_ledger_key_root) -- the path to a directory containing ledger keys
 
@@ -37,7 +37,7 @@ configuration file may be constructed as:
 ```bash
    export PDO_INSTALL_ROOT=${PDO_SOURCE_ROOT}/build/_dev
    export PDO_LEDGER_KEY_ROOT=${PDO_INSTALL_ROOT}/opt/pdo/etc/keys/ledger
-   export PDO_LEDGER_URL=http://127.0.0.1:8008
+   export PDO_LEDGER_URL=http://127.0.0.1:6600
 ```
 and before building it you call the configuration script as
 
@@ -50,7 +50,7 @@ list of export commands of the variables instead of directly exporting
 them to the environment.
 
 Passing parameter `--reset-keys` will unset key variables
-`PDO_ENCLAVE_CODE_SIGN_PEM`, `PDO_LEDGER_KEY_SKF`,
+`PDO_ENCLAVE_CODE_SIGN_PEM`,
 `PDO_SPID` and `PDO_SPID_API_KEY` before setting variables.
 
 <!-- -------------------------------------------------- -->
@@ -202,14 +202,14 @@ instructions to create the API key to support SGX hardware mode.
 
 <!-- -------------------------------------------------- -->
 ### `PDO_LEDGER_TYPE`
-(default: `sawtooth`):
+(default: `ccf`):
 
 `PDO_LEDGER_TYPE` is the ledger to be used with PDO.
-PDO supports sawtooth and ccf (Microsoft) based ledgers.
+PDO supports ccf (Microsoft) based ledgers.
 
 <!-- -------------------------------------------------- -->
 ### `PDO_LEDGER_URL`
-(default: `http://127.0.0.1:8008/`):
+(default: `http://127.0.0.1:6600/`):
 
 `PDO_LEDGER_URL` is the URL used to submit transactions to the
 ledger. This should be the URL for the REST API component.
@@ -223,10 +223,3 @@ stored for ledger integration; files in this directory are not
 automatically generated.
 
 <!-- -------------------------------------------------- -->
-### `PDO_LEDGER_KEY_SKF`
-(default: `${PDO_LEDGER_KEY_ROOT/pdo_validator.priv`)
-
-`PDO_LEDGER_KEY_SKF` is used to update settings in the Sawtooth
-validator. This is the key used by the Sawtooth ledger and is generally
-found in the file `.sawtooth/keys/ledger.priv` in the Sawtooth
-installation directory hiearchy.

--- a/docs/host_install.md
+++ b/docs/host_install.md
@@ -19,7 +19,7 @@ installation is described below.
 - Install SGX SSL
 - Install required build dependencies
 - Set up environment variables to configure the build
-- Build and install Sawtooth
+- Build and install CCF
 - Build the PDO package
 
 ## <a name="environment">Setup Build Environment</a>
@@ -205,10 +205,7 @@ Processors; transaction processors enable the distributed ledger to handle
 application requests. This repository contains the code required to build
 Transaction Processors that handle PDO requests.
 
-Currently, PDO supports two types of ledgers: Hyperledger Sawtooth and
-Microsoft CCF. The default ledger choice for PDO is Sawtooth. The CCF based
-ledger can be enabled by setting the environment variable
-`PDO_LEDGER_TYPE=ccf.`
+Currently, PDO supports one type of ledger: Microsoft CCF.
 
 We recommend running a ledger instance locally in the provided Docker image:
 ```
@@ -223,16 +220,6 @@ For details on how to configure PDO for a given ledger, see [environment.md](./e
 ### Build and Install Ledger Natively
 
 It is also possible to run the ledger natively on the host.
-
-Follow the
-[setup document](../sawtooth/docs/SETUP.md)
-to install both Sawtooth and the custom Sawtooth Transaction Processors.
-
-Note that the Sawtooth components do not depend on any other components
-of the PDO project, and can be set up on an entirely separate machine from
-the one running Private Data Objects. It is recommended that Sawtooth be
-run on Ubuntu 16.04 as it is the only operating system version on which
-Sawtooth is actively supported.
 
 See [HERE](../ccf_transaction_processor/Readme.md) to learn more about the
 ccf based transaction processor. Currently PDO supports CCF ledger under

--- a/docs/host_install.md
+++ b/docs/host_install.md
@@ -30,7 +30,7 @@ distributions will require similar packages.
 ```bash
 sudo apt install -y cmake curl git pkg-config unzip xxd libssl-dev build-essential
 sudo apt install -y swig python3 python3-dev python3-venv virtualenv
-sudo apt install -y liblmdb-dev libprotobuf-dev libsecp256k1-dev protobuf-compiler libncurses5-dev
+sudo apt install -y liblmdb-dev libsecp256k1-dev libncurses5-dev
 ```
 
 <!--

--- a/docs/install.md
+++ b/docs/install.md
@@ -43,10 +43,8 @@ PDO in SGX HW mode, the PDO component has to run in an SGX-enabled
 environment. Below installation and configuration instructions will make
 sure that the host and the docker components fullfill this requirement.
 
-If Sawtooth ledger is used, then both Sawtooth (and the PDO transaction
-processors for Sawtooth) should be run on Ubuntu 16.04. If Microsoft CCF
-ledger is used, both CCF and the PDO transaction processor should be run
-on Ubuntu 18.04.
+If Microsoft CCF ledger is used, both CCF and the PDO transaction processor
+should be run on Ubuntu 18.04.
 We provide Docker images to run the ledger in the supported environment.
 
 The ledger and PDO may run on other Linux distributions, but the installation
@@ -205,7 +203,7 @@ used environment variables is available [here](environment.md).
 Docker provides the easiest way to install and run PDO. It allows you to
 develop easily on a variety of systems and isolates all package
 installations from the host. Further, it simplifies end-to-end setup
-with a local Sawtooth ledger. Instructions for installation with docker are available
+with a local ledger. Instructions for installation with docker are available
 [here](docker.md).
 
 ## Host System Installation

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -7,17 +7,10 @@ https://creativecommons.org/licenses/by/4.0/
 This page provides and index to the documentation for each of the PDO
 components.
 
-# Sawtooth & Transaction Processors
+# CCF & Transaction Processors
 
-General information about how the sawtooth transaction processors work and how
-to use the pdo-cli command-line application to query the state of the Sawtooth
-blockchain can be found [here](../sawtooth/docs/USAGE.md).
-
-Information about the three different types of transaction processors used by
-Private Data Objects is here:
-- [Contract Registry](../sawtooth/docs/cregistry.md)
-- [Enclave Registry](../sawtooth/docs/eregistry.md)
-- [Coordination and Commit Log](../sawtooth/docs/ccl.md)
+General information about how the ccf transaction processors work
+can be found [here](../ccf_transaction_processor/README.md).
 
 # Common library
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -42,8 +42,8 @@ different service instances plus the `pdo-shell` client configuration.
 
 # <a name="Ledger">Run the Ledger
 
-Using PDO requires a running instance of a ledger (Hyperledger Sawtooth or
-Microsoft CCF). The easiest way to spin up an instance of the ledger for
+Using PDO requires a running instance of a ledger (Microsoft CCF).
+The easiest way to spin up an instance of the ledger for
 local testing is to use the provided Docker images.
 
 Run the following commands:

--- a/eservice/bin/register-with-ledger.sh
+++ b/eservice/bin/register-with-ledger.sh
@@ -90,15 +90,16 @@ function Register {
         VAR_BASENAME=$(grep -o 'BASENAME:.*' ${eservice_enclave_info_file} | cut -f2- -d:)
 
         : "${PDO_LEDGER_URL:?Registration failed! PDO_LEDGER_URL environment variable not set}"
-        : "${PDO_LEDGER_KEY_SKF:?Registration failed! PDO_LEDGER_KEY_SKF environment variable not set}"
         : "PDO_IAS_KEY_PEM" "${PDO_IAS_KEY_PEM:?Registration failed! PDO_IAS_KEY_PEM environment variable not set}"
 
-        try ${SRCDIR}/sawtooth/bin/pdo-cli set-setting --keyfile $PDO_LEDGER_KEY_SKF --url $PDO_LEDGER_URL \
-            pdo.test.registry.measurements ${VAR_MRENCLAVE}
-        try ${SRCDIR}/sawtooth/bin/pdo-cli set-setting --keyfile $PDO_LEDGER_KEY_SKF --url $PDO_LEDGER_URL \
-            pdo.test.registry.basenames ${VAR_BASENAME}
-        try ${SRCDIR}/sawtooth/bin/pdo-cli set-setting --keyfile $PDO_LEDGER_KEY_SKF --url $PDO_LEDGER_URL \
-            pdo.test.registry.public_key "$(cat $PDO_IAS_KEY_PEM)"
+        yell WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
+        yell ""
+        yell Skipping registration to the ledger ${PDO_LEDGER_URL} of
+        yell "MRENCLAVE=${VAR_MRENCLAVE}"
+        yell "BASENAME=${VAR_BASENAME}"
+        yell "PDO_IAS_KEY_PEM=${PDO_IAS_KEY_PEM}"
+        yell ""
+        yell WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
     fi
 }
 

--- a/eservice/bin/register-with-ledger.sh
+++ b/eservice/bin/register-with-ledger.sh
@@ -92,6 +92,7 @@ function Register {
         : "${PDO_LEDGER_URL:?Registration failed! PDO_LEDGER_URL environment variable not set}"
         : "PDO_IAS_KEY_PEM" "${PDO_IAS_KEY_PEM:?Registration failed! PDO_IAS_KEY_PEM environment variable not set}"
 
+        # FIXME: Replace when CCF TP has been updated for HW mode.
         yell WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING
         yell ""
         yell Skipping registration to the ledger ${PDO_LEDGER_URL} of

--- a/eservice/docs/test-scripts.md
+++ b/eservice/docs/test-scripts.md
@@ -13,7 +13,7 @@ second script, ``test-contract.py`` supports arbitrary contracts and
 reads the messages from a file.
 
 Both scripts can optionally include the provisioning service, enclave
-service and a Sawtooth ledger.
+service and a ledger.
 
 The flow for both scripts includes the following:
 1. create and register an enclave, if necessary
@@ -48,8 +48,8 @@ file.
 
 The following configuration variables can be specified:
 
-* ``Sawtooth``
-  * ``LedgerURL`` -- the URL to use for the Sawtooth ledger; if no value is
+* ``Ledger``
+  * ``LedgerURL`` -- the URL to use for the ledger; if no value is
   specified, then the test will not send transactions to the ledger
   * ``Organization`` -- the organization name used in the enclave
   registration transaction; unused if an eservice is specified
@@ -93,7 +93,7 @@ the configuration file
 * ``--config <string>`` -- name of the configuration file
 * ``--config-dir <string>`` -- path to the configuration file if the config file
   name is not absolute
-* ``--ledger <string>`` -- URL for the Sawtooth ledger
+* ``--ledger <string>`` -- URL for the ledger
 * ``--no-ledger`` -- flag to indicate that no ledger should be used
 * ``--data <string>`` -- path to directory used for storing data
 * ``--secret-count <integer>`` -- number of secrets to generate if no
@@ -176,17 +176,17 @@ extension.
 $ python test-request.py --no-ledger
 
 # Run the test with a ledger receiving transactions
-$ python test-request.py --ledger http://localhost:8008 --loglevel warn
+$ python test-request.py --ledger http://localhost:6600 --loglevel warn
 
 # Run the test with the integer key contract, a ledger
 # and two provisioningservices
-$ python test-contract.py --ledger http://localhost:8008 \
+$ python test-contract.py --ledger http://localhost:6600 \
     --pservice http://localhost:7101 http://localhost:7102 \
     --contract integer-key
 
 # Run the test with the mock-contract, a ledger, two provisioning
 # services, and an enclave service, 500 increment operations
-$ python test-request.py --ledger http://localhost:8008 \
+$ python test-request.py --ledger http://localhost:6600 \
     --pservice http://localhost:7101 http://localhost:7102 \
     --eservice http://localhost:7001 \
     --iterations 500

--- a/eservice/etc/sample_eservice.toml
+++ b/eservice/etc/sample_eservice.toml
@@ -57,7 +57,7 @@ LogFile  = "${logs}/${identity}.log"
 # Keys are used to sign the registration transaction
 # should it be required
 SearchPath = [ ".", "./keys", "${keys}" ]
-FileName = "${identity}_private.skf"
+FileName = "${identity}_private.pem"
 
 # --------------------------------------------------
 # EnclaveData -- configuration of sealed storage for the enclave

--- a/eservice/etc/sample_sservice.toml
+++ b/eservice/etc/sample_sservice.toml
@@ -44,4 +44,4 @@ LogFile  = "${logs}/${identity}.log"
 # Keys are used to sign the registration transaction
 # should it be required
 SearchPath = [ ".", "./keys", "${keys}" ]
-FileName = "${identity}_private.skf"
+FileName = "${identity}_private.pem"

--- a/eservice/pdo/eservice/pdo_helper.py
+++ b/eservice/pdo/eservice/pdo_helper.py
@@ -100,8 +100,7 @@ class Enclave(object) :
 
         :param file_name:  string, name of the file
         :param search_path: list of strings, directories to search for the data file
-        :param txn_keys: Used to sign the register_enclave transaction. For Sawtooth,
-                         this is of type TransactionKeys, while for CCF, this is of type ServiceKeys
+        :param txn_keys: Used to sign the register_enclave transaction. For CCF, this is of type ServiceKeys
         """
         if txn_keys is None :
             txn_keys = keys.generate_txn_keys()
@@ -142,8 +141,7 @@ class Enclave(object) :
     def create_new_enclave(cls, txn_keys = None, block_store = None) :
         """create_new_enclave -- create a new enclave
 
-        :param txn_keys: Used to sign the register_enclave transaction. For Sawtooth,
-                         this is of type TransactionKeys, while for CCF, this is of type ServiceKeys
+        :param txn_keys: Used to sign the register_enclave transaction. For CCF, this is of type ServiceKeys
         """
         if txn_keys is None :
             txn_keys = keys.generate_txn_keys()
@@ -299,7 +297,7 @@ class Enclave(object) :
     # -------------------------------------------------------
     def register_enclave(self, ledger_config) :
         """
-        register the enclave with the sawtooth ledger
+        register the enclave with the ledger
 
         :param ledger_config: dictionary of configuration information that must include LedgerURL
         """

--- a/eservice/pdo/eservice/scripts/EServiceCLI.py
+++ b/eservice/pdo/eservice/scripts/EServiceCLI.py
@@ -197,7 +197,7 @@ def LocalMain(config) :
         logger.exception('failed to initialize enclave; %s', e)
         sys.exit(-1)
 
-    # create the sawtooth transaction keys needed to register the enclave
+    # create the transaction keys needed to register the enclave
     try :
         key_config = config['Key']
         key_file = key_config['FileName']
@@ -247,7 +247,7 @@ ContractEtc = os.path.join(ContractHome, "etc")
 ContractKeys = os.path.join(ContractHome, "keys")
 ContractLogs = os.path.join(ContractHome, "logs")
 ContractData = os.path.join(ContractHome, "data")
-LedgerURL = os.environ.get("PDO_LEDGER_URL", "http://127.0.0.1:8008/")
+LedgerURL = os.environ.get("PDO_LEDGER_URL", "http://127.0.0.1:6600/")
 ScriptBase = os.path.splitext(os.path.basename(sys.argv[0]))[0]
 
 config_map = {
@@ -324,7 +324,7 @@ def Main() :
     # set up the ledger configuration
     if config.get('Ledger') is None :
         config['Ledger'] = {
-            'LedgerURL' : 'http://localhost:8008',
+            'LedgerURL' : 'http://localhost:6600',
         }
     if options.ledger :
         config['Ledger']['LedgerURL'] = options.ledger

--- a/eservice/pdo/eservice/scripts/EServiceEnclaveInfoCLI.py
+++ b/eservice/pdo/eservice/scripts/EServiceEnclaveInfoCLI.py
@@ -110,7 +110,7 @@ ContractEtc = os.path.join(ContractHome, "etc")
 ContractKeys = os.path.join(ContractHome, "keys")
 ContractLogs = os.path.join(ContractHome, "logs")
 ContractData = os.path.join(ContractHome, "data")
-LedgerURL = os.environ.get("PDO_LEDGER_URL", "http://127.0.0.1:8008/")
+LedgerURL = os.environ.get("PDO_LEDGER_URL", "http://127.0.0.1:6600/")
 ScriptBase = os.path.splitext(os.path.basename(sys.argv[0]))[0]
 
 IasKeysPath = os.environ.get("PDO_SGX_KEY_ROOT")

--- a/eservice/pdo/sservice/scripts/SServiceCLI.py
+++ b/eservice/pdo/sservice/scripts/SServiceCLI.py
@@ -210,7 +210,7 @@ ContractEtc = os.path.join(ContractHome, "etc")
 ContractKeys = os.path.join(ContractHome, "keys")
 ContractLogs = os.path.join(ContractHome, "logs")
 ContractData = os.path.join(ContractHome, "data")
-LedgerURL = os.environ.get("PDO_LEDGER_URL", "http://127.0.0.1:8008/")
+LedgerURL = os.environ.get("PDO_LEDGER_URL", "http://127.0.0.1:6600/")
 ScriptBase = os.path.splitext(os.path.basename(sys.argv[0]))[0]
 
 config_map = {

--- a/eservice/tests/test-secrets.py
+++ b/eservice/tests/test-secrets.py
@@ -64,7 +64,7 @@ ContractEtc = os.path.join(ContractHome, "etc")
 ContractKeys = os.path.join(ContractHome, "keys")
 ContractLogs = os.path.join(ContractHome, "logs")
 ContractData = os.path.join(ContractHome, "data")
-LedgerURL = os.environ.get("PDO_LEDGER_URL", "http://127.0.0.1:8008/")
+LedgerURL = os.environ.get("PDO_LEDGER_URL", "http://127.0.0.1:6600/")
 ScriptBase = os.path.splitext(os.path.basename(sys.argv[0]))[0]
 
 config_map = {

--- a/pservice/etc/sample_pservice.toml
+++ b/pservice/etc/sample_pservice.toml
@@ -21,9 +21,9 @@ HttpPort = 7800
 Host = "localhost"
 
 # --------------------------------------------------
-# Sawtooth -- sawtooth ledger configuration
+# Ledger configuration
 # --------------------------------------------------
-[Sawtooth]
+[Ledger]
 LedgerURL = "${ledger}"
 
 # --------------------------------------------------

--- a/pservice/pdo/pservice/scripts/PServiceCLI.py
+++ b/pservice/pdo/pservice/scripts/PServiceCLI.py
@@ -425,7 +425,7 @@ ContractEtc = os.path.join(ContractHome, "etc")
 ContractKeys = os.path.join(ContractHome, "keys")
 ContractLogs = os.path.join(ContractHome, "logs")
 ContractData = os.path.join(ContractHome, "data")
-LedgerURL = os.environ.get("PDO_LEDGER_URL", "http://127.0.0.1:8008/")
+LedgerURL = os.environ.get("PDO_LEDGER_URL", "http://127.0.0.1:6600/")
 ScriptBase = os.path.splitext(os.path.basename(sys.argv[0]))[0]
 
 config_map = {
@@ -503,7 +503,7 @@ def Main() :
     # set up the ledger configuration
     if config.get('Ledger') is None :
         config['Ledger'] = {
-            'LedgerURL' : 'http://localhost:8008',
+            'LedgerURL' : 'http://localhost:6600',
         }
     if options.ledger :
         config['Ledger']['LedgerURL'] = options.ledger

--- a/python/Makefile
+++ b/python/Makefile
@@ -27,8 +27,6 @@ PY_VERSION=${shell . $(abspath $(DSTDIR)/bin/activate) && python3 --version | se
 MOD_VERSION=${shell ../bin/get_version}
 
 EGG_FILE = dist/pdo_common_library-${MOD_VERSION}-py${PY_VERSION}-linux-x86_64.egg
-#PROTOBUF_DPATH = pdo/submitter/sawtooth/pdo_protos/
-#PROTOBUF_SPATH = pdo/submittersawtooth/pdo_protos/protobufs//
 PROTOBUF_SOURCE = pdo_contract_ccl.proto pdo_contract_enclave_registry.proto pdo_contract_registry.proto
 PROTOBUF_PYTHON = $(subst .proto,_pb2.py,$(PROTOBUF_SOURCE))
 PYTHON_SOURCE = $(shell cat MANIFEST)

--- a/python/Makefile
+++ b/python/Makefile
@@ -27,8 +27,6 @@ PY_VERSION=${shell . $(abspath $(DSTDIR)/bin/activate) && python3 --version | se
 MOD_VERSION=${shell ../bin/get_version}
 
 EGG_FILE = dist/pdo_common_library-${MOD_VERSION}-py${PY_VERSION}-linux-x86_64.egg
-PROTOBUF_SOURCE = pdo_contract_ccl.proto pdo_contract_enclave_registry.proto pdo_contract_registry.proto
-PROTOBUF_PYTHON = $(subst .proto,_pb2.py,$(PROTOBUF_SOURCE))
 PYTHON_SOURCE = $(shell cat MANIFEST)
 
 CRYPTO_SWIG_SOURCE = pdo/common/crypto.i
@@ -51,12 +49,6 @@ COMMON_LIB = ../common/build/libupdo-common.a
 
 all: $(EGG_FILE)
 
-#$(PROTOBUF_DPATH)%_pb2.py : $(PROTOBUF_SPATH)%.proto
-#	protoc --python_out=$(PROTOBUF_DPATH) --proto_path=$(PROTOBUF_SPATH) $<
-
-#$(addprefix $(PROTOBUF_DPATH),$(PROTOBUF_PYTHON)) : $(addprefix $(PROTOBUF_SPATH),$(PROTOBUF_SOURCE))
-
-#$(EGG_FILE) : $(CRYPTO_SWIG_TARGET) $(KV_SWIG_TARGET) $(addprefix $(PROTOBUF_DPATH),$(PROTOBUF_PYTHON)) $(PYTHON_SOURCE)
 $(EGG_FILE) : $(CRYPTO_SWIG_TARGET) $(KV_SWIG_TARGET) $(PYTHON_SOURCE)
 	@ . $(abspath $(DSTDIR)/bin/activate) && \
 		python setup.py bdist_egg
@@ -73,7 +65,6 @@ test: install
 	(cd ../common/tests/crypto && python test_cryptoWrapper.py)
 
 clean:
-	#rm -f $(addprefix $(PROTOBUF_DPATH),$(PROTOBUF_PYTHON))
 	@ . $(abspath $(DSTDIR)/bin/activate) && \
 		python setup.py clean --all
 

--- a/python/pdo/common/keys.py
+++ b/python/pdo/common/keys.py
@@ -16,6 +16,7 @@ import os
 import hashlib
 import pdo.common.crypto as crypto
 import pdo.common.utility as putils
+from pdo.common.utility import deprecated
 
 import logging
 logger = logging.getLogger(__name__)
@@ -30,12 +31,10 @@ def generate_txn_keys(ledger_type=os.environ.get('PDO_LEDGER_TYPE')):
     """ txn_keys are used to sign register_enclave transaction.
     The format is based on the ledger type"""
 
-    if ledger_type == 'sawtooth':
-        return TransactionKeys()
-    elif ledger_type == 'ccf':
+    if ledger_type == 'ccf':
         return ServiceKeys.create_service_keys()
     else:
-        raise Exception("Invalid ledger_type. Must be either 'sawtooth' or 'ccf'")
+        raise Exception("Invalid ledger_type. Must be either 'ccf'")
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
@@ -43,12 +42,10 @@ def read_transaction_keys_from_file(key_file, search_path, \
     ledger_type = os.environ.get('PDO_LEDGER_TYPE')):
     """ use the correct read handler based on ledger type to read txn keys"""
 
-    if ledger_type == 'sawtooth':
-        txn_keys = TransactionKeys.read_from_file(key_file, search_path)
-    elif ledger_type == 'ccf':
+    if ledger_type == 'ccf':
         txn_keys = ServiceKeys.read_from_file(key_file, search_path)
     else:
-        raise Exception("Invalid Ledger Type. Must be either 'sawtooth' or 'ccf'")
+        raise Exception("Invalid Ledger Type. Must be 'ccf'")
 
     return txn_keys
 
@@ -60,6 +57,7 @@ class TransactionKeys(object) :
     """
 
     @classmethod
+    @deprecated
     def read_from_file(cls, file_name, search_path = ['.', './keys']) :
         full_file = putils.find_file_in_path(file_name, search_path)
         with open(full_file, "r") as ff :
@@ -69,10 +67,12 @@ class TransactionKeys(object) :
         return cls(secp256k1.PrivateKey(priv))
 
     @classmethod
+    @deprecated
     def from_hex(cls, hex_encoded_private_key) :
         priv = binascii.unhexlify(hex_encoded_private_key)
         return cls(secp256k1.PrivateKey(priv))
 
+    @deprecated
     def __init__(self, private_key = None) :
         if private_key == None :
             private_key = secp256k1.PrivateKey()
@@ -81,6 +81,7 @@ class TransactionKeys(object) :
         self.private_key = private_key
 
     @property
+    @deprecated
     def hashed_identity(self) :
         key_byte_array = crypto.string_to_byte_array(self.txn_public)
         hashed_txn_key = crypto.compute_message_hash(key_byte_array)
@@ -89,10 +90,12 @@ class TransactionKeys(object) :
         return encoded_hashed_key
 
     @property
+    @deprecated
     def txn_private(self) :
         return self.private_key.serialize()
 
     @property
+    @deprecated
     def txn_public(self) :
         return self.public_key.serialize().hex()
 

--- a/python/pdo/contract/message.py
+++ b/python/pdo/contract/message.py
@@ -27,7 +27,7 @@ class ContractMessage(object) :
     def __init__(self, request_originator_keys, channel_id, **kwargs) :
         """
         :param request_originator_keys: object of type ServiceKeys
-        :param channel_keys: object of type TransactionKeys
+        :param channel_id: nonce
         """
         self.__request_originator_keys = request_originator_keys
         self.channel_id = channel_id

--- a/python/pdo/contract/request.py
+++ b/python/pdo/contract/request.py
@@ -74,17 +74,14 @@ class ContractRequest(object) :
 
     # -------------------------------------------------------
     def make_channel_keys(self, ledger_type=os.environ.get('PDO_LEDGER_TYPE')):
-        if ledger_type=='sawtooth':
-            self.channel_keys =  keys.TransactionKeys()
-            self.channel_id = self.channel_keys.txn_public
-        elif ledger_type=='ccf':
+        if ledger_type=='ccf':
             ## the channel keys for CCF are really just a uniquifier since we don't
             ## need to hide the submitters ID (since CCF runs inside SGX)
             seed = crypto.random_bit_string(32)
             self.channel_id = crypto.byte_array_to_base64(seed)
             self.channel_keys = crypto.string_to_byte_array(self.channel_id)
         else:
-            raise Exception("Invalid Ledger Type. Must be either sawtooth or ccf.")
+            raise Exception("Invalid Ledger Type. Must be ccf.")
 
     # -------------------------------------------------------
     @property

--- a/python/pdo/contract/transaction.py
+++ b/python/pdo/contract/transaction.py
@@ -301,7 +301,7 @@ class TransactionRequest(object):
 
         self.ledger_config = ledger_config
         # add the wait parameter to the ledger config, if there is one.
-        # Used only with Sawtooth. Defaults to 30s in Sawtooth submitter
+        # Question: does CCF (or the submitter) use this parameter?
         if wait_parameter_for_ledger:
             self.ledger_config['wait'] = wait_parameter_for_ledger
         self.commit_id = commit_id

--- a/python/pdo/service_client/provisioning.py
+++ b/python/pdo/service_client/provisioning.py
@@ -34,7 +34,7 @@ class ProvisioningServiceClient(GenericServiceClient) :
 
     # -----------------------------------------------------------------
     # enclave_id -- string containing PEM-encoded enclave public key
-    # contract_id -- 256-character hex-encoded string containing sawtooth transaction ID for contract registration
+    # contract_id -- 256-character hex-encoded string containing the transaction ID for contract registration
     # creator_id -- string containing PEM-encoded contract owner's public key - used to verify signature
     # signature -- hex-encoded string signature of (enclave_id + contract_id) signed with owner's private key
     # -----------------------------------------------------------------

--- a/python/pdo/submitter/__init__.py
+++ b/python/pdo/submitter/__init__.py
@@ -13,6 +13,5 @@
 # limitations under the License.
 
 __all__ = [ "ccf",
-        "sawtooth",
         "submitter",
         "create"]

--- a/python/pdo/submitter/ccf/docs/ccf_payload_schema.json
+++ b/python/pdo/submitter/ccf/docs/ccf_payload_schema.json
@@ -182,7 +182,7 @@
                 },
                 "nonce":{
                     "description":[
-                        "Equivalent of channel id used for Sawtooth CCL transactions. Hash of nonce get signed by enclave"
+                        "Hash of nonce get signed by enclave"
                     ],
                     "type":"string",
                     "required":true,

--- a/python/pdo/submitter/create.py
+++ b/python/pdo/submitter/create.py
@@ -24,12 +24,10 @@ logger = logging.getLogger(__name__)
 def create_submitter(ledger_config, *args, **kwargs) :
     ledger_type = ledger_config.get('LedgerType', os.environ.get('PDO_LEDGER_TYPE'))
 
-    if ledger_type == 'sawtooth':
-        import pdo.submitter.sawtooth.sawtooth_submitter as sw_sub
-        return sw_sub.SawtoothSubmitter(ledger_config, *args, **kwargs)
-    elif ledger_type == 'ccf':
+    if ledger_type == 'ccf':
         import pdo.submitter.ccf.ccf_submitter as ccf_sub
         return ccf_sub.CCFSubmitter(ledger_config, *args, **kwargs)
     else:
-        logger.error("Invalid Ledger Type. Must be either 'sawtooth' or 'ccf'")
-        raise Exception("Invalid Ledger Type. Must be either 'sawtooth' or 'ccf'")
+        err_msg="Invalid Ledger Type. Must be 'ccf'"
+        logger.error(err_msg)
+        raise Exception(err_msg)

--- a/python/pdo/submitter/submitter.py
+++ b/python/pdo/submitter/submitter.py
@@ -24,12 +24,12 @@ class Submitter(object):
 
     def __init__(self, ledger_config, *args, **kwargs):
 
-        self.url = ledger_config.get('LedgerURL','http://localhost:8008')
+        self.url = ledger_config.get('LedgerURL','http://localhost:6600')
         self.pdo_signer = kwargs.get('pdo_signer', None) #PDO payload signer
 
 # -----------------------------------------------------------------
 # Following APIs are provided by the ledger submitter. These must be overridden by child class
-# (SawtoothSubmitter or CCFSubmitter). The purpose of having these as abstractmethods
+# (CCFSubmitter). The purpose of having these as abstract methods
 # is to fix the APIs. Future plans include unifying some aspects of implementation under
 # the parent method (like unifying JSON payload schema)
 

--- a/python/pdo/test/contract.py
+++ b/python/pdo/test/contract.py
@@ -517,7 +517,7 @@ ContractKeys = os.path.join(ContractHome, "keys")
 ContractLogs = os.path.join(ContractHome, "logs")
 ContractData = os.path.join(ContractHome, "data")
 ContractInterpreter = os.environ.get("PDO_INTERPRETER", "gipsy")
-LedgerURL = os.environ.get("PDO_LEDGER_URL", "http://127.0.0.1:8008/")
+LedgerURL = os.environ.get("PDO_LEDGER_URL", "http://127.0.0.1:6600/")
 ScriptBase = os.path.splitext(os.path.basename(sys.argv[0]))[0]
 
 config_map = {
@@ -554,7 +554,7 @@ def Main() :
     parser.add_argument('--logfile', help='Name of the log file, __screen__ for standard output', type=str)
     parser.add_argument('--loglevel', help='Logging level', type=str)
 
-    parser.add_argument('--ledger', help='URL for the Sawtooth ledger', type=str)
+    parser.add_argument('--ledger', help='URL for the ledger', type=str)
     parser.add_argument('--no-ledger', help='Do not attempt ledger registration', action="store_true")
 
     parser.add_argument('--data-dir', help='Directory for storing generated files', type=str)
@@ -620,7 +620,7 @@ def Main() :
     # set up the ledger configuration
     if config.get('Ledger') is None :
         config['Ledger'] = {
-            'LedgerURL' : 'http://localhost:8008',
+            'LedgerURL' : 'http://localhost:6600',
         }
     if options.ledger :
         config['Ledger']['LedgerURL'] = options.ledger

--- a/python/pdo/test/request.py
+++ b/python/pdo/test/request.py
@@ -438,7 +438,7 @@ ContractKeys = os.path.join(ContractHome, "keys")
 ContractLogs = os.path.join(ContractHome, "logs")
 ContractData = os.path.join(ContractHome, "data")
 ContractInterpreter = os.environ.get("PDO_INTERPRETER", "gipsy")
-LedgerURL = os.environ.get("PDO_LEDGER_URL", "http://127.0.0.1:8008/")
+LedgerURL = os.environ.get("PDO_LEDGER_URL", "http://127.0.0.1:6600/")
 ScriptBase = os.path.splitext(os.path.basename(sys.argv[0]))[0]
 
 config_map = {
@@ -475,7 +475,7 @@ def Main() :
     parser.add_argument('--logfile', help='Name of the log file, __screen__ for standard output', type=str)
     parser.add_argument('--loglevel', help='Logging level', type=str)
 
-    parser.add_argument('--ledger', help='URL for the Sawtooth ledger', type=str)
+    parser.add_argument('--ledger', help='URL for the ledger', type=str)
     parser.add_argument('--no-ledger', help='Do not attempt ledger registration', action="store_true")
 
     parser.add_argument('--data-dir', help='Directory for storing generated files', type=str)
@@ -540,7 +540,7 @@ def Main() :
     # set up the ledger configuration
     if config.get('Ledger') is None :
         config['Ledger'] = {
-            'LedgerURL' : 'http://localhost:8008',
+            'LedgerURL' : 'http://localhost:6600',
         }
     if options.ledger :
         config['Ledger']['LedgerURL'] = options.ledger


### PR DESCRIPTION
This PR completes the removal of Sawtooth and depends on #379 for testing (at least the eservice) in HW mode.

This PR removes the following Sawtooth-related things:
- references in docs and toml files
- build flags and procedures
- scripts for SKF files
- configuration flags and procedures in services

Also, it updates:
- the default ledger port 8008 -> 6600
- the default ledger type sawtooth -> ccf
- the registration with the ledger -- which is now empty since CCF is not set up for checking proof-data in HW mode
- the default service keys *.skf -> *.pem
- the TransactionKeys class by deprecating the methods