### PR TITLE
Enable DCAP quote generation

### DIFF
--- a/build/__tools__/expand-config
+++ b/build/__tools__/expand-config
@@ -78,6 +78,7 @@ try :
     LedgerType = os.environ["PDO_LEDGER_TYPE"]
     SPID = os.environ["PDO_SPID"]
     SPID_API_KEY = os.environ["PDO_SPID_API_KEY"]
+    PDO_ATTESTATION_TYPE = os.environ["PDO_ATTESTATION_TYPE"]
 except KeyError as ke :
     print("incomplete configuration, missing definition of {0}".format(str(ke)))
     sys.exit(-1)
@@ -112,7 +113,8 @@ config_map = {
     'eservice_key_format': EserviceKeyFormat,
     'proxy' : HttpsProxy,
     'spid' : SPID,
-    'spid_api_key' : SPID_API_KEY
+    'spid_api_key' : SPID_API_KEY,
+    'attestation_type' : PDO_ATTESTATION_TYPE
 }
 
 # -----------------------------------------------------------------

--- a/build/__tools__/verify-pre-conf.sh
+++ b/build/__tools__/verify-pre-conf.sh
@@ -47,6 +47,17 @@ if [ "${SGX_MODE}" = "HW" ]; then
     if [[ ! "${PDO_SPID_API_KEY}" =~ ^[A-Fa-f0-9]{32}$ ]]; then
 	warn "PDO_SPID_API_KEY is not defined correctly, should be a a 32-byte hex key"
     fi
+
+    if [[ ! "${PDO_ATTESTATION_TYPE}" = "epid-linkable" ]] && [[ ! "${PDO_ATTESTATION_TYPE}" = "dcap" ]]; then
+        die "PDO_ATTESTATION_TYPE=${PDO_ATTESTATION_TYPE} not defined epid-linkable or dcap in HW mode"
+    fi
 fi
+
+if [ "${SGX_MODE}" = "SIM" ]; then
+    if [[ ! "${PDO_ATTESTATION_TYPE}" = "simulated" ]]; then
+        die "PDO_ATTESTATION_TYPE=${PDO_ATTESTATION_TYPE} not defined simulated in SIM mode"
+    fi
+fi
+
 
 exit $F_VERIFIED

