### PR TITLE
Renaming sawtooth-pdo.sgx.yaml to pdo.sgx.yaml 

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -28,7 +28,7 @@ DOCKER_COMPOSE_FILES_CCF += ccf-pdo.yaml ccf-pdo.local-code.yaml
 DOCKER_COMPOSE_FILES_CCF_ONLY += ccf.yaml ccf.local-code.yaml
 
 ifeq ($(SGX_MODE),HW)
-   DOCKER_COMPOSE_FILES_STL += sawtooth-pdo.sgx.yaml
+   DOCKER_COMPOSE_FILES_STL += pdo.sgx.yaml
    SGX_DEVICE_PATH=$(shell if [ -e "/dev/isgx" ]; then echo "/dev/isgx"; elif [ -e "/dev/sgx/enclave" ]; then echo "/dev/sgx/enclave"; else echo "ERROR: NO SGX DEVICE FOUND"; fi)
    DOCKER_COMPOSE_COMMAND := env SGX_DEVICE_PATH=${SGX_DEVICE_PATH} ${DOCKER_COMPOSE_COMMAND}
 endif

--- a/docker/pdo.sgx.yaml
+++ b/docker/pdo.sgx.yaml
@@ -1,4 +1,4 @@
-# Copyright 2017 Intel Corporation
+# Copyright 2023 Intel Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,9 +13,9 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-# This docker-compose file extends the basic sawtooth-pdo template with support
-# for SGX in hardware mode. To use add a '-f sawtooth-pdo.sgx.yaml' _after_ the
-# '-f sawtooth-pdo.yaml'. This can also be combined with sawtooth-pdo.local-code.yaml.
+# This docker-compose file extends the basic <ledger>-pdo template with support
+# for SGX in hardware mode. To use add '-f pdo.sgx.yaml' _after_ the
+# '-f <ledger>-pdo.yaml'. This can also be combined with <ledger>-pdo.local-code.yaml.
 
 # Before you can run the containers in hardware mode, you will have to prepare following
 # files in the sgx subdirectory
@@ -24,7 +24,7 @@
 # - sgx_ias_key.pem
 # See 'build/common-config -h' for information on the content of these files
 #
-# in the pdo-build shell (see sawtooth-pdo.yaml), before doing any operation
+# in the pdo-build shell, before doing any operation
 # you also will have to register sgx-related information in the ledger with
 # following steps
 #    export PDO_SGX_KEY_ROOT=/project/pdo/build/opt/pdo/etc/keys/sgx/
@@ -39,7 +39,7 @@ services:
   # PDO EHS, PS and client ...
   pdo-build:
     image: pdo-sgx-build
-    container_name: sawtooth-pdo-sgx-build
+    container_name: pdo-sgx-build
     build:
       args:
         SGX_MODE: HW


### PR DESCRIPTION
This PR renames sawtooth-pdo.sgx.yaml to pdo.sgx.yaml  so that the same file as can be used to mount sgx drivers when PDO is run in HW mode with CCF TP. Usage will come in the next PR

Signed-off-by: Prakash Narayana Moorthy <prakash.narayana.moorthy@intel.com>