### PR TITLE
Change the python version regular expression for multi-digit versions

### DIFF
--- a/bin/lib/common.sh
+++ b/bin/lib/common.sh
@@ -56,3 +56,12 @@ function die() {
 function try() {
     "$@" || die "operation failed: $*"
 }
+
+# Common function to test python version
+#-----------------------------------------
+function check_python_version() {
+    VERSION=$(python3 --version | sed 's/Python 3\.\([0-9][0-9]*\).*/\1/')
+    if [[ $VERSION -lt 5 ]]; then
+        die unsupported version of python
+    fi
+}

--- a/build/Makefile
+++ b/build/Makefile
@@ -53,7 +53,7 @@ CLEAN=$(abspath $(SCRIPTDIR)/__tools__/clean.sh)
 TESTSCRIPT=$(abspath $(SCRIPTDIR)/__tools__/run-tests.sh)
 BENCHMARKSCRIPT=$(abspath $(SCRIPTDIR)/__tools__/run-benchmarks.sh)
 
-PY_VERSION=${shell python3 --version | sed 's/Python \(3\.[0-9]\).*/\1/'}
+PY_VERSION=${shell python3 --version | sed 's/Python \(3\.[0-9]*\)\.[0-9]*/\1/'}
 PYTHON_DIR=$(DSTDIR)/lib/python$(PY_VERSION)/site-packages/
 
 ifndef NO_SGX_RUN_DURING_BUILD

--- a/build/__tools__/build.sh
+++ b/build/__tools__/build.sh
@@ -20,13 +20,7 @@ SCRIPTDIR="$(dirname $(readlink --canonicalize ${BASH_SOURCE}))"
 SRCDIR="$(realpath ${SCRIPTDIR}/../..)"
 
 source ${SRCDIR}/bin/lib/common.sh
-
-# -----------------------------------------------------------------
-# -----------------------------------------------------------------
-PY3_VERSION=$(python --version | sed 's/Python 3\.\([0-9]\).*/\1/')
-if [[ $PY3_VERSION -lt 5 ]]; then
-    die activate python3 first
-fi
+check_python_version
 
 # Automatically determine how many cores the host system has
 # (for use with multi-threaded make)

--- a/build/__tools__/clean.sh
+++ b/build/__tools__/clean.sh
@@ -14,16 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PY3_VERSION=$(python --version | sed 's/Python 3\.\([0-9]\).*/\1/')
-if [[ $PY3_VERSION -lt 5 ]]; then
-    echo activate python3 first
-    exit
-fi
-
 SCRIPTDIR="$(dirname $(readlink --canonicalize ${BASH_SOURCE}))"
 SRCDIR="$(realpath ${SCRIPTDIR}/../..)"
 
 source ${SRCDIR}/bin/lib/common.sh
+check_python_version
+
+# -----------------------------------------------------------------
+# -----------------------------------------------------------------
 
 yell --------------- COMMON ---------------
 cd $SRCDIR/common/crypto/verify_ias_report

--- a/build/__tools__/run-benchmarks.sh
+++ b/build/__tools__/run-benchmarks.sh
@@ -20,6 +20,7 @@ SCRIPTDIR="$(dirname $(readlink --canonicalize ${BASH_SOURCE}))"
 SRCDIR="$(realpath ${SCRIPTDIR}/../..)"
 
 source ${SRCDIR}/bin/lib/common.sh
+check_python_version
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
@@ -29,11 +30,6 @@ fi
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
-PY3_VERSION=$(python --version | sed 's/Python 3\.\([0-9]\).*/\1/')
-if [[ $PY3_VERSION -lt 5 ]]; then
-    die activate python3 first
-fi
-
 : "${PDO_SOURCE_ROOT:-$(die Missing environment variable PDO_SOURCE_ROOT)}"
 : "${PDO_INTERPRETER:-$(die Missing environment variable PDO_INTERPRETER)}"
 

--- a/build/__tools__/run-perf-tests.sh
+++ b/build/__tools__/run-perf-tests.sh
@@ -20,14 +20,10 @@ SCRIPTDIR="$(dirname $(readlink --canonicalize ${BASH_SOURCE}))"
 SRCDIR="$(realpath ${SCRIPTDIR}/../..)"
 
 source ${SRCDIR}/bin/lib/common.sh
+check_python_version
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
-PY3_VERSION=$(python --version | sed 's/Python 3\.\([0-9]\).*/\1/')
-if [[ $PY3_VERSION -lt 5 ]]; then
-    die activate python3 first
-fi
-
 : "${PDO_HOME:-$(die Missing environment variable PDO_HOME)}"
 
 # -----------------------------------------------------------------

--- a/build/__tools__/run-tests.sh
+++ b/build/__tools__/run-tests.sh
@@ -20,6 +20,7 @@ SCRIPTDIR="$(dirname $(readlink --canonicalize ${BASH_SOURCE}))"
 SRCDIR="$(realpath ${SCRIPTDIR}/../..)"
 
 source ${SRCDIR}/bin/lib/common.sh
+check_python_version
 
 PDO_LOG_LEVEL=${PDO_LOG_LEVEL:-info}
 
@@ -31,11 +32,6 @@ fi
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
-PY3_VERSION=$(python --version | sed 's/Python 3\.\([0-9]\).*/\1/')
-if [[ $PY3_VERSION -lt 5 ]]; then
-    die activate python3 first
-fi
-
 SCRIPTDIR="$(dirname $(readlink --canonicalize ${BASH_SOURCE}))"
 SRCDIR="$(realpath ${SCRIPTDIR}/../..)"
 

--- a/ccf_transaction_processor/scripts/start_ccf_network.sh
+++ b/ccf_transaction_processor/scripts/start_ccf_network.sh
@@ -14,16 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PY3_VERSION=$(python --version | sed 's/Python 3\.\([0-9]\).*/\1/')
-if [[ $PY3_VERSION -lt 5 ]]; then
-    echo activate python3 first
-    exit 1
-fi
-
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
 F_SERVICEHOME="$( cd -P "$( dirname ${BASH_SOURCE[0]} )/.." && pwd )"
 source ${F_SERVICEHOME}/bin/lib/pdo_common.sh
+
+check_python_version
 
 if [ -f ${F_SERVICEHOME}/run/cchost.pid ]; then
     if ps -p $(cat ${F_SERVICEHOME}/run/cchost.pid) > /dev/null

--- a/ccf_transaction_processor/scripts/start_cchost.sh
+++ b/ccf_transaction_processor/scripts/start_cchost.sh
@@ -14,12 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PY3_VERSION=$(python --version | sed 's/Python 3\.\([0-9]\).*/\1/')
-if [[ $PY3_VERSION -lt 5 ]]; then
-    echo activate python3 first
-    exit 1
-fi
-
 F_SERVICEHOME="$( cd -P "$( dirname ${BASH_SOURCE[0]} )/.." && pwd )"
 source ${F_SERVICEHOME}/bin/lib/pdo_common.sh
 

--- a/ccf_transaction_processor/scripts/stop_cchost.sh
+++ b/ccf_transaction_processor/scripts/stop_cchost.sh
@@ -14,12 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PY3_VERSION=$(python --version | sed 's/Python 3\.\([0-9]\).*/\1/')
-if [[ $PY3_VERSION -lt 5 ]]; then
-    echo activate python3 first
-    exit 1
-fi
-
 F_SERVICEHOME="$( cd -P "$( dirname ${BASH_SOURCE[0]} )/.." && pwd )"
 source ${F_SERVICEHOME}/bin/lib/pdo_common.sh
 

--- a/client/Makefile
+++ b/client/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PY_VERSION=${shell python3 --version | sed 's/Python \(3\.[0-9]\).*/\1/'}
+PY_VERSION=${shell python3 --version | sed 's/Python \(3\.[0-9]*\)\.[0-9]*/\1/'}
 MOD_VERSION=${shell ../bin/get_version}
 EGG_FILE=dist/pdo_client-${MOD_VERSION}-py${PY_VERSION}.egg
 

--- a/eservice/Makefile
+++ b/eservice/Makefile
@@ -15,7 +15,7 @@
 SCRIPTDIR ?= $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 SRCDIR ?= $(abspath $(SCRIPTDIR)/..)
 
-PY_VERSION=${shell python --version | sed 's/Python \([0-9]\.[0-9]\).*/\1/'}
+PY_VERSION=${shell python3 --version | sed 's/Python \(3\.[0-9]*\)\.[0-9]*/\1/'}
 MOD_VERSION=${shell ../bin/get_version}
 
 ifndef SGX_MODE

--- a/eservice/bin/es-start.sh
+++ b/eservice/bin/es-start.sh
@@ -14,15 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PY3_VERSION=$(python --version | sed 's/Python 3\.\([0-9]\).*/\1/')
-if [[ $PY3_VERSION -lt 5 ]]; then
-    echo activate python3 first
-    exit 1
-fi
-
 F_SERVICEHOME="$( cd -P "$( dirname ${BASH_SOURCE[0]} )/.." && pwd )"
 source ${F_SERVICEHOME}/bin/lib/common.sh
 source ${F_SERVICEHOME}/bin/lib/common_service.sh
+
+check_python_version
 
 F_BASENAME='eservice'
 F_SERVICE_CMD='eservice'

--- a/eservice/bin/register-with-ledger.sh
+++ b/eservice/bin/register-with-ledger.sh
@@ -14,13 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-PY3_VERSION=$(python --version | sed 's/Python 3\.\([0-9]\).*/\1/')
-if [[ $PY3_VERSION -lt 5 ]]; then
-    echo activate python3 first
-    exit 101
-fi
-
 SCRIPTDIR="$(dirname $(readlink --canonicalize ${BASH_SOURCE}))"
 SRCDIR="$(realpath ${SCRIPTDIR}/../..)"
 DSTDIR=${PDO_INSTALL_ROOT}
@@ -36,6 +29,7 @@ PDO_IAS_KEY_PEM=${PDO_SGX_KEY_ROOT}/sgx_ias_key.pem
 eservice_enclave_info_file=$(mktemp /tmp/pdo-test.XXXXXXXXX)
 
 source ${SRCDIR}/bin/lib/common.sh
+check_python_version
 
 function cleanup {
     yell "Clean up temporary files"

--- a/eservice/bin/ss-start.sh
+++ b/eservice/bin/ss-start.sh
@@ -14,15 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PY3_VERSION=$(python --version | sed 's/Python 3\.\([0-9]\).*/\1/')
-if [[ $PY3_VERSION -lt 5 ]]; then
-    echo activate python3 first
-    exit
-fi
-
 F_SERVICEHOME="$( cd -P "$( dirname ${BASH_SOURCE[0]} )/.." && pwd )"
 source ${F_SERVICEHOME}/bin/lib/common.sh
 source ${F_SERVICEHOME}/bin/lib/common_service.sh
+
+check_python_version
 
 F_BASENAME='sservice'
 F_SERVICE_CMD='sservice'

--- a/pservice/Makefile
+++ b/pservice/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PY_VERSION=${shell python3 --version | sed 's/Python \(3\.[0-9]\).*/\1/'}
+PY_VERSION=${shell python3 --version | sed 's/Python \(3\.[0-9]*\)\.[0-9]*/\1/'}
 MOD_VERSION=${shell ../bin/get_version}
 
 EGG_FILE=dist/pdo_pservice-${MOD_VERSION}-py${PY_VERSION}-linux-x86_64.egg

--- a/pservice/bin/ps-start.sh
+++ b/pservice/bin/ps-start.sh
@@ -14,15 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-PY3_VERSION=$(python --version | sed 's/Python 3\.\([0-9]\).*/\1/')
-if [[ $PY3_VERSION -lt 5 ]]; then
-    echo activate python3 first
-    exit 1
-fi
-
 F_SERVICEHOME="$( cd -P "$( dirname ${BASH_SOURCE[0]} )/.." && pwd )"
 source ${F_SERVICEHOME}/bin/lib/common.sh
 source ${F_SERVICEHOME}/bin/lib/common_service.sh
+
+check_python_version
 
 F_BASENAME='pservice'
 F_SERVICE_CMD='pservice'

--- a/python/Makefile
+++ b/python/Makefile
@@ -23,7 +23,7 @@ endif
 SCRIPTDIR ?= $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 DSTDIR ?= $(PDO_INSTALL_ROOT)
 
-PY_VERSION=${shell . $(abspath $(DSTDIR)/bin/activate) && python3 --version | sed 's/Python \(3\.[0-9]\).*/\1/'}
+PY_VERSION=${shell python3 --version | sed 's/Python \(3\.[0-9]*\)\.[0-9]*/\1/'}
 MOD_VERSION=${shell ../bin/get_version}
 
 EGG_FILE = dist/pdo_common_library-${MOD_VERSION}-py${PY_VERSION}-linux-x86_64.egg


### PR DESCRIPTION
This is preliminary support for clients running on ubuntu 22.04 where the python version is 3.10. Previously the regular expression used to get the version was limited to one digit minor versions. This should fix that limitation.

Note that shell scripts can use the check_python_version macro defined in the common.sh library.

Signed-off-by: Mic Bowman <mic.bowman@intel.com>