--- a/build/common-config.sh
+++ b/build/common-config.sh
@@ -68,6 +68,12 @@ var_set() {
 	"
 	env_key_sort[$i]="SGX_MODE"; i=$i+1; export SGX_MODE=${env_val[SGX_MODE]}
 
+    env_val[PCCS_URL]="${PCCS_URL:-https://$(hostname -A | cut -d" " -f1):8081/sgx/certification/v3/}"
+    env_desc[PCCS_URL]="
+        PCCS_URL is the URL of the SGX PCCS service necessary for dcap-based attestations.
+    "
+    env_key_sort[$i]="PCCS_URL"; i=$i+1; export PCCS_URL=${env_val[PCCS_URL]}
+
 	env_val[PDO_LEDGER_URL]="${PDO_LEDGER_URL:-http://127.0.0.1:6600}"
 	env_desc[PDO_LEDGER_URL]="
 		PDO_LEDGER_URL is the URL is to submit transactions to the ledger.
@@ -131,6 +137,13 @@ var_set() {
                 The default path points to a key which is generated during built on-demand.
 	"
 	env_key_sort[$i]="PDO_ENCLAVE_CODE_SIGN_PEM"; i=$i+1; export PDO_ENCLAVE_CODE_SIGN_PEM=${env_val[PDO_ENCLAVE_CODE_SIGN_PEM]}
+
+    env_val[PDO_ATTESTATION_TYPE]="${PDO_ATTESTATION_TYPE:-$(cat ${PDO_SGX_KEY_ROOT}/sgx_attestation_type.txt)}"
+    env_desc[PDO_ATTESTATION_TYPE]="
+        PDO_ATTESTATION_TYPE indicates the type of attestation that will be used.
+        simulated in SIM mode; epid-linkable or dcap in HW mode.
+    "
+    env_key_sort[$i]="PDO_ATTESTATION_TYPE"; i=$i+1; export PDO_ATTESTATION_TYPE=${env_val[PDO_ATTESTATION_TYPE]}
 
 	env_val[PDO_SPID]="${PDO_SPID:-$(cat ${PDO_SGX_KEY_ROOT}/sgx_spid.txt)}"
 	env_desc[PDO_SPID]="
@@ -231,6 +244,7 @@ do
 	    unset PDO_ENCLAVE_CODE_SIGN_PEM
 	    unset PDO_SPID
 	    unset PDO_SPID_API_KEY
+	    unset PDO_ATTESTATION_TYPE
             ;;
         --evalable-export|-e)
 	    is_sourced=0

--- a/build/keys/sgx_mode_hw/.gitignore
+++ b/build/keys/sgx_mode_hw/.gitignore
@@ -1,3 +1,4 @@
 ias_root_ca.cert
 ias_signing.cert
 sgx_ias_key.pem
+sgx_attestation_type.txt

--- a/build/keys/sgx_mode_sim/sgx_attestation_type.txt
+++ b/build/keys/sgx_mode_sim/sgx_attestation_type.txt
@@ -1,0 +1,1 @@
+simulated

--- a/build/opt/pdo/etc/template/enclave.toml
+++ b/build/opt/pdo/etc/template/enclave.toml
@@ -33,3 +33,6 @@ https_proxy = '${proxy}'
 
 # spid_api_key is a 32-digit hex string tied to the SPID
 spid_api_key = '${spid_api_key}'
+
+# attestation type is a string: 'simulated', epid-linkable, or 'dcap'
+attestation_type = '${attestation_type}'

--- a/docker/Dockerfile.pdo-build
+++ b/docker/Dockerfile.pdo-build
@@ -51,7 +51,7 @@
 #     you will have to
 #     - PDO_SGX_KEY_ROOT env var pointing to the directory with the actual files and/or
 #       PDO_LEDGER_URL properly configured ..
-#     - unset PDO_SPID PDO_SPID_API_KEY
+#     - unset PDO_SPID PDO_SPID_API_KEY PDO_ATTESTATION_TYPE
 #     - call 'source /project/pdo/src/private-data-objects/build/common-config.sh'
 #     - run 'make -C /project/pdo/src/private-data-objects/build conf'
 #   - if you want to debug with gdb and alike, you also might want to add options

--- a/docker/Dockerfile.pdo-dev
+++ b/docker/Dockerfile.pdo-dev
@@ -67,6 +67,9 @@ ARG SGX=2.15.1
 ARG OPENSSL=1.1.1g
 ARG SGXSSL=2.10_1.1.1g
 
+ARG PCCS_URL=https://localhost:8081/sgx/certification/v3/
+ENV PCCS_URL=${PCCS_URL}
+
 ARG ADD_APT_PKGS=
 
 # Add necessary packages
@@ -153,6 +156,17 @@ RUN echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu ${U
       #   correspondingly, also libsgx_uae_service.so and <sgx_uae_service.h>
       #   is split into corresponding smaller libraries and header-files to make
       #   integration with DCAP easier and minimize pulling in unnecessary dependencies
+
+# Install SGX DCAP packages
+RUN apt-get install -y \
+    libsgx-dcap-ql \
+    libsgx-dcap-ql-dev \
+    libsgx-dcap-default-qpl
+
+# Disable certificate check for PCCS
+RUN sed -i 's/"use_secure_cert": true/"use_secure_cert": false/' /etc/sgx_default_qcnl.conf
+# set the PCCS URL provided as input
+RUN sed -i 's#"pccs_url": ".*"#"pccs_url": "'${PCCS_URL}'"#' /etc/sgx_default_qcnl.conf
 
 # Install SGX SDK
 RUN mkdir -p /opt/intel

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -25,10 +25,25 @@ DOCKER_COMPOSE_FILES_CCF += ccf-pdo.yaml ccf-pdo.local-code.yaml
 DOCKER_COMPOSE_FILES_CCF_ONLY += ccf.yaml ccf.local-code.yaml
 
 ifeq ($(SGX_MODE),HW)
-   DOCKER_COMPOSE_FILES_CCF += pdo.sgx.yaml
-   SGX_DEVICE_PATH=$(shell if [ -e "/dev/isgx" ]; then echo "/dev/isgx"; elif [ -e "/dev/sgx/enclave" ]; then echo "/dev/sgx/enclave"; else echo "ERROR: NO SGX DEVICE FOUND"; fi)
-   DOCKER_COMPOSE_COMMAND := env SGX_DEVICE_PATH=${SGX_DEVICE_PATH} ${DOCKER_COMPOSE_COMMAND}
+	DOCKER_COMPOSE_FILES_CCF += pdo.sgx.yaml
+
+	SGX_ATTESTATION_TYPE=$(shell if [ -e "./sgx/sgx_attestation_type.txt" ]; then cat "./sgx/sgx_attestation_type.txt"; fi)
+
+ifeq ($(SGX_ATTESTATION_TYPE),epid-linkable)
+	SGX_DEVICE_PATH=$(shell if [ -e "/dev/isgx" ]; then echo "/dev/isgx"; elif [ -e "/dev/sgx/enclave" ]; then echo "/dev/sgx/enclave"; else echo "ERROR: NO SGX DEVICE FOUND"; fi)
 endif
+
+ifeq ($(SGX_ATTESTATION_TYPE),dcap)
+	SGX_DEVICE_PATH=$(shell if [ -e "/dev/sgx_enclave" ]; then echo "/dev/sgx_enclave"; else echo "ERROR: NO SGX DEVICE FOUND"; fi)
+	SGX_PROVISION_DEVICE_PATH=$(shell if [ -e "/dev/sgx_provision" ]; then echo "/dev/sgx_provision"; else echo "ERROR: NO SGX PROV DEVICE FOUND"; fi)
+	# set pccs url: grab from env, or assume it's in the local host listening on 8081
+	PCCS_URL:=$(if $(PCCS_URL),$(PCCS_URL),https://$(shell hostname -A | cut -d" " -f1):8081/sgx/certification/v3/)
+	DOCKER_BUILD_OPTS := ${DOCKER_BUILD_OPTS} --build-arg PCCS_URL=${PCCS_URL}
+endif
+
+	DOCKER_COMPOSE_COMMAND := env SGX_DEVICE_PATH=${SGX_DEVICE_PATH} env SGX_PROVISION_DEVICE_PATH=${SGX_PROVISION_DEVICE_PATH} ${DOCKER_COMPOSE_COMMAND}
+endif
+
 ifdef http_proxy
    DO_PROXY = 1
 endif
@@ -99,7 +114,7 @@ test-env-setup-with-no-build-ccf:
 	# - configure
 	if [ "$(SGX_MODE)" = "HW" ]; then \
        $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF) \
-		   exec -T pdo-build bash -c 'source /etc/bash.bashrc && export PDO_SGX_KEY_ROOT=/project/pdo/build/opt/pdo/etc/keys/sgx/ && unset PDO_SPID PDO_SPID_API_KEY PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && make -C /project/pdo/src/private-data-objects/build force-conf register'; \
+		   exec -T pdo-build bash -c 'source /etc/bash.bashrc && export PDO_SGX_KEY_ROOT=/project/pdo/build/opt/pdo/etc/keys/sgx/ && unset PDO_SPID PDO_SPID_API_KEY PDO_HOSTNAME PDO_ATTESTATION_TYPE && source /project/pdo/src/private-data-objects/build/common-config.sh && make -C /project/pdo/src/private-data-objects/build force-conf register'; \
     fi
 
 test-with-no-build-ccf: test-env-setup-with-no-build-ccf

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -25,7 +25,7 @@ DOCKER_COMPOSE_FILES_CCF += ccf-pdo.yaml ccf-pdo.local-code.yaml
 DOCKER_COMPOSE_FILES_CCF_ONLY += ccf.yaml ccf.local-code.yaml
 
 ifeq ($(SGX_MODE),HW)
-   DOCKER_COMPOSE_FILES_CCF += ccf-pdo.sgx.yaml
+   DOCKER_COMPOSE_FILES_CCF += pdo.sgx.yaml
    SGX_DEVICE_PATH=$(shell if [ -e "/dev/isgx" ]; then echo "/dev/isgx"; elif [ -e "/dev/sgx/enclave" ]; then echo "/dev/sgx/enclave"; else echo "ERROR: NO SGX DEVICE FOUND"; fi)
    DOCKER_COMPOSE_COMMAND := env SGX_DEVICE_PATH=${SGX_DEVICE_PATH} ${DOCKER_COMPOSE_COMMAND}
 endif
@@ -96,6 +96,7 @@ test-env-setup-with-no-build-ccf:
 	-$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF) down
 	# - start services
 	$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF) up -d
