### PR TITLE
Separate Sawtooth and CCF tests, speed up CI, reduce (unnecessary) logs and solve double build (with possible corruption) issue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,4 +29,4 @@ jobs:
                   # this command, CI tests work on the main branch and on local
                   # branches. However, they fail as a PR is created.
                   git checkout -b we-need-a-branch-for-below-to-work
-                  make -C docker test
+                  make -C docker test-with-${PDO_LEDGER_TYPE}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,7 @@ jobs:
         strategy:
             matrix:
                 interpreter: [gipsy, wawaka, wawaka-opt]
+                pdo_ledger_type: [sawtooth, ccf]
 
         steps:
             - name: Check out repo
@@ -21,6 +22,7 @@ jobs:
             - name: Build and run tests
               env:
                   PDO_INTERPRETER: ${{ matrix.interpreter }}
+                  PDO_LEDGER_TYPE: ${{ matrix.pdo_ledger_type }}
               run: |
                   # The creation of a dummy branch is necessary for the CI tests
                   # to work on PRs. Based on empirical results, in the absence of

--- a/docker/Dockerfile.pdo-dev
+++ b/docker/Dockerfile.pdo-dev
@@ -111,7 +111,6 @@ RUN apt-get update \
     net-tools \
     dnsutils \
     $ADD_APT_PKGS \
- && apt-get -y -q upgrade \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
 # environment variables

--- a/docker/Dockerfile.pdo-dev
+++ b/docker/Dockerfile.pdo-dev
@@ -192,7 +192,7 @@ RUN git clone 'https://github.com/intel/intel-sgx-ssl.git' \
   && cd openssl_source \
   && wget -q https://www.openssl.org/source/openssl-${OPENSSL}.tar.gz \
   && cd ../Linux \
-  && make SGX_MODE=SIM DESTDIR=/opt/intel/sgxssl VERBOSE=0 all \
+  && bash -c "make SGX_MODE=SIM DESTDIR=/opt/intel/sgxssl VERBOSE=0 all &> /dev/null" \
   && make install \
   && make clean \
   && echo "export SGX_SSL=/opt/intel/sgxssl" >> /etc/profile.d/pdo.sh

--- a/docker/Dockerfile.pdo-dev
+++ b/docker/Dockerfile.pdo-dev
@@ -192,7 +192,7 @@ RUN git clone 'https://github.com/intel/intel-sgx-ssl.git' \
   && cd openssl_source \
   && wget -q https://www.openssl.org/source/openssl-${OPENSSL}.tar.gz \
   && cd ../Linux \
-  && make SGX_MODE=SIM DESTDIR=/opt/intel/sgxssl all test \
+  && make SGX_MODE=SIM DESTDIR=/opt/intel/sgxssl VERBOSE=0 all \
   && make install \
   && make clean \
   && echo "export SGX_SSL=/opt/intel/sgxssl" >> /etc/profile.d/pdo.sh

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -61,9 +61,11 @@ all:
 
 pdo-dev-image:
 	# unconditionally build, count on docker caching to not rebuild if not necessary
+	@echo "Building pdo-dev docker image"
 	docker build $(DOCKER_BUILD_OPTS) -f Dockerfile.pdo-dev -t pdo-dev .
 
 pdo-composition: pdo-dev-image
+	@echo "Running PDO docker composition for Sawtooth"
 	env PDO_REPO_BRANCH=$$(git rev-parse --abbrev-ref HEAD) $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_STL) build
 	# Note:
 	# - using `sawtooth-pdo.local-code.yaml` in above will cause the docker context to be `../`.
@@ -80,6 +82,7 @@ pdo-composition: pdo-dev-image
 	#     running out of disk space during the build...
 
 pdo-composition-ccf: pdo-dev-image
+	@echo "Running PDO docker composition for CCF"
 	env PDO_REPO_BRANCH=$$(git rev-parse --abbrev-ref HEAD) $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF) build
 
 ccf-only:
@@ -88,13 +91,21 @@ ccf-only:
 
 test-stl: pdo-composition test-with-no-build
 test-ccf: pdo-composition-ccf test-with-no-build-ccf
-test: test-stl test-ccf
+
+ifeq ($(PDO_LEDGER_TYPE),sawtooth)
+test: test-stl
+endif
+
+ifeq ($(PDO_LEDGER_TYPE),ccf)
+test: test-ccf
+endif
 
 test-env-setup: pdo-composition test-env-setup-with-no-build
 test-env-setup-ccf: pdo-composition-ccf test-env-setup-with-no-build-ccf
 test-env-setup-ccf-only: ccf-only test-env-setup-with-no-build-ccf-only
 
 test-env-setup-with-no-build:
+	@echo "Bringing up environment for tests with Sawtooth"
 	# just to be on safe side, make sure environment is not still up (e.g.,from previous failed attempt)
 	-$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_STL) down
 	# - start services
