### PR TITLE
Upgrade wawaka to WAMR-1.1.2 release

### DIFF
--- a/common/interpreter/wawaka_wasm/README.md
+++ b/common/interpreter/wawaka_wasm/README.md
@@ -31,7 +31,7 @@ There are many toolchains that could be used to build a WASM code. By default, W
 compiled with the compilers provided by [WASI SDK](https://github.com/WebAssembly/wasi-sdk). To use
 WASI SDK, download and install the appropriate package file from
 https://github.com/WebAssembly/wasi-sdk/releases (we have verified that release wasi-sdk-12 works
-with WAMR version WAMR-01-18-2022).
+with WAMR version WAMR-1.1.2).
 
 ```bash
 wget -q -P /tmp https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-12/wasi-sdk_12.0_amd64.deb
@@ -46,14 +46,14 @@ SDK would be installed in the directory `/opt/wasi-sdk`.
 If wawaka is configured as the contract interpreter, the libraries implementing the WASM interpreter
 will be built for use with Intel SGX. The source for the WAMR interpreter is
 included as a submodule in the interpreters/ folder, and will
-always point to the latest tagged commit that we have validated: `WAMR-01-18-2022`.
+always point to the latest tagged commit that we have validated: `WAMR-1.1.2`.
 If the PDO parent repo was not cloned with the `--recurse-submodules` flag,
 you will have to explictly pull the submodule source.
 
 ```
 cd ${PDO_SOURCE_ROOT}/interpreters/wasm-micro-runtime
 git submodule update --init
-git checkout WAMR-01-18-2022 # optional
+git checkout WAMR-1.1.2 # optional
 ```
 
 The WAMR API is built during the Wawaka build, so no additional

--- a/common/interpreter/wawaka_wasm/WawakaInterpreter.cpp
+++ b/common/interpreter/wawaka_wasm/WawakaInterpreter.cpp
@@ -77,9 +77,10 @@ void wasm_logger(unsigned int level, const char *msg, const int value)
 }
 
 // XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-void wasm_printer(const char *msg)
+int wasm_printer(const char *msg)
 {
     SAFE_LOG(PDO_LOG_ERROR, msg);
+    return 0; // for updated WAMR os_print_function_t
 }
 
 } /* extern "C" */

--- a/docker/Dockerfile.pdo-build
+++ b/docker/Dockerfile.pdo-build
@@ -24,7 +24,7 @@
 #  - pdo repo branch to use:			PDO_REPO_BRANCH (default: main)
 #  - build in debug mode:			PDO_DEBUG_BUILD (default: 0)
 #  - contract interpreter (gipsy or wawaka):	PDO_INTERPRETER (default: gipsy)
-#  - wamr version:		                WAMR    (default: WAMR-01-18-2022)
+#  - wamr version:		                WAMR    (default: WAMR-1.1.2)
 
 # Build:
 #   $ docker build -f docker/Dockerfile.pdo-build -t pdo-build docker
@@ -109,7 +109,7 @@ ENV PDO_LEDGER_KEY_ROOT=${PDO_LEDGER_KEY_ROOT}
 
 # - web-assembly/wasm/wawaka
 #   - Configure WAMR source
-ARG WAMR=WAMR-01-18-2022
+ARG WAMR=WAMR-1.1.2
 RUN cd /project/pdo/src/private-data-objects/interpreters/wasm-micro-runtime \
  && git checkout ${WAMR}\
  && echo "export WASM_SRC=$(pwd)" >> /etc/profile.d/pdo.sh

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -110,7 +110,7 @@ happening inside a contract, do not use with confidential contracts.
 `WASM_SRC` points to the installation of the wasm-micro-runtime. This
 is used to build the WASM interpreter for the wawaka contract interpreter.
 The git submodule points to the latest tagged commit of [WAMR](https://github.com/bytecodealliance/wasm-micro-runtime) we have validated:
-`WAMR-01-18-2022`.
+`WAMR-1.1.2`.
 
 <!-- -------------------------------------------------- -->
 ### `WASM_MEM_CONFIG`


### PR DESCRIPTION
Key new features since last supported version (WAMR-01-19-2022):

- Since [WAMR-05-18-2022](https://github.com/bytecodealliance/wasm-micro-runtime/releases/tag/WAMR-05-18-2022)
  * Implement Berkeley Socket APIs for libc-wasi and linux-sgx platforms
  * Fix native stack overflow check failed in interpreter
  * Fix various AOT compilation and loader issues

- Since [fast-jit-06-29-2022](https://github.com/bytecodealliance/wasm-micro-runtime/releases/tag/fast-jit-06-29-2022):
  * First implementation of fast JIT

- Since [WAMR-1.0.0](https://github.com/bytecodealliance/wasm-micro-runtime/releases/tag/WAMR-1.0.0)
  * Implement HW bound check for interpreter and Fast JIT
  * Implement Python and go language bindings
  * Enable SGX remote attestation using librats
  * Add a new API to get free memory in memory pool
  * Enable AOT compiler with llvm-14/15
  * Support 3rd-party toolchains in wamrc

- Since [WAMR-1.1.0](https://github.com/bytecodealliance/wasm-micro-runtime/releases/tag/WAMR-1.1.0)
  * Add support for SGX IPFS
  * Add check for code section size, fix interpreter float operations
  * Prevent an already detached thread from being detached again for thread manager

- Since [WAMR-1.1.1](https://github.com/bytecodealliance/wasm-micro-runtime/releases/tag/WAMR-1.1.1)
  * Improvements to Socket API implementations
  * Integrate WASI-NN into WAMR: support TensorFlow/CPU/F32 in the first stage

- Since [WAMR-1.1.2](https://github.com/bytecodealliance/wasm-micro-runtime/releases/tag/WAMR-1.1.2)
  * Change iwasm exit code in certain conditions
  * Enable bulk memory by default; normalize how the global heap pool is configured across iwasm apps
  * Refine AOT exception checks when functions return