+	# - configure
 	if [ "$(SGX_MODE)" = "HW" ]; then \
        $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF) \
 		   exec -T pdo-build bash -c 'source /etc/bash.bashrc && export PDO_SGX_KEY_ROOT=/project/pdo/build/opt/pdo/etc/keys/sgx/ && unset PDO_SPID PDO_SPID_API_KEY PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && make -C /project/pdo/src/private-data-objects/build force-conf register'; \

--- a/docker/pdo.sgx.yaml
+++ b/docker/pdo.sgx.yaml
@@ -22,13 +22,14 @@
 # - sgx_spid.txt
 # - sgx_spid_api_key.txt
 # - sgx_ias_key.pem
+# - sgx_attestation_type.txt
 # See 'build/common-config -h' for information on the content of these files
 #
 # in the pdo-build shell (see ccf-pdo.yaml), before doing any operation
 # you also will have to register sgx-related information in the ledger with
 # following steps
 #    export PDO_SGX_KEY_ROOT=/project/pdo/build/opt/pdo/etc/keys/sgx/
-#    unset PDO_SPID PDO_SPID_API_KEY
+#    unset PDO_SPID PDO_SPID_API_KEY PDO_ATTESTATION_TYPE
 #    source /project/pdo/src/private-data-objects/build/common-config.sh
 #    make -C /project/pdo/src/private-data-objects/build conf register
 