@@ -115,12 +126,15 @@ test-env-setup-with-no-build-ccf-only:
 	$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF_ONLY) up -d
 
 test-env-setup-with-no-build-ccf:
+	@echo "Bringing up environment for tests with CCF"
 	# just to be on safe side, make sure environment is not still up (e.g.,from previous failed attempt)
 	-$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF) down
 	# - start services
 	$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF) up -d
 
 test-with-no-build: test-env-setup-with-no-build
+	# - run automated tests
+	@echo "Running PDO tests with Sawtooth"
 	# 'sawtooth-pdo.debugging.yaml' doesn't start pdo-tp, so we will have to manually start it
 	if [ ! -z "$(PDO_DEBUG_BUILD)" ]; then  \
 	   $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_STL) \
@@ -135,6 +149,7 @@ test-with-no-build: test-env-setup-with-no-build
 
 test-with-no-build-ccf: test-env-setup-with-no-build-ccf
 	# - run automated tests
+	@echo "Running PDO tests with CCF"
 	# the pdo container must add the ip address of the pdo-tp-ccf container to its no proxy list (if behind a proxy)
 	if [ ! -z "$(no_proxy)" ]; then \
 	   $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF)  exec -T pdo-build bash -i -c "source /set_no_proxy.sh && /project/pdo/build/opt/pdo/etc/keys/ledger/check-for-ccf-keys.sh && /project/pdo/src/private-data-objects/build/__tools__/run-tests.sh"; \

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -89,16 +89,8 @@ ccf-only:
 	env PDO_REPO_BRANCH=$$(git rev-parse --abbrev-ref HEAD) $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF_ONLY) build
 
 
-test-stl: pdo-composition test-with-no-build
-test-ccf: pdo-composition-ccf test-with-no-build-ccf
-
-ifeq ($(PDO_LEDGER_TYPE),sawtooth)
-test: test-stl
-endif
-
-ifeq ($(PDO_LEDGER_TYPE),ccf)
-test: test-ccf
-endif
+test-with-sawtooth: pdo-composition test-with-no-build
+test-with-ccf: pdo-composition-ccf test-with-no-build-ccf
 
 test-env-setup: pdo-composition test-env-setup-with-no-build
 test-env-setup-ccf: pdo-composition-ccf test-env-setup-with-no-build-ccf

--- a/python/Makefile
+++ b/python/Makefile
@@ -69,9 +69,16 @@ $(EGG_FILE) : $(CRYPTO_SWIG_TARGET) $(KV_SWIG_TARGET) $(addprefix $(PROTOBUF_DPA
 	@ . $(abspath $(DSTDIR)/bin/activate) && \
 		BUILD_CLIENT=$(BUILD_CLIENT) python3 setup.py bdist_egg
 
-$(CRYPTO_SWIG_TARGET) $(KV_SWIG_TARGET) : $(CRYPTO_SWIG_SOURCE) $(KV_SWIG_SOURCE) $(COMMON_LIB) $(CRYPTO_LIB) $(KEYVAL_LIB)
+# In the following, we use the pattern rule with multiple targets
+# so that make knows that they are created through a single invocation of the target-body
+# Without that, when make runs with multiple threads, the target-body is executed
+# multiple times, possibly inducing build corruptions
+# This pattern rule can be avoided by using grouped targets starting in make 4.3
+pdo/common/crypto%py pdo/common/key_value_swig/key_value_swig%py : $(CRYPTO_SWIG_SOURCE) $(KV_SWIG_SOURCE) $(COMMON_LIB) $(CRYPTO_LIB) $(KEYVAL_LIB)
 	@ . $(abspath $(DSTDIR)/bin/activate) && \
 		BUILD_CLIENT=$(BUILD_CLIENT) python3 setup.py build_ext --force
+	test -e pdo/common/crypto$*py
+	test -e pdo/common/key_value_swig/key_value_swig$*py
 
 install: $(EGG_FILE)
 	@ . $(abspath $(DSTDIR)/bin/activate) && \


### PR DESCRIPTION
This PR reduce the run time of the CI by ~30% by:
1. separating the tests for sawtooth and ccf, thus running them in parallel
2. removing the upgrade of the packages -- which was performed on all packages in pdo-dev, not just those necessary for PDO
3. redirecting the stdout/err of the sgxssl/openssl build to /dev/null -- importantly, this also reduces the CI logs from ~30K lines to **~8K lines**!!!

Additionally, it solves an issue with a duplicate build (of setup.py in /python).
The issue was caused by a misrepresented rule. The rule has 2 targets, which are all generated in one execution. However, by listing the 2 targets as dependencies and running make with multiple threads, make does not know that those targets should be grouped, so it runs the rule twice in parallel.
The result is a double build, which sometimes succeeds and sometimes corrupts the outputs (and later builds fail).
It is quite possible that the issues experienced so far on the system tests of the key-value store were due to this problem.
In fact, the python and the swig files used in the tests (which sometimes failed with an "illegal instruction") were part of the double build output.