### PR TITLE
Fix build in HW mode

### DIFF
--- a/build/__tools__/build.sh
+++ b/build/__tools__/build.sh
@@ -50,7 +50,6 @@ if [ ${F_CLIENT} == "yes" ]; then
 else
     CMAKE_ARGS="-DBUILD_CLIENT=0 -DBUILD_TRUSTED=1 -DBUILD_UNTRUSTED=1"
     MAKE_ARGS="-j${NUM_CORES} BUILD_CLIENT=0"
-    MAKE_ARGS="BUILD_CLIENT=0"
 fi
 
 # -----------------------------------------------------------------

--- a/pservice/Makefile
+++ b/pservice/Makefile
@@ -62,14 +62,14 @@ $(CONTRACT_ENCLAVE_MRENCLAVE_C_FILE): $(CONTRACT_ENCLAVE_MRENCLAVE_TEMPLATE_FILE
 	VAR_MRENCLAVE=$$(perl -0777 -ne 'if (/metadata->enclave_css.body.enclave_hash.m:([a-fx0-9 \n]+)/) { $$eh = $$1; $$eh=~s/0x| |\n//g; $$eh=~tr/a-z/A-Z/; print "$${eh}\n"; }' $(CONTRACT_ENCLAVE_MRENCLAVE_META_FILE)) && \
 	sed "s/MR_ENCLAVE_PLACEMARK/$${VAR_MRENCLAVE}/" $(CONTRACT_ENCLAVE_MRENCLAVE_TEMPLATE_FILE) > $(CONTRACT_ENCLAVE_MRENCLAVE_C_FILE)
 
-$(ENCLAVE_LIB) : build $(ENCLAVE_FILES)
+$(ENCLAVE_LIB) : build
 	@echo Build Enclave
 	$(MAKE) -C build
 
 $(SWIG_TARGET) : $(SWIG_FILES) $(ENCLAVE_LIB)
 	python setup.py build_ext
 
-build :
+build : $(ENCLAVE_FILES)
 	mkdir $@
 	cd $@ && cmake .. -G "Unix Makefiles"
 


### PR DESCRIPTION
This PR fixes an issue in the build in HW mode.

The issue is due to missing target dependencies in the pservice build.
When the `build` target triggers the cmake, the `contract_enclave_mrenclave.cpp` file (part of the `ENCLAVE_FILES` target) must be available, as the cmake checks for that.
However, there is no dependency between the two targets.

Curiously, this issue seems to have been uncovered by unintentionally making the build single-task.
So far, apparently, the `make all` triggered both targets in parallel in the right order.

Signed-off-by: Bruno Vavala <bruno.vavala@intel.com>