@@ -48,4 +49,5 @@ services:
       - /var/run/aesmd:/var/run/aesmd
     devices:
       - ${SGX_DEVICE_PATH:-/dev/isgx}:${SGX_DEVICE_PATH:-/dev/isgx}
+      - ${SGX_PROVISION_DEVICE_PATH:-/dev/null}:${SGX_PROVISION_DEVICE_PATH:-/tmp/no_prov_device}
 

--- a/docker/pdo.sgx.yaml
+++ b/docker/pdo.sgx.yaml
@@ -1,0 +1,51 @@
+# Copyright 2017 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+
+# This docker-compose file extends the basic ccf-pdo template with support
+# for SGX in hardware mode. To use add a '-f pdo.sgx.yaml' _after_ the
+# '-f ccf-pdo.yaml'. This can also be combined with ccf-pdo.local-code.yaml.
+
+# Before you can run the containers in hardware mode, you will have to prepare following
+# files in the sgx subdirectory
+# - sgx_spid.txt
+# - sgx_spid_api_key.txt
+# - sgx_ias_key.pem
+# See 'build/common-config -h' for information on the content of these files
+#
+# in the pdo-build shell (see ccf-pdo.yaml), before doing any operation
+# you also will have to register sgx-related information in the ledger with
+# following steps
+#    export PDO_SGX_KEY_ROOT=/project/pdo/build/opt/pdo/etc/keys/sgx/
+#    unset PDO_SPID PDO_SPID_API_KEY
+#    source /project/pdo/src/private-data-objects/build/common-config.sh
+#    make -C /project/pdo/src/private-data-objects/build conf register
+
+version: "2.1"
+
+services:
+
+  # PDO EHS, PS and client ...
+  pdo-build:
+    image: pdo-sgx-build
+    container_name: pdo-sgx-build
+    build:
+      args:
+        SGX_MODE: HW
+    volumes:
+      - ${PDO_SGX_KEY_ROOT:-./sgx/}:/project/pdo/build/opt/pdo/etc/keys/sgx/
+      - /var/run/aesmd:/var/run/aesmd
+    devices:
+      - ${SGX_DEVICE_PATH:-/dev/isgx}:${SGX_DEVICE_PATH:-/dev/isgx}
+

--- a/docker/sgx/.gitignore
+++ b/docker/sgx/.gitignore
@@ -1,3 +1,4 @@
 enclave_code_sign.pem
 sgx_ias_key.pem
 sgx_spid.txt
+sgx_attestation_type.txt

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -51,7 +51,7 @@ them to the environment.
 
 Passing parameter `--reset-keys` will unset key variables
 `PDO_ENCLAVE_CODE_SIGN_PEM`,
-`PDO_SPID` and `PDO_SPID_API_KEY` before setting variables.
+`PDO_SPID`, `PDO_SPID_API_KEY`, `PDO_ATTESTATION_TYPE` before setting variables.
 
 <!-- -------------------------------------------------- -->
 <!-- -------------------------------------------------- -->
@@ -152,6 +152,13 @@ you should provide your own version, at least for `PDO_SPID` and
 [BUILD document](install.md) for more information.
 
 <!-- -------------------------------------------------- -->
+
+### `PCCS_URL`
+(default: `https://$(hostname -A | cut -d" " -f1):8081/sgx/certification/v3/`)
+
+`PCCS_URL` is the url of the SGX PCCS service which is necessary for DCAP attestations.
+For other types of attestations, this value is ignored.
+
 ### `PDO_ENCLAVE_CODE_SIGN_PEM`
 (default: `${PDO_SGX_KEY_ROOT}/enclave_code_sign.pem`):
 
@@ -195,6 +202,14 @@ If the variable is unset, the configuration script
 The default value will work for SGX simulation mode. See
 [SGX section](install.md#SGX) of the [BUILD document](install.md) for
 instructions to create the API key to support SGX hardware mode.
+
+### `PDO_ATTESTATION_TYPE`
+(default `simulated`)
+
+`PDO_ATTESTATION_TYPE` contains the type of attestation used by the eservice
+for the contract enclave.
+The default value is `simulated`, in SGX SIM mode.
+In SGX HW mode, the available types are `epid-linkable` and `dcap`.
 
 <!-- -------------------------------------------------- -->
 <!-- -------------------------------------------------- -->

--- a/docs/install.md
+++ b/docs/install.md
@@ -127,6 +127,7 @@ or you can define yours with `export PDO_SGX_KEY_ROOT=<your folder>`):
 * save your API key in `${PDO_SGX_KEY_ROOT}/sgx_spid_api_key.txt`
 * save the IAS root CA certificate in `${PDO_SGX_KEY_ROOT}/sgx_ias_key.pem`
   (`wget https://certificates.trustedservices.intel.com/Intel_SGX_Attestation_RootCA.pem -O ${PDO_SGX_KEY_ROOT}/sgx_ias_key.pem`)
+* save the attestation type `epid-linkable` or `dcap` in `${PDO_SGX_KEY_ROOT}/sgx_attestation_type.txt`
 
 #### Install the SGX Kernel Driver (Hardware Support)
 

--- a/eservice/docs/test-scripts.md
+++ b/eservice/docs/test-scripts.md
@@ -70,6 +70,7 @@ The following configuration variables can be specified:
   * ``ias_url`` --  URL of the Intel Attestation Service (IAS) server (ignored)
   * ``https_proxy`` -- proxy used to contact IAS server (ignored)
   * ``spid_api_key`` -- the api key corresponding to spid (ignored)
+  * ``attestation_type`` -- the type of attestation that the eservice will use (ignored)
 
 * ``contract`` -- the base name of the contract to use, this is
   expected to reference a file found in ``SchemeSearchPath``

--- a/eservice/etc/sample_eservice.toml
+++ b/eservice/etc/sample_eservice.toml
@@ -94,3 +94,6 @@ https_proxy = ''
 
 # spid_api_key is a 32-digit hex string tied to the SPID
 spid_api_key = 'DEADBEEF00000000DEADBEEF00000000'
+
+# attestation type is a string: 'simulated', epid-linkable, or 'dcap'
+attestation_type = 'simulated'

--- a/eservice/pdo/eservice/enclave/enclave/base.cpp
+++ b/eservice/pdo/eservice/enclave/enclave/base.cpp
@@ -75,6 +75,7 @@ std::string pdo::enclave_api::base::GetLastError(void)
 pdo_err_t pdo::enclave_api::base::Initialize(
     const std::string& inPathToEnclave,
     const HexEncodedString& inSpid,
+    const std::string& inAttestationType,
     const int numOfEnclaves
     )
 {
@@ -96,6 +97,7 @@ pdo_err_t pdo::enclave_api::base::Initialize(
             for (pdo::enclave_api::Enclave& enc : g_Enclave)
             {
                 enc.SetSpid(inSpid);
+                enc.SetAttestationType(inAttestationType);
                 enc.Load(inPathToEnclave);
                 enc.StartWorker();
             }

--- a/eservice/pdo/eservice/enclave/enclave/base.h
+++ b/eservice/pdo/eservice/enclave/enclave/base.h
@@ -64,6 +64,7 @@ namespace pdo
             pdo_err_t Initialize(
                 const std::string& inPathToEnclave,
                 const HexEncodedString& inSpid,
+                const std::string& inAttestationType,
                 const int numOfEnclaves
                 );
 

--- a/eservice/pdo/eservice/enclave/enclave/enclave.h
+++ b/eservice/pdo/eservice/enclave/enclave/enclave.h
@@ -52,10 +52,7 @@ namespace pdo {
 
             void ShutdownWorker();
 
-            size_t GetQuoteSize() const
-            {
-                return this->quoteSize;
-            } // GetQuoteSize
+            size_t GetQuoteSize() const;
 
             size_t GetSealedSignupDataSize() const
             {
@@ -66,6 +63,10 @@ namespace pdo {
                 sgx_epid_group_id_t* outEpidGroup
                 );
 
+            void GetTargetInfo(
+                sgx_target_info_t* reportTargetInfo
+                );
+
             void GetEnclaveCharacteristics(
                 sgx_measurement_t* outEnclaveMeasurement,
                 sgx_basename_t* outEnclaveBasename
@@ -73,6 +74,10 @@ namespace pdo {
 
             void SetSpid(
                 const HexEncodedString& inSpid
+                );
+
+            void SetAttestationType(
+                const std::string& inAttestationType
                 );
 
             void SetSignatureRevocationList(
@@ -105,6 +110,17 @@ namespace pdo {
             }
 
         protected:
+            void CreateDCAPQuoteFromReport(
+                const sgx_report_t* inEnclaveReport,
+                ByteArray& outEnclaveQuote
+                );
+            void CreateEPIDQuoteFromReport(
+                const sgx_report_t* inEnclaveReport,
+                ByteArray& outEnclaveQuote
+                );
+
+            const uint8_t* GetSignatureRevocationList(uint32_t* pRevocationListSize) const;
+
             void LoadEnclave();
             static void QuerySgxStatus();
 
@@ -112,11 +128,12 @@ namespace pdo {
             sgx_enclave_id_t enclaveId;
             long threadId;
 
-            size_t quoteSize;
             size_t sealedSignupDataSize;
 
             std::string signatureRevocationList;
             sgx_spid_t spid;
+
+            std::string attestationType;
 
             sgx_target_info_t reportTargetInfo;
             sgx_epid_group_id_t epidGroupId;

--- a/eservice/pdo/eservice/enclave/enclave_info.cpp
+++ b/eservice/pdo/eservice/enclave/enclave_info.cpp
@@ -35,6 +35,7 @@ bool is_sgx_simulator()
 pdo_enclave_info::pdo_enclave_info(
     const std::string& enclaveModulePath,
     const std::string& spid,
+    const std::string& attestation_type,
     const int num_of_enclaves
     )
 {
@@ -44,6 +45,7 @@ pdo_enclave_info::pdo_enclave_info(
 
     pdo_err_t ret = pdo::enclave_api::base::Initialize(enclaveModulePath,
                                                        spid,
+                                                       attestation_type,
                                                        num_of_enclaves);
     ThrowPDOError(ret);
     SAFE_LOG1(PDO_LOG_INFO, "SGX PDO enclave initialized.");

--- a/eservice/pdo/eservice/enclave/enclave_info.h
+++ b/eservice/pdo/eservice/enclave/enclave_info.h
@@ -26,6 +26,7 @@ public:
     pdo_enclave_info(
         const std::string& enclaveModulePath,
         const std::string& spid,
+        const std::string& attestation_type,
         const int num_of_enclaves
         );
     virtual ~pdo_enclave_info();

--- a/eservice/pdo/eservice/pdo_helper.py
+++ b/eservice/pdo/eservice/pdo_helper.py
@@ -80,10 +80,10 @@ def shutdown_enclave() :
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
-def get_enclave_service_info(spid, config=None) :
+def get_enclave_service_info(spid, attestation_type, config=None) :
     """get_enclave_service_info -- Retrieve enclave MRENCLAVE & BASENAME
     """
-    return pdo_enclave.get_enclave_service_info(spid, config=config)
+    return pdo_enclave.get_enclave_service_info(spid, attestation_type, config=config)
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------

--- a/eservice/pdo/eservice/pdo_helper.py
+++ b/eservice/pdo/eservice/pdo_helper.py
@@ -306,10 +306,16 @@ class Enclave(object) :
 
             submitter = create_submitter(ledger_config, pdo_signer = self.txn_keys)
 
+            if self.proof_data != "" and ledger_config.get('LedgerType', "none") == "ccf":
+                logger.warning("Zeroing proof_data field since PDO-TP in CCF does not currently support SGX HW mode")
+                proof_data = ""
+            else:
+                proof_data = self.proof_data
+
             txnsignature = submitter.register_encalve(
                 self.verifying_key,
                 self.encryption_key,
-                self.proof_data,
+                proof_data,
                 self.nonce, # registration block content
                 ledger_config.get('Organization', "EMPTY")) # Eservice Organization Info
         except Exception as e :

--- a/eservice/pdo/eservice/scripts/EServiceEnclaveInfoCLI.py
+++ b/eservice/pdo/eservice/scripts/EServiceEnclaveInfoCLI.py
@@ -33,13 +33,13 @@ import time
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
 
-def GetBasename(spid, save_path, config) :
+def GetBasename(spid, attestation_type, save_path, config) :
     attempts = 0
     while True :
         try :
             logger.debug('initialize the enclave')
             enclave_config = {}
-            info = pdo_enclave_helper.get_enclave_service_info(spid, config=enclave_config)
+            info = pdo_enclave_helper.get_enclave_service_info(spid, attestation_type, config=enclave_config)
 
             logger.info('save MR_ENCLAVE and MR_BASENAME to %s', save_path)
             with open(save_path, "w") as file :
@@ -94,8 +94,8 @@ def GetIasCertificates(config) :
     pdo_enclave.shutdown()
     return
 
-def LocalMain(config, spid, save_path) :
-    GetBasename(spid, save_path, config)
+def LocalMain(config, spid, attestation_type, save_path) :
+    GetBasename(spid, attestation_type, save_path, config)
     GetIasCertificates(config)
 
     sys.exit(0)
@@ -141,6 +141,7 @@ def Main() :
 
     parser.add_argument('--identity', help='Identity to use for the process', required = True, type = str)
     parser.add_argument('--spid', help='SPID to generate enclave basename', type=str)
+    parser.add_argument('--attestation-type', help='Attestation type used by the eservice', type=str)
     parser.add_argument('--save', help='Where to save MR_ENCLAVE and BASENAME', type=str)
 
     parser.add_argument('--logfile', help='Name of the log file, __screen__ for standard output', type=str)
@@ -160,6 +161,9 @@ def Main() :
 
     if options.spid :
         spid = options.spid
+
+    if options.attestation_type :
+        attestation_type = options.attestation_type
 
     global config_map
     config_map['identity'] = options.identity
@@ -184,7 +188,7 @@ def Main() :
     sys.stderr = plogger.stream_to_logger(logging.getLogger('STDERR'), logging.WARN)
 
     # GO!
-    LocalMain(config, spid, save_path)
+    LocalMain(config, spid, attestation_type, save_path)
 
 ## -----------------------------------------------------------------
 ## Entry points

--- a/eservice/setup.py
+++ b/eservice/setup.py
@@ -101,6 +101,7 @@ libraries = [
     'lmdb'
 ]
 
+
 if sgx_mode_env == "HW":
     libraries.append('sgx_urts')
     libraries.append('sgx_uae_service')
@@ -110,6 +111,7 @@ if sgx_mode_env == "SIM":
     libraries.append('sgx_uae_service_sim')
     SGX_SIMULATOR_value = '1'
 
+libraries.append('sgx_dcap_ql')
 libraries.append('sgx_usgxssl')
 
 module_files = [

--- a/pservice/CMakeLists.txt
+++ b/pservice/CMakeLists.txt
@@ -38,6 +38,12 @@ if("${SGX_MODE} " STREQUAL " ")
 endif()
 IF("${SGX_MODE}" STREQUAL "SIM")
     OPTION(SGX_USE_SIMULATOR "Use the sgx simulator" TRUE)
+ELSEIF("$ENV{PDO_LEDGER_TYPE}" STREQUAL "ccf")
+    # Note: we force SIM mode in the pservice when using ccf,
+    #       because ccf currently does not accept/verify/return the proof_data field,
+    #       which is verified by the pservice in HW mode
+    message(WARNING, "Forcing SIM mode at PService because CCF is being used")
+    OPTION(SGX_USE_SIMULATOR "Use the sgx simulator" TRUE)
 ELSE()
     OPTION(SGX_USE_SIMULATOR "Use the sgx simulator" FALSE)
     If(NOT EXISTS ${PDO_TOP_DIR}pservice/lib/libpdo_enclave/contract_enclave_mrenclave.cpp)

--- a/pservice/setup.py
+++ b/pservice/setup.py
@@ -88,10 +88,18 @@ libraries = [
     'updo-common'
 ]
 
-if sgx_mode_env == "HW":
+if sgx_mode_env == "HW" and os.environ.get('PDO_LEDGER_TYPE', "none") != "ccf":
     libraries.append('sgx_urts')
     libraries.append('sgx_uae_service')
     SGX_SIMULATOR_value = '0'
+
+if sgx_mode_env == "HW" and os.environ.get('PDO_LEDGER_TYPE', "none") == "ccf":
+    # Forcing SIM mode since ccf does not support PDO HW mode
+    libraries.append('sgx_urts_sim')
+    libraries.append('sgx_uae_service_sim')
+    print("Forcing SIM mode in PService since ccf does not support PDO HW mode")
+    SGX_SIMULATOR_value = '1'
+
 if sgx_mode_env == "SIM":
     libraries.append('sgx_urts_sim')
     libraries.append('sgx_uae_service_sim')

--- a/python/pdo/submitter/ccf/ccf_submitter.py
+++ b/python/pdo/submitter/ccf/ccf_submitter.py
@@ -467,7 +467,7 @@ class PayloadBuilder(object):
         payloadblob['encryption_key'] = encryption_key
         payloadblob['proof_data'] = proof_data
         if proof_data:
-            payloadblob['enclave_persistent_id'] = get_epid_pseudonym_from_proof_data(proof_data)
+            payloadblob['enclave_persistent_id'] = sub.get_epid_pseudonym_from_proof_data(proof_data)
         else:
             payloadblob['enclave_persistent_id'] = "ignored field, no proof data"
         payloadblob['registration_block_context'] = registration_block_context


### PR DESCRIPTION
This PR enables DCAP quote generation in PDO, alongside EPID quotes.

The PR adds the following features:
*  a new `PDO_ATTESTATION_TYPE` variable to specify the type of attestation. Currently, it supports the following values: `simulated` in SIM mode; `epid-linkable` or `dcap` in HW mode.
* updated docker build to support DCAP quote generation in HW mode
  * updated support for dcap devices and a new file to specify the sgx attestation type (even in SIM mode)
  * a PCCS is required and the build assumes that an instance is up and running. The URL can be configured through the `PCCS_URL` variable.
* documentation for the dcap attestation and new variables
* support for DCAP quote generation, alongside EPID quote generation, inside the eservice. The attestation type is used to select the quoting enclave target and the right data structures to use. As before, a generic quote buffer is returned to the caller. For EPID, this is sent to IAS to retrieve the verification report. For DCAP, the proof data is currently dropped because: 1) support for DCAP quote verification must be implemented; 2) this allows to test the rest of PDO (CCF TP and pservice), albeit (with the rest compiled) for SIM mode.

Testing.
* This PR depends on #379 -- which enables HW mode only for the eservice, for testing purposes.
* This PR was tested through:
  * the usual github CI, in SIM mode;
  * locally in HW mode with EPID;
  * locally in HW mode with DCAP, using a local PCCS on the same platform -- if behind a proxy, the no-proxy variables must be set properly, so that the docker compose/container can access the service on the host.
    *  Troubleshooting proxy/PCCS issues in CI. Errors in proxy/pccs configuration typically result in `Error returned from the p_sgx_get_quote_config API. 0xe019`.
      * Make sure that the no-/proxy variables are set up correctly on the host (since these are later ported to the containers in the CI) and in the containers.
      * Also, make sure that the `/etc/sgx_default_qcnl.conf` on the host, or in the container, is set up correctly with a reachable PCCS.