### PR TITLE
Start moving towards service startup that could be used for "production"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,4 +29,5 @@ jobs:
                   # this command, CI tests work on the main branch and on local
                   # branches. However, they fail as a PR is created.
                   git checkout -b we-need-a-branch-for-below-to-work
+                  . build/common-config.sh
                   make -C docker test-with-${PDO_LEDGER_TYPE}

--- a/bin/lib/common.sh
+++ b/bin/lib/common.sh
@@ -65,3 +65,14 @@ function check_python_version() {
         die unsupported version of python
     fi
 }
+
+# -----------------------------------------
+# Check the environment for completeness
+# -----------------------------------------
+: "${PDO_HOME:-$(die Missing environment variable PDO_HOME)}"
+: "${PDO_HOSTNAME:-$(die Missing environment variable PDO_HOSTNAME)}"
+: "${PDO_INTERPRETER:-$(die Missing environment variable PDO_INTERPRETER)}"
+: "${PDO_LEDGER_KEY_ROOT:-$(die Missing environment variable PDO_LEDGER_KEY_ROOT)}"
+: "${PDO_LEDGER_TYPE:-$(die Missing environment variable PDO_LEDGER_TYPE)}"
+: "${PDO_LEDGER_URL:-$(die Missing environment variable PDO_LEDGER_URL)}"
+: "${PDO_SOURCE_ROOT:-$(die Missing environment variable PDO_SOURCE_ROOT)}"

--- a/bin/lib/common_service.sh
+++ b/bin/lib/common_service.sh
@@ -56,6 +56,9 @@ service_start() {
     F_CLEAN='no'
     F_LOGLEVEL=''
 
+    # this is needed for extended pattern matching of configuration file names
+    shopt -s extglob
+
     # -----------------------------------------------------------------
     # Process command line arguments
     # -----------------------------------------------------------------
@@ -88,14 +91,14 @@ service_start() {
     done
 
     # (1) do not start if service already running
-    PLIST=$(pgrepf  "${F_BINDIR}/${F_SERVICE_CMD} .* --config ${F_BASENAME}[0-9].toml\b")
+    PLIST=$(pgrepf  "${F_BINDIR}/${F_SERVICE_CMD} .* --config ${F_BASENAME}[0-9]+.toml\b")
     if [ -n "$PLIST" ] ; then
         echo existing ${F_SERVICE_NANME} services detected, please shutdown first
         exit 1
     fi
 
     # (2) start services asynchronously
-    ILIST=$(basename --suffix=.toml ${F_CONFDIR}/${F_BASENAME}[0-9].toml)
+    ILIST=$(basename --suffix=.toml ${F_CONFDIR}/${F_BASENAME}+([0-9]).toml)
     for IDENTITY in ${ILIST[@]} ; do
         echo start ${F_SERVICE_NAME} service $IDENTITY
 
@@ -169,7 +172,7 @@ service_status() {
 
     echo "running processes of ${F_SERVICE_NAME} service"
 
-    PLIST=$(pgrepf  "${F_BINDIR}/${F_SERVICE_CMD} .* --config ${F_BASENAME}[0-9].toml\b")
+    PLIST=$(pgrepf  "${F_BINDIR}/${F_SERVICE_CMD} .* --config ${F_BASENAME}[0-9]+.toml\b")
     if [ -n "$PLIST" ] ; then
         ps -h --format pid,start,cmd -p $PLIST
     fi
@@ -182,6 +185,9 @@ service_status() {
 # - cmd-line params have to be passed as arguments of function
 service_stop() {
     F_USAGE='-c|--config path -b|--base name'
+
+    # this is needed for extended pattern matching of configuration file names
+    shopt -s extglob
 
     # -----------------------------------------------------------------
     # Process command line arguments
@@ -203,7 +209,7 @@ service_stop() {
     done
 
     rc=0
-    ILIST=$(basename --suffix=.toml ${F_CONFDIR}/${F_BASENAME}[0-9].toml)
+    ILIST=$(basename --suffix=.toml ${F_CONFDIR}/${F_BASENAME}+([0-9]).toml)
     for IDENTITY in ${ILIST[@]} ; do
         echo "stopping ${F_SERVICE_NAME} service ${IDENTITY}"
         if [ -f ${F_LOGDIR}/${IDENTITY}.pid ]; then

--- a/bin/lib/common_service.sh
+++ b/bin/lib/common_service.sh
@@ -118,26 +118,15 @@ service_start() {
         fi
 
 	if [ "${F_SERVICE_CMD}" = "sservice" ]; then
-            echo ${F_SERVICE_CMD} --identity ${IDENTITY} \
-                 --config ${IDENTITY}.toml --config-dir ${F_CONFDIR} \
-		 ${F_LOGLEVEL}
             ${F_SERVICE_CMD} --identity ${IDENTITY} --config ${IDENTITY}.toml --config-dir ${F_CONFDIR} \
 			     ${F_LOGLEVEL} 2> $EFILE > $OFILE &
             echo $! > ${F_LOGDIR}/${IDENTITY}.pid
 	else
-            echo ${F_SERVICE_CMD} --identity ${IDENTITY} \
-                 --config ${IDENTITY}.toml enclave.toml --config-dir ${F_CONFDIR} \
-                 ${F_LEDGERURL} ${F_LOGLEVEL}
             ${F_SERVICE_CMD} --identity ${IDENTITY} --config ${IDENTITY}.toml enclave.toml --config-dir ${F_CONFDIR} \
                              ${F_LEDGERURL} ${F_LOGLEVEL} 2> $EFILE > $OFILE &
             echo $! > ${F_LOGDIR}/${IDENTITY}.pid
 	fi
     done
-
-    PLIST=$(pgrepf  "${F_BINDIR}/${F_SERVICE_CMD} .* --config ${F_BASENAME}[0-9].toml\b")
-    if [ -n "$PLIST" ] ; then
-        ps -h --format pid,start,cmd -p $PLIST
-    fi
 
     # (3) wait for successfull start of the services
     for IDENTITY in ${ILIST[@]} ; do

--- a/build/Makefile
+++ b/build/Makefile
@@ -248,7 +248,9 @@ register : $(PYTHON_DIR)
 	@ echo registering enclave and IAS public key on the ledger
 	. $(abspath $(DSTDIR)/bin/activate) && $(SRCDIR)/eservice/bin/register-with-ledger.sh
 
-.PHONY : register
+else
+register :
+
 endif
 
 client: environment template build-client config-client
@@ -268,3 +270,4 @@ benchmark : $(PYTHON_DIR)
 .PHONY : install rebuild template test verify-pre-build verify-pre-config
 .PHONY : client build-client config-client
 .PHONY : keys service-keys system-keys user-keys
+.PHONY : register

--- a/build/Makefile
+++ b/build/Makefile
@@ -41,8 +41,21 @@ SCRIPTDIR ?= $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 DSTDIR ?= $(PDO_INSTALL_ROOT)
 SRCDIR ?= $(abspath $(SCRIPTDIR)/..)
 
-KEYDIR := $(DSTDIR)/opt/pdo/keys/
-ETCDIR := $(DSTDIR)/opt/pdo/etc/
+# this is an optional configuration variable to control the
+# hostname used in configuration files; we use it here to
+# customize the site.psh file
+ifndef PDO_HOSTNAME
+SERVICE_HOST := localhost
+else
+SERVICE_HOST := $(PDO_HOSTNAME)
+endif
+
+# splitting out the configuration root in order to make it easier
+# to build a separate configuration that can be used with the startup
+# scripts; by default the configuration is put into the regular tree
+CONFDIR := $(DSTDIR)
+KEYDIR := $(CONFDIR)/opt/pdo/keys/
+ETCDIR := $(CONFDIR)/opt/pdo/etc/
 
 KEYGEN=$(abspath $(SCRIPTDIR)/__tools__/make-keys)
 CNFGEN=$(abspath $(SCRIPTDIR)/__tools__/expand-config)
@@ -104,7 +117,24 @@ $(PYTHON_DIR) :
 
 $(DSTDIR) :
 	@echo CREATE INSTALLATION DIRECTORY $(DSTDIR)
-	mkdir -p $(DSTDIR)
+	@mkdir -p $(DSTDIR)
+	@mkdir -p $(DSTDIR)/opt/pdo/bin
+	@mkdir -p $(DSTDIR)/opt/pdo/contracts
+	@mkdir -p $(DSTDIR)/opt/pdo/data
+	@mkdir -p $(DSTDIR)/opt/pdo/logs
+
+# these are kept separate so that we can build a service
+# configuration from the templates that is different from
+# the test configuration
+$(KEYDIR) :
+	@echo Create the key directory $(KEYDIR)
+	@mkdir -p $(KEYDIR)
+
+$(ETCDIR) :
+	@echo Create the etc directory $(ETCDIR)
+	@mkdir -p $(ETCDIR)
+	@mkdir -p $(ETCDIR)/keys/sgx
+	@mkdir -p $(ETCDIR)/keys/ledger
 
 verify-pre-build :
 	$(VERIFY_PRE_BUILD)
@@ -128,18 +158,18 @@ ${PDO_ENCLAVE_CODE_SIGN_PEM} :
 service_indexes := 1 2 3 4 5
 
 ifeq ($(PDO_LEDGER_TYPE),sawtooth)
-	ESERVICE_KEYS := $(addprefix $(KEYDIR),$(foreach i,$(service_indexes),eservice$(i)_private.skf))
+	ESERVICE_KEYS := $(addprefix $(KEYDIR)/,$(foreach i,$(service_indexes),eservice$(i)_private.skf))
 	ecdsa_curve := secp256k1
 else
-	ESERVICE_KEYS := $(addprefix $(KEYDIR),$(foreach i,$(service_indexes),eservice$(i)_private.pem))
+	ESERVICE_KEYS := $(addprefix $(KEYDIR)/,$(foreach i,$(service_indexes),eservice$(i)_private.pem))
 	ecdsa_curve := secp384r1
 endif
 
-SSERVICE_PEM := $(addprefix $(KEYDIR),$(foreach i,$(service_indexes),sservice$(i)_private.pem))
-PSERVICE_PEM := $(addprefix $(KEYDIR),$(foreach i,$(service_indexes),pservice$(i)_private.pem))
+SSERVICE_PEM := $(addprefix $(KEYDIR)/,$(foreach i,$(service_indexes),sservice$(i)_private.pem))
+PSERVICE_PEM := $(addprefix $(KEYDIR)/,$(foreach i,$(service_indexes),pservice$(i)_private.pem))
 
 user_indexes := 1 2 3 4 5 6 7 8 9 10
-USER_PEM := $(addprefix $(KEYDIR),$(foreach i,$(user_indexes),user$(i)_private.pem))
+USER_PEM := $(addprefix $(KEYDIR)/,$(foreach i,$(user_indexes),user$(i)_private.pem))
 
 %.skf :
 	. $(abspath $(DSTDIR)/bin/activate) && $(KEYGEN) --keyfile $(subst _private,,$*) --format skf
@@ -147,7 +177,11 @@ USER_PEM := $(addprefix $(KEYDIR),$(foreach i,$(user_indexes),user$(i)_private.p
 %.pem :
 	. $(abspath $(DSTDIR)/bin/activate) && $(KEYGEN) --keyfile $(subst _private,,$*) --format pem --curve $(ecdsa_curve)
 
-keys : $(ESERVICE_KEYS) $(SSERVICE_PEM) $(PSERVICE_PEM) $(USER_PEM)
+service-keys : $(KEYDIR) $(ESERVICE_KEYS) $(SSERVICE_PEM) $(PSERVICE_PEM)
+
+user-keys : $(KEYDIR) $(USER_PEM)
+
+keys : service-keys user-keys
 
 ESERVICE_CONF := $(ETCDIR)/eservice1.toml
 SSERVICE_CONF := $(ETCDIR)/sservice1.toml
@@ -162,15 +196,17 @@ ESERVICE_CONF_TEMPLATE := $(SCRIPTDIR)/opt/pdo/etc/template/eservice.toml
 verified-conf : verify-pre-conf
 	${MAKE} conf
 
-conf : $(GENERATED_CONF_FILES) $(ETCDIR)/site.psh
+conf : $(ETCDIR) $(GENERATED_CONF_FILES) $(ETCDIR)/site.psh
 
 force-conf : verify-pre-conf
-	- rm $(ESERVICE_CONF) $(SSERVICE_CONF) $(PSERVICE_CONF) $(ETCDIR)/enclave.toml $(ETCDIR)/pcontract.toml
+	- rm -f $(ESERVICE_CONF) $(SSERVICE_CONF) $(PSERVICE_CONF)
+	- rm -f  $(ETCDIR)/enclave.toml $(ETCDIR)/pcontract.toml
+	- rm -f $(ETCDIR)/site.psh
 	${MAKE} conf
 
 $(ETCDIR)/site.psh : $(SCRIPTDIR)/opt/pdo/etc/template/site.psh
-	@ echo copy site.psh
-	@ cp $(SCRIPTDIR)/opt/pdo/etc/template/site.psh $(ETCDIR)/site.psh
+	@ echo create site.psh
+	@ sed "s/SERVICE_HOST/$(SERVICE_HOST)/" $(SCRIPTDIR)/opt/pdo/etc/template/site.psh > $(ETCDIR)/site.psh
 
 $(ESERVICE_CONF) : $(ESERVICE_CONF_TEMPLATE)
 	@ echo create configuration files for eservice
@@ -207,13 +243,7 @@ $(CONTRACT_CONF) : $(SCRIPTDIR)/opt/pdo/etc/template/pcontract.toml
 			--output-directory $(dir $@) \
 			single --file $(notdir $@)
 
-template : $(PYTHON_DIR)
-	mkdir -p $(DSTDIR)/opt/pdo/data
-	mkdir -p $(DSTDIR)/opt/pdo/etc
-	mkdir -p $(DSTDIR)/opt/pdo/etc/keys/sgx
-	mkdir -p $(DSTDIR)/opt/pdo/etc/keys/ledger
-	mkdir -p $(DSTDIR)/opt/pdo/keys
-	mkdir -p $(DSTDIR)/opt/pdo/logs
+template : $(DSTDIR) $(ETCDIR) $(KEYDIR)
 
 ifeq ($(SGX_MODE),HW)
 register : $(PYTHON_DIR)
@@ -235,4 +265,5 @@ benchmark : $(PYTHON_DIR)
 	. $(abspath $(DSTDIR)/bin/activate) && $(BENCHMARKSCRIPT)
 
 .PHONY : all build verified-build clean clean-build clean-install conf verified-conf environment
-.PHONY : install keys rebuild system-keys template test verify-pre-build verify-pre-conf
+.PHONY : install rebuild template test verify-pre-build verify-pre-conf
+.PHONY : keys service-keys system-keys user-keys

--- a/build/Makefile
+++ b/build/Makefile
@@ -45,38 +45,38 @@ SRCDIR ?= $(abspath $(SCRIPTDIR)/..)
 # hostname used in configuration files; we use it here to
 # customize the site.psh file
 ifndef PDO_HOSTNAME
-SERVICE_HOST := localhost
+SERVICE_HOST = localhost
 else
-SERVICE_HOST := $(PDO_HOSTNAME)
+SERVICE_HOST = $(PDO_HOSTNAME)
 endif
 
 # splitting out the configuration root in order to make it easier
 # to build a separate configuration that can be used with the startup
 # scripts; by default the configuration is put into the regular tree
-CONFDIR := $(DSTDIR)
-KEYDIR := $(CONFDIR)/opt/pdo/keys/
-ETCDIR := $(CONFDIR)/opt/pdo/etc/
+CONFDIR ?= $(DSTDIR)
+KEYDIR = $(CONFDIR)/opt/pdo/keys/
+ETCDIR = $(CONFDIR)/opt/pdo/etc/
 
-KEYGEN=$(abspath $(SCRIPTDIR)/__tools__/make-keys)
-CNFGEN=$(abspath $(SCRIPTDIR)/__tools__/expand-config)
-BUILD=$(abspath $(SCRIPTDIR)/__tools__/build.sh)
-VERIFY_PRE_BUILD=$(abspath $(SCRIPTDIR)/__tools__/verify-pre-build.sh)
-VERIFY_PRE_CONF=$(abspath $(SCRIPTDIR)/__tools__/verify-pre-conf.sh)
-CLEAN=$(abspath $(SCRIPTDIR)/__tools__/clean.sh)
-TESTSCRIPT=$(abspath $(SCRIPTDIR)/__tools__/run-tests.sh)
-BENCHMARKSCRIPT=$(abspath $(SCRIPTDIR)/__tools__/run-benchmarks.sh)
+KEYGEN = $(abspath $(SCRIPTDIR)/__tools__/make-keys)
+CNFGEN = $(abspath $(SCRIPTDIR)/__tools__/expand-config)
+BUILD = $(abspath $(SCRIPTDIR)/__tools__/build.sh)
+VERIFY_PRE_BUILD = $(abspath $(SCRIPTDIR)/__tools__/verify-pre-build.sh)
+VERIFY_PRE_CONF = $(abspath $(SCRIPTDIR)/__tools__/verify-pre-conf.sh)
+CLEAN = $(abspath $(SCRIPTDIR)/__tools__/clean.sh)
+TESTSCRIPT = $(abspath $(SCRIPTDIR)/__tools__/run-tests.sh)
+BENCHMARKSCRIPT = $(abspath $(SCRIPTDIR)/__tools__/run-benchmarks.sh)
 
-PY_VERSION=${shell python3 --version | sed 's/Python \(3\.[0-9]*\)\.[0-9]*/\1/'}
-PYTHON_DIR=$(DSTDIR)/lib/python$(PY_VERSION)/site-packages/
+PY_VERSION = ${shell python3 --version | sed 's/Python \(3\.[0-9]*\)\.[0-9]*/\1/'}
+PYTHON_DIR = $(DSTDIR)/lib/python$(PY_VERSION)/site-packages/
 
 ifndef NO_SGX_RUN_DURING_BUILD
-  CONDITIONAL_CONF_TARGET=verified-conf
+  CONDITIONAL_CONF_TARGET = verified-config
   ifeq ($(SGX_MODE),HW)
-    CONDITIONAL_REGISTER_TARGET=register
+    CONDITIONAL_REGISTER_TARGET = register
   endif
 else
   ifneq ($(SGX_MODE),HW)
-    CONDITIONAL_CONF_TARGET=verified-conf
+    CONDITIONAL_CONF_TARGET = verified-config
   endif
 endif
 
@@ -139,7 +139,7 @@ $(ETCDIR) :
 verify-pre-build :
 	$(VERIFY_PRE_BUILD)
 
-verify-pre-conf :
+verify-pre-config :
 	$(VERIFY_PRE_CONF)
 
 build : $(PYTHON_DIR)
@@ -155,21 +155,21 @@ system-keys : ${PDO_ENCLAVE_CODE_SIGN_PEM}
 ${PDO_ENCLAVE_CODE_SIGN_PEM} :
 	openssl genrsa -3 -out ${PDO_ENCLAVE_CODE_SIGN_PEM} 3072
 
-service_indexes := 1 2 3 4 5
+service_indexes = 1 2 3 4 5
 
 ifeq ($(PDO_LEDGER_TYPE),sawtooth)
-	ESERVICE_KEYS := $(addprefix $(KEYDIR)/,$(foreach i,$(service_indexes),eservice$(i)_private.skf))
-	ecdsa_curve := secp256k1
+	ESERVICE_KEYS = $(addprefix $(KEYDIR)/,$(foreach i,$(service_indexes),eservice$(i)_private.skf))
+	ecdsa_curve = secp256k1
 else
-	ESERVICE_KEYS := $(addprefix $(KEYDIR)/,$(foreach i,$(service_indexes),eservice$(i)_private.pem))
-	ecdsa_curve := secp384r1
+	ESERVICE_KEYS = $(addprefix $(KEYDIR)/,$(foreach i,$(service_indexes),eservice$(i)_private.pem))
+	ecdsa_curve = secp384r1
 endif
 
-SSERVICE_PEM := $(addprefix $(KEYDIR)/,$(foreach i,$(service_indexes),sservice$(i)_private.pem))
-PSERVICE_PEM := $(addprefix $(KEYDIR)/,$(foreach i,$(service_indexes),pservice$(i)_private.pem))
+SSERVICE_PEM = $(addprefix $(KEYDIR)/,$(foreach i,$(service_indexes),sservice$(i)_private.pem))
+PSERVICE_PEM = $(addprefix $(KEYDIR)/,$(foreach i,$(service_indexes),pservice$(i)_private.pem))
 
-user_indexes := 1 2 3 4 5 6 7 8 9 10
-USER_PEM := $(addprefix $(KEYDIR)/,$(foreach i,$(user_indexes),user$(i)_private.pem))
+user_indexes = 1 2 3 4 5 6 7 8 9 10
+USER_PEM = $(addprefix $(KEYDIR)/,$(foreach i,$(user_indexes),user$(i)_private.pem))
 
 %.skf :
 	. $(abspath $(DSTDIR)/bin/activate) && $(KEYGEN) --keyfile $(subst _private,,$*) --format skf
@@ -183,26 +183,26 @@ user-keys : $(KEYDIR) $(USER_PEM)
 
 keys : service-keys user-keys
 
-ESERVICE_CONF := $(ETCDIR)/eservice1.toml
-SSERVICE_CONF := $(ETCDIR)/sservice1.toml
-PSERVICE_CONF := $(ETCDIR)/pservice1.toml
-ENCLAVE_CONF := $(ETCDIR)/enclave.toml
-CONTRACT_CONF := $(ETCDIR)/pcontract.toml
+ESERVICE_CONF = $(ETCDIR)/eservice1.toml
+SSERVICE_CONF = $(ETCDIR)/sservice1.toml
+PSERVICE_CONF = $(ETCDIR)/pservice1.toml
+ENCLAVE_CONF = $(ETCDIR)/enclave.toml
+CONTRACT_CONF = $(ETCDIR)/pcontract.toml
 
-GENERATED_CONF_FILES := $(ESERVICE_CONF) $(SSERVICE_CONF) $(PSERVICE_CONF) $(ENCLAVE_CONF) $(CONTRACT_CONF)
+GENERATED_CONF_FILES = $(ESERVICE_CONF) $(SSERVICE_CONF) $(PSERVICE_CONF) $(ENCLAVE_CONF) $(CONTRACT_CONF)
 
-ESERVICE_CONF_TEMPLATE := $(SCRIPTDIR)/opt/pdo/etc/template/eservice.toml
+ESERVICE_CONF_TEMPLATE = $(SCRIPTDIR)/opt/pdo/etc/template/eservice.toml
 
-verified-conf : verify-pre-conf
-	${MAKE} conf
+verified-config : verify-pre-config
+	${MAKE} config
 
-conf : $(ETCDIR) $(GENERATED_CONF_FILES) $(ETCDIR)/site.psh
+config : $(ETCDIR) $(GENERATED_CONF_FILES) $(ETCDIR)/site.psh
 
-force-conf : verify-pre-conf
+force-config : verify-pre-config
 	- rm -f $(ESERVICE_CONF) $(SSERVICE_CONF) $(PSERVICE_CONF)
 	- rm -f  $(ETCDIR)/enclave.toml $(ETCDIR)/pcontract.toml
 	- rm -f $(ETCDIR)/site.psh
-	${MAKE} conf
+	${MAKE} config
 
 $(ETCDIR)/site.psh : $(SCRIPTDIR)/opt/pdo/etc/template/site.psh
 	@ echo create site.psh
@@ -253,10 +253,12 @@ register : $(PYTHON_DIR)
 .PHONY : register
 endif
 
-client: environment template build-client $(CONTRACT_CONF) $(USER_PEM) $(ETCDIR)/site.psh
+client: environment template build-client config-client
 
 build-client : $(PYTHON_DIR)
 	. $(abspath $(DSTDIR)/bin/activate) && $(BUILD) --client
+
+config-client : $(CONTRACT_CONF) $(USER_PEM) $(ETCDIR)/site.psh
 
 test : $(PYTHON_DIR)
 	. $(abspath $(DSTDIR)/bin/activate) && $(TESTSCRIPT)
@@ -264,6 +266,7 @@ test : $(PYTHON_DIR)
 benchmark : $(PYTHON_DIR)
 	. $(abspath $(DSTDIR)/bin/activate) && $(BENCHMARKSCRIPT)
 
-.PHONY : all build verified-build clean clean-build clean-install conf verified-conf environment
-.PHONY : install rebuild template test verify-pre-build verify-pre-conf
+.PHONY : all build verified-build clean clean-build clean-install config verified-config environment
+.PHONY : install rebuild template test verify-pre-build verify-pre-config
+.PHONY : client build-client config-client
 .PHONY : keys service-keys system-keys user-keys

--- a/build/Makefile
+++ b/build/Makefile
@@ -43,12 +43,10 @@ SRCDIR ?= $(abspath $(SCRIPTDIR)/..)
 
 # this is an optional configuration variable to control the
 # hostname used in configuration files; we use it here to
-# customize the site.psh file
-ifndef PDO_HOSTNAME
-SERVICE_HOST = localhost
-else
-SERVICE_HOST = $(PDO_HOSTNAME)
-endif
+# customize the site.psh file; this may be most useful when
+# building a client that will connect to services on a
+# different/remote host
+SERVICE_HOST ?= $(PDO_HOSTNAME)
 
 # splitting out the configuration root in order to make it easier
 # to build a separate configuration that can be used with the startup

--- a/build/__tools__/run-perf-tests.sh
+++ b/build/__tools__/run-perf-tests.sh
@@ -34,7 +34,7 @@ F_ITERATIONS=1000
 F_LEDGERURL=--no-ledger
 F_LOGLEVEL=info
 F_SERVICES=1
-F_SERVICEURL=http://localhost:7101
+F_SERVICEURL=http://intsim-t4.jf.intel.com:7101
 F_USAGE='[-c|--count client] [-i|--iterations count] [--ledger url]'
 
 TEMP=`getopt -o c:i:l: --long count:,iterations:,help,ledger:,loglevel: \

--- a/build/__tools__/run-perf-tests.sh
+++ b/build/__tools__/run-perf-tests.sh
@@ -34,7 +34,7 @@ F_ITERATIONS=1000
 F_LEDGERURL=--no-ledger
 F_LOGLEVEL=info
 F_SERVICES=1
-F_SERVICEURL=http://intsim-t4.jf.intel.com:7101
+3F_SERVICEURL=http://${PDO_HOSTNAME}:7101
 F_USAGE='[-c|--count client] [-i|--iterations count] [--ledger url]'
 
 TEMP=`getopt -o c:i:l: --long count:,iterations:,help,ledger:,loglevel: \

--- a/build/opt/pdo/etc/template/eservice.toml
+++ b/build/opt/pdo/etc/template/eservice.toml
@@ -19,7 +19,7 @@
 # Identity is a string used to identify the service in log files
 Identity = "${identity}"
 HttpPort = ${{7100+_count_}}
-Host = "localhost"
+Host = "${host}"
 
 # Max number of threads for processing WSGI requests
 WorkerThreads = 8
@@ -31,7 +31,7 @@ ReactorThreads = 8
 # StorageService -- information about KV block stores
 # --------------------------------------------------
 [StorageService]
-URL = "http://localhost:${{7200+_count_}}"
+URL = "http://${host}:${{7200+_count_}}"
 BlockStore = "${data}/${{identity.replace('eservice','sservice')}}.mdb"
 
 # --------------------------------------------------

--- a/build/opt/pdo/etc/template/pservice.toml
+++ b/build/opt/pdo/etc/template/pservice.toml
@@ -18,7 +18,7 @@
 [ProvisioningService]
 Identity = "${identity}"
 HttpPort = ${{7000+_count_}}
-Host = "localhost"
+Host = "${host}"
 
 # --------------------------------------------------
 # Ledger -- ledger configuration

--- a/build/opt/pdo/etc/template/site.psh
+++ b/build/opt/pdo/etc/template/site.psh
@@ -26,11 +26,11 @@ fi
 ## will be used by the local client to create & interact with
 ## contracts.
 ## -----------------------------------------------------------------
-set -s eservice1 -v http://localhost:7101
-set -s eservice2 -v http://localhost:7102
-set -s eservice3 -v http://localhost:7103
-set -s eservice4 -v http://localhost:7104
-set -s eservice5 -v http://localhost:7105
+set -s eservice1 -v http://SERVICE_HOST:7101
+set -s eservice2 -v http://SERVICE_HOST:7102
+set -s eservice3 -v http://SERVICE_HOST:7103
+set -s eservice4 -v http://SERVICE_HOST:7104
+set -s eservice5 -v http://SERVICE_HOST:7105
 
 ## load the local database if it exists
 set --conditional -s dbfile --state Service EnclaveServiceDatabaseFile
@@ -59,11 +59,11 @@ fi
 ## into the contract enclaves.
 ## -----------------------------------------------------------------
 
-set -s pservice1 -v http://localhost:7001
-set -s pservice2 -v http://localhost:7002
-set -s pservice3 -v http://localhost:7003
-set -s pservice4 -v http://localhost:7004
-set -s pservice5 -v http://localhost:7005
+set -s pservice1 -v http://SERVICE_HOST:7001
+set -s pservice2 -v http://SERVICE_HOST:7002
+set -s pservice3 -v http://SERVICE_HOST:7003
+set -s pservice4 -v http://SERVICE_HOST:7004
+set -s pservice5 -v http://SERVICE_HOST:7005
 
 ## default pservice group
 pservice add --url ${pservice1}
@@ -146,11 +146,11 @@ eservice --group all use --url ${eservice1}
 ## persistent storage service
 ## -----------------------------------------------------------------
 
-set -s sservice1 -v http://localhost:7201
-set -s sservice2 -v http://localhost:7202
-set -s sservice3 -v http://localhost:7203
-set -s sservice4 -v http://localhost:7204
-set -s sservice5 -v http://localhost:7205
+set -s sservice1 -v http://SERVICE_HOST:7201
+set -s sservice2 -v http://SERVICE_HOST:7202
+set -s sservice3 -v http://SERVICE_HOST:7203
+set -s sservice4 -v http://SERVICE_HOST:7204
+set -s sservice5 -v http://SERVICE_HOST:7205
 
 set -s persistent_storage_service -v ${sservice1}
 

--- a/build/opt/pdo/etc/template/sservice.toml
+++ b/build/opt/pdo/etc/template/sservice.toml
@@ -19,7 +19,7 @@
 # Identity is a string used to identify the service in log files
 Identity = "${identity}"
 HttpPort = ${{7200+_count_}}
-Host = "localhost"
+Host = "${host}"
 BlockStore = "${data}/${identity}.mdb"
 GarbageCollectionInterval = 10
 

--- a/build/tests/multi-user.sh
+++ b/build/tests/multi-user.sh
@@ -86,12 +86,13 @@ declare -i u p v value
 
 say increment the value with a simple expression ${iterations} times, querying enclaves in round robin
 for v in $(seq 1 ${iterations}) ; do
+    echo pass $v
     u=$((v % user_count + base_user))
     p=$((v % port_count + base_port))
     value=$(${PDO_HOME}/bin/pdo-invoke.psh \
                        --wait yes \
                        --logfile __screen__ --loglevel ${PDO_LOG_LEVEL} \
-                       --enclave "http://localhost:${p}" --identity user${u} \
+                       --enclave "http://${PDO_HOSTNAME}:${p}" --identity user${u} \
                        --pdo_file ${SAVE_FILE} --method anonymous_inc_value)
     if [ $value != $v ]; then
         die "contract has the wrong value ($value instead of $v) for enclave $e"
@@ -103,7 +104,7 @@ for v in $(seq 1 ${port_count}) ; do
     p=$((v % port_count + base_port))
     value=$(${PDO_HOME}/bin/pdo-invoke.psh \
                        --logfile __screen__ --loglevel ${PDO_LOG_LEVEL} \
-                       --enclave "http://localhost:${p}" --identity user1 \
+                       --enclave "http://${PDO_HOSTNAME}:${p}" --identity user1 \
                        --pdo_file ${SAVE_FILE} --method get_value)
     if [ $value != $iterations ]; then
         die "contract has the wrong value ($value instead of $iterations for enclave $e"

--- a/build/tests/shell-test.psh
+++ b/build/tests/shell-test.psh
@@ -19,72 +19,72 @@ set --conditional -s save -v .
 
 ## create an eservice db with the known enclave services
 eservice_db clear
-eservice_db add --url http://localhost:7101 --name es7101
-eservice_db add --url http://localhost:7102 --name es7102
-eservice_db add --url http://localhost:7103 --name es7103
-eservice_db add --url http://localhost:7104 --name es7104
-eservice_db add --url http://localhost:7105 --name es7105
+eservice_db add --url http://${host}:7101 --name es7101
+eservice_db add --url http://${host}:7102 --name es7102
+eservice_db add --url http://${host}:7103 --name es7103
+eservice_db add --url http://${host}:7104 --name es7104
+eservice_db add --url http://${host}:7105 --name es7105
 eservice_db save --database ${data}/test-db.json
 
 eservice_db clear
 eservice_db load --database ${data}/test-db.json
 
 ## default pservice group
-pservice add --url http://localhost:7001
-pservice add --url http://localhost:7002
-pservice add --url http://localhost:7003
+pservice add --url http://${host}:7001
+pservice add --url http://${host}:7002
+pservice add --url http://${host}:7003
 
 ## pservice group p1
-pservice --group p1 add --url http://localhost:7003
-pservice --group p1 add --url http://localhost:7004
-pservice --group p1 add --url http://localhost:7005
+pservice --group p1 add --url http://${host}:7003
+pservice --group p1 add --url http://${host}:7004
+pservice --group p1 add --url http://${host}:7005
 
 ## pservice group all
-pservice --group all add --url http://localhost:7001
-pservice --group all add --url http://localhost:7002
-pservice --group all add --url http://localhost:7003
-pservice --group all add --url http://localhost:7004
-pservice --group all add --url http://localhost:7005
+pservice --group all add --url http://${host}:7001
+pservice --group all add --url http://${host}:7002
+pservice --group all add --url http://${host}:7003
+pservice --group all add --url http://${host}:7004
+pservice --group all add --url http://${host}:7005
 
 ## default eservice group
-eservice add --url http://localhost:7101
-eservice add --url http://localhost:7102
-eservice add --url http://localhost:7103
+eservice add --url http://${host}:7101
+eservice add --url http://${host}:7102
+eservice add --url http://${host}:7103
 
 ## eservice group e1
 eservice --group e1 add --name es7103 es7104 es7105
-eservice --group e1 use --url http://localhost:7105
+eservice --group e1 use --url http://${host}:7105
 
 ## eservice group all
-eservice --group all add --url http://localhost:7101
-eservice --group all add --url http://localhost:7102 http://localhost:7103 --name es7104 es7105
+eservice --group all add --url http://${host}:7101
+eservice --group all add --url http://${host}:7102 http://${host}:7103 --name es7104 es7105
 eservice --group all use --name es7104
 
 ## default sservice group
-set -s persistent_storage_service -v http://localhost:7201
+set -s persistent_storage_service -v http://${host}:7201
 
-sservice add --url http://localhost:7201
-sservice add --url http://localhost:7202
-sservice add --url http://localhost:7203
+sservice add --url http://${host}:7201
+sservice add --url http://${host}:7202
+sservice add --url http://${host}:7203
 sservice set --duration 120 --replicas 2 --persistent ${persistent_storage_service}
 
 ## sservice group s1
-sservice --group s1 add --url http://localhost:7203
-sservice --group s1 add --url http://localhost:7204
-sservice --group s1 add --url http://localhost:7205
+sservice --group s1 add --url http://${host}:7203
+sservice --group s1 add --url http://${host}:7204
+sservice --group s1 add --url http://${host}:7205
 sservice --group s2 set --duration 120 --replicas 2 --persistent ${persistent_storage_service}
 
 ## sservice group s2
-sservice --group s2 add --url http://localhost:7201
-sservice --group s2 add --url http://localhost:7202
+sservice --group s2 add --url http://${host}:7201
+sservice --group s2 add --url http://${host}:7202
 sservice --group s2 set --duration 120 --replicas 1 --persistent ${persistent_storage_service}
 
 ## all sservices
-sservice --group all add --url http://localhost:7201
-sservice --group all add --url http://localhost:7202
-sservice --group all add --url http://localhost:7203
-sservice --group all add --url http://localhost:7204
-sservice --group all add --url http://localhost:7205
+sservice --group all add --url http://${host}:7201
+sservice --group all add --url http://${host}:7202
+sservice --group all add --url http://${host}:7203
+sservice --group all add --url http://${host}:7204
+sservice --group all add --url http://${host}:7205
 sservice --group all set --duration 3600 --replicas 3 --persistent ${persistent_storage_service}
 
 ## create some contracts
@@ -107,8 +107,8 @@ fi
 
 identity -n user2
 create -c mock-contract -s _mock-contract -r all -p all -e all -f ${save}/${contract2}.pdo
-send -f ${save}/${contract2}.pdo --wait inc_value -e http://localhost:7101
-send -f ${save}/${contract2}.pdo --wait inc_value -e http://localhost:7102
+send -f ${save}/${contract2}.pdo --wait inc_value -e http://${host}:7101
+send -f ${save}/${contract2}.pdo --wait inc_value -e http://${host}:7102
 send -f ${save}/${contract2}.pdo --wait inc_value -e random
 send -f ${save}/${contract2}.pdo --wait inc_value -e random
 send -f ${save}/${contract2}.pdo get_value -s value

--- a/docker/Dockerfile.pdo-build
+++ b/docker/Dockerfile.pdo-build
@@ -52,7 +52,7 @@
 #       PDO_LEDGER_URL properly configured ..
 #     - unset PDO_SPID PDO_SPID_API_KEY
 #     - call 'source /project/pdo/src/private-data-objects/build/common-config.sh'
-#     - run 'make -C /project/pdo/src/private-data-objects/build conf'
+#     - run 'make -C /project/pdo/src/private-data-objects/build config'
 #   - if you want to debug with gdb and alike, you also might want to add options
 #     '--security-opt seccomp=unconfined --security-opt apparmor=unconfined --cap-add=SYS_PTRACE '
 #   - for develooping based on source in host you might map source into container with an option
@@ -105,6 +105,8 @@ ENV PDO_LEDGER_TYPE=${PDO_LEDGER_TYPE}
 
 ARG PDO_LEDGER_KEY_ROOT=/project/pdo/build/opt/pdo/etc/keys/ledger
 ENV PDO_LEDGER_KEY_ROOT=${PDO_LEDGER_KEY_ROOT}
+
+ENV TERM=screen-256color
 
 RUN \
 # as we added now PDO source, also define PDO_SOURCE_ROOT to pdo env, ..

--- a/docker/Dockerfile.pdo-dev
+++ b/docker/Dockerfile.pdo-dev
@@ -69,6 +69,8 @@ ARG SGXSSL=2.10_1.1.1g
 
 ARG ADD_APT_PKGS=
 
+ENV TERM=screen-256color
+
 # Add necessary packages
 # TODO(xenial): we need to manually install protobuf 3 as xenial has v2
 # Note: ocamlbuild is required by PREREQ but does not exist for xenial. However, the relevant componets are part of 'ocaml' package, later ubuntu split up that package ...

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -110,7 +110,7 @@ test-env-setup-with-no-build:
 	   exec -T validator sawset proposal create --url http://rest-api:8008 --key /root/.sawtooth/keys/my_key.priv sawtooth.validator.transaction_families='[{"family": "intkey", "version": "1.0"}, {"family":"sawtooth_settings", "version":"1.0"}, {"family": "pdo_contract_enclave_registry", "version": "1.0"}, {"family":  "pdo_contract_instance_registry", "version": "1.0"}, {"family": "ccl_contract", "version": "1.0"}]'
 	if [ "$(SGX_MODE)" = "HW" ]; then \
 	   $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_STL) \
-	      exec -T pdo-build bash -c 'source /etc/bash.bashrc && export PDO_SGX_KEY_ROOT=/project/pdo/build/opt/pdo/etc/keys/sgx/ && unset PDO_SPID PDO_SPID_API_KEY PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && make -C /project/pdo/src/private-data-objects/build force-conf register'; \
+	      exec -T pdo-build bash -c 'source /etc/bash.bashrc && export PDO_SGX_KEY_ROOT=/project/pdo/build/opt/pdo/etc/keys/sgx/ && unset PDO_SPID PDO_SPID_API_KEY PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && make -C /project/pdo/src/private-data-objects/build force-config register'; \
 	fi
 
 test-env-setup-with-no-build-ccf-only:
@@ -140,7 +140,7 @@ test-with-no-build: test-env-setup-with-no-build
 	fi
 	# - run automated tests
 	$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_STL) \
-	   exec -T pdo-build bash -i -c "unset PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && make -C /project/pdo/src/private-data-objects/build force-conf && /project/pdo/src/private-data-objects/build/__tools__/run-tests.sh"
+	   exec -T pdo-build bash -i -c "unset PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && make -C /project/pdo/src/private-data-objects/build force-config && /project/pdo/src/private-data-objects/build/__tools__/run-tests.sh"
 	# - teardown
 	$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_STL) down
 
@@ -149,9 +149,9 @@ test-with-no-build-ccf: test-env-setup-with-no-build-ccf
 	@echo "Running PDO tests with CCF"
 	# the pdo container must add the ip address of the pdo-tp-ccf container to its no proxy list (if behind a proxy)
 	if [ ! -z "$(no_proxy)" ]; then \
-	   $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF)  exec -T pdo-build bash -i -c "source /set_no_proxy.sh && /project/pdo/build/opt/pdo/etc/keys/ledger/check-for-ccf-keys.sh && unset PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && make -C /project/pdo/src/private-data-objects/build force-conf && /project/pdo/src/private-data-objects/build/__tools__/run-tests.sh"; \
+	   $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF)  exec -T pdo-build bash -i -c "source /set_no_proxy.sh && /project/pdo/build/opt/pdo/etc/keys/ledger/check-for-ccf-keys.sh && unset PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && make -C /project/pdo/src/private-data-objects/build force-config && /project/pdo/src/private-data-objects/build/__tools__/run-tests.sh"; \
 	else \
-	   $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF)  exec -T pdo-build bash -i -c "/project/pdo/build/opt/pdo/etc/keys/ledger/check-for-ccf-keys.sh && unset PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && make -C /project/pdo/src/private-data-objects/build force-conf && /project/pdo/src/private-data-objects/build/__tools__/run-tests.sh"; \
+	   $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF)  exec -T pdo-build bash -i -c "/project/pdo/build/opt/pdo/etc/keys/ledger/check-for-ccf-keys.sh && unset PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && make -C /project/pdo/src/private-data-objects/build force-config && /project/pdo/src/private-data-objects/build/__tools__/run-tests.sh"; \
 	fi
 
 	# remove ccf keys from local folder

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -108,10 +108,8 @@ test-env-setup-with-no-build:
 	# - insitialize the ledger
 	$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_STL) \
 	   exec -T validator sawset proposal create --url http://rest-api:8008 --key /root/.sawtooth/keys/my_key.priv sawtooth.validator.transaction_families='[{"family": "intkey", "version": "1.0"}, {"family":"sawtooth_settings", "version":"1.0"}, {"family": "pdo_contract_enclave_registry", "version": "1.0"}, {"family":  "pdo_contract_instance_registry", "version": "1.0"}, {"family": "ccl_contract", "version": "1.0"}]'
-	if [ "$(SGX_MODE)" = "HW" ]; then \
-	   $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_STL) \
-	      exec -T pdo-build bash -c 'source /etc/bash.bashrc && export PDO_SGX_KEY_ROOT=/project/pdo/build/opt/pdo/etc/keys/sgx/ && unset PDO_SPID PDO_SPID_API_KEY PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && make -C /project/pdo/src/private-data-objects/build force-config register'; \
-	fi
+	$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_STL) \
+		exec -T pdo-build bash -c 'source /etc/bash.bashrc && export PDO_SGX_KEY_ROOT=/project/pdo/build/opt/pdo/etc/keys/sgx/ && unset PDO_SPID PDO_SPID_API_KEY PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && make -C /project/pdo/src/private-data-objects/build force-config register'
 
 test-env-setup-with-no-build-ccf-only:
 	# just to be on safe side, make sure environment is not still up (e.g.,from previous failed attempt)
@@ -125,10 +123,8 @@ test-env-setup-with-no-build-ccf:
 	-$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF) down
 	# - start services
 	$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF) up -d
-	if [ "$(SGX_MODE)" = "HW" ]; then \
-	   $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF) \
-	      exec -T pdo-build bash -c 'source /etc/bash.bashrc && export PDO_SGX_KEY_ROOT=/project/pdo/build/opt/pdo/etc/keys/sgx/ && unset PDO_SPID PDO_SPID_API_KEY PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && /project/pdo/build/opt/pdo/etc/keys/ledger/check-for-ccf-keys.sh && make -C /project/pdo/src/private-data-objects/build force-conf register'; \
-	fi
+	$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF) \
+		exec -T pdo-build bash -c 'source /etc/bash.bashrc && export PDO_SGX_KEY_ROOT=/project/pdo/build/opt/pdo/etc/keys/sgx/ && unset PDO_SPID PDO_SPID_API_KEY PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && /project/pdo/build/opt/pdo/etc/keys/ledger/check-for-ccf-keys.sh && make -C /project/pdo/src/private-data-objects/build force-config register'
 
 test-with-no-build: test-env-setup-with-no-build
 	# - run automated tests
@@ -140,7 +136,7 @@ test-with-no-build: test-env-setup-with-no-build
 	fi
 	# - run automated tests
 	$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_STL) \
-	   exec -T pdo-build bash -i -c "unset PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && make -C /project/pdo/src/private-data-objects/build force-config && /project/pdo/src/private-data-objects/build/__tools__/run-tests.sh"
+	   exec -T pdo-build bash -i -c "unset PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && /project/pdo/src/private-data-objects/build/__tools__/run-tests.sh"
 	# - teardown
 	$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_STL) down
 
@@ -149,9 +145,9 @@ test-with-no-build-ccf: test-env-setup-with-no-build-ccf
 	@echo "Running PDO tests with CCF"
 	# the pdo container must add the ip address of the pdo-tp-ccf container to its no proxy list (if behind a proxy)
 	if [ ! -z "$(no_proxy)" ]; then \
-	   $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF)  exec -T pdo-build bash -i -c "source /set_no_proxy.sh && /project/pdo/build/opt/pdo/etc/keys/ledger/check-for-ccf-keys.sh && unset PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && make -C /project/pdo/src/private-data-objects/build force-config && /project/pdo/src/private-data-objects/build/__tools__/run-tests.sh"; \
+	   $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF)  exec -T pdo-build bash -i -c "source /set_no_proxy.sh && /project/pdo/build/opt/pdo/etc/keys/ledger/check-for-ccf-keys.sh && unset PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && /project/pdo/src/private-data-objects/build/__tools__/run-tests.sh"; \
 	else \
-	   $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF)  exec -T pdo-build bash -i -c "/project/pdo/build/opt/pdo/etc/keys/ledger/check-for-ccf-keys.sh && unset PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && make -C /project/pdo/src/private-data-objects/build force-config && /project/pdo/src/private-data-objects/build/__tools__/run-tests.sh"; \
+	   $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF)  exec -T pdo-build bash -i -c "/project/pdo/build/opt/pdo/etc/keys/ledger/check-for-ccf-keys.sh && unset PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && /project/pdo/src/private-data-objects/build/__tools__/run-tests.sh"; \
 	fi
 
 	# remove ccf keys from local folder

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -140,19 +140,18 @@ test-with-no-build: test-env-setup-with-no-build
 	fi
 	# - run automated tests
 	$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_STL) \
-	   exec -T pdo-build bash -i -c /project/pdo/src/private-data-objects/build/__tools__/run-tests.sh
+	   exec -T pdo-build bash -i -c "unset PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && make -C /project/pdo/src/private-data-objects/build force-conf && /project/pdo/src/private-data-objects/build/__tools__/run-tests.sh"
 	# - teardown
 	$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_STL) down
-
 
 test-with-no-build-ccf: test-env-setup-with-no-build-ccf
 	# - run automated tests
 	@echo "Running PDO tests with CCF"
 	# the pdo container must add the ip address of the pdo-tp-ccf container to its no proxy list (if behind a proxy)
 	if [ ! -z "$(no_proxy)" ]; then \
-	   $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF)  exec -T pdo-build bash -i -c "source /set_no_proxy.sh && /project/pdo/build/opt/pdo/etc/keys/ledger/check-for-ccf-keys.sh && /project/pdo/src/private-data-objects/build/__tools__/run-tests.sh"; \
+	   $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF)  exec -T pdo-build bash -i -c "source /set_no_proxy.sh && /project/pdo/build/opt/pdo/etc/keys/ledger/check-for-ccf-keys.sh && unset PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && make -C /project/pdo/src/private-data-objects/build force-conf && /project/pdo/src/private-data-objects/build/__tools__/run-tests.sh"; \
 	else \
-	   $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF)  exec -T pdo-build bash -i -c "/project/pdo/build/opt/pdo/etc/keys/ledger/check-for-ccf-keys.sh && /project/pdo/src/private-data-objects/build/__tools__/run-tests.sh"; \
+	   $(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS_CCF)  exec -T pdo-build bash -i -c "/project/pdo/build/opt/pdo/etc/keys/ledger/check-for-ccf-keys.sh && unset PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && make -C /project/pdo/src/private-data-objects/build force-conf && /project/pdo/src/private-data-objects/build/__tools__/run-tests.sh"; \
 	fi
 
 	# remove ccf keys from local folder

--- a/docker/ccf-pdo.proxy.yaml
+++ b/docker/ccf-pdo.proxy.yaml
@@ -35,7 +35,7 @@ services:
     environment: #used during run time
       http_proxy: "${http_proxy}"
       https_proxy: "${https_proxy}"
-      no_proxy: "${no_proxy},pdo-tp-ccf,pdo-build"
+      no_proxy: "${no_proxy},pdo-tp-ccf,pdo-build,ccf-pdo-build"
 
   # PDO Transaction processor
   pdo-tp-ccf:
@@ -47,5 +47,4 @@ services:
     environment:
       http_proxy: "${http_proxy}"
       https_proxy: "${https_proxy}"
-      no_proxy: "${no_proxy},pdo-tp-ccf,pdo-build"
-
+      no_proxy: "${no_proxy},pdo-tp-ccf,pdo-build,ccf-pdo-build"

--- a/docker/ccf-pdo.yaml
+++ b/docker/ccf-pdo.yaml
@@ -64,6 +64,7 @@ services:
         echo "export no_proxy=\$${no_proxy},\`getent hosts pdo-tp-ccf | awk '{ print \$$1 }'\`" > /set_no_proxy.sh
         tail -f /dev/null
     volumes:
+      - ${PDO_SGX_KEY_ROOT:-./sgx/}:/project/pdo/build/opt/pdo/etc/keys/sgx/
       - ./ccf_keys/:/project/pdo/build/opt/pdo/etc/keys/ledger/
 
 

--- a/docker/ccf-pdo.yaml
+++ b/docker/ccf-pdo.yaml
@@ -13,9 +13,9 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-# This docker-compose file starts a complete end-to-end environment for PDO/CCF with 
+# This docker-compose file starts a complete end-to-end environment for PDO/CCF with
 # sgx in simulator mode. The code used are the main branch for pdo. For CCF,
-# we use version 1.0.19 
+# we use version 1.0.19
 #
 # To use, define the env host_ip (= host_ip_address) & do the following
 # - build base pdo-dev image (see docker/Dockerfile.pdo-dev for build-time options ..)
@@ -23,7 +23,7 @@
 # If you are behind proxy, ensure that proxy is defined in ~/.docker/config.json for the above command to work
 # - build docker-composed images (here and below with additional -f options as mentioned above)
 #    docker-compose -f ccf-pdo.yaml build
-# If you are behind proxy, use docker-compose -f ccf-pdo.yaml -f ccf-pdo.proxy.yaml build. 
+# If you are behind proxy, use docker-compose -f ccf-pdo.yaml -f ccf-pdo.proxy.yaml build.
 # ~/.docker/config.json does not work with docker-compose. Continue to add the ccf-pdo.proxy.yaml for the rest of the
 # docker-compose commands as well.
 # - start up enviroment. This will instantiate the ccf ledger as well

--- a/docker/ccf.proxy.yaml
+++ b/docker/ccf.proxy.yaml
@@ -35,4 +35,4 @@ services:
     environment:
       http_proxy: "${http_proxy}"
       https_proxy: "${https_proxy}"
-      no_proxy: "${no_proxy},pdo-tp-ccf,pdo-build,10.0.0.0/8,192.168.0.0/16,172.0.0.0/8"
+      no_proxy: "${no_proxy},pdo-tp-ccf,pdo-build,ccf-pdo-build,10.0.0.0/8,192.168.0.0/16,172.0.0.0/8"

--- a/docker/pdo.sgx.yaml
+++ b/docker/pdo.sgx.yaml
@@ -30,7 +30,7 @@
 #    export PDO_SGX_KEY_ROOT=/project/pdo/build/opt/pdo/etc/keys/sgx/
 #    unset PDO_SPID PDO_SPID_API_KEY
 #    source /project/pdo/src/private-data-objects/build/common-config.sh
-#    make -C /project/pdo/src/private-data-objects/build conf register
+#    make -C /project/pdo/src/private-data-objects/build config register
 
 version: "2.1"
 
@@ -48,4 +48,3 @@ services:
       - /var/run/aesmd:/var/run/aesmd
     devices:
       - ${SGX_DEVICE_PATH:-/dev/isgx}:${SGX_DEVICE_PATH:-/dev/isgx}
-

--- a/docker/pdo.sgx.yaml
+++ b/docker/pdo.sgx.yaml
@@ -44,7 +44,6 @@ services:
       args:
         SGX_MODE: HW
     volumes:
-      - ${PDO_SGX_KEY_ROOT:-./sgx/}:/project/pdo/build/opt/pdo/etc/keys/sgx/
       - /var/run/aesmd:/var/run/aesmd
     devices:
       - ${SGX_DEVICE_PATH:-/dev/isgx}:${SGX_DEVICE_PATH:-/dev/isgx}

--- a/docker/sawtooth-pdo.proxy.yaml
+++ b/docker/sawtooth-pdo.proxy.yaml
@@ -35,7 +35,7 @@ services:
     environment:
       http_proxy: "${http_proxy}"
       https_proxy: "${https_proxy}"
-      no_proxy: "${no_proxy},shell,rest-api,validator,settings-tp,pdo-tp,pdo-build"
+      no_proxy: "${no_proxy},shell,rest-api,validator,settings-tp,pdo-tp,pdo-build,sawtooth-pdo-build,pdo-sgx-build"
 
   # PDO Transaction processor
   pdo-tp:
@@ -47,28 +47,28 @@ services:
     environment:
       http_proxy: "${http_proxy}"
       https_proxy: "${https_proxy}"
-      no_proxy: "${no_proxy},shell,rest-api,validator,settings-tp,pdo-tp,pdo-build"
+      no_proxy: "${no_proxy},shell,rest-api,validator,settings-tp,pdo-tp,pdo-build,sawtooth-pdo-build,pdo-sgx-build"
 
   settings-tp:
     environment:
       http_proxy: "${http_proxy}"
       https_proxy: "${https_proxy}"
-      no_proxy: "${no_proxy},shell,rest-api,validator,settings-tp,pdo-tp,pdo-build"
+      no_proxy: "${no_proxy},shell,rest-api,validator,settings-tp,pdo-tp,pdo-build,sawtooth-pdo-build,pdo-sgx-build"
 
   validator:
     environment:
       http_proxy: "${http_proxy}"
       https_proxy: "${https_proxy}"
-      no_proxy: "${no_proxy},shell,rest-api,validator,settings-tp,pdo-tp,pdo-build"
+      no_proxy: "${no_proxy},shell,rest-api,validator,settings-tp,pdo-tp,pdo-build,sawtooth-pdo-build,pdo-sgx-build"
 
   rest-api:
     environment:
       http_proxy: "${http_proxy}"
       https_proxy: "${https_proxy}"
-      no_proxy: "${no_proxy},shell,rest-api,validator,settings-tp,pdo-tp,pdo-build"
+      no_proxy: "${no_proxy},shell,rest-api,validator,settings-tp,pdo-tp,pdo-build,sawtooth-pdo-build,pdo-sgx-build"
 
   shell:
     environment:
       http_proxy: "${http_proxy}"
       https_proxy: "${https_proxy}"
-      no_proxy: "${no_proxy},shell,rest-api,validator,settings-tp,pdo-tp,pdo-build"
+      no_proxy: "${no_proxy},shell,rest-api,validator,settings-tp,pdo-tp,pdo-build,sawtooth-pdo-build,pdo-sgx-build"

--- a/docker/sawtooth-pdo.yaml
+++ b/docker/sawtooth-pdo.yaml
@@ -16,7 +16,7 @@
 # This docker-compose file starts a complete end-to-end environment for PDO with sawtooth in default mode
 # and sgx in simulator mode. The code used are the main branches for pdo and sawtooth.  If you want to
 # build against non-standard gitrepos/braches, you can define the environment variables PDO_REPO_URL and
-# PDO_REPO_BRANCH to overwrite the defaults for PDO url/branch. 
+# PDO_REPO_BRANCH to overwrite the defaults for PDO url/branch.
 # This will not work if the repo requires authentication, e.g., git
 # with ssh, -- broader adoption of docker version 18.09+ (look for --secret/--ssh parameters) might change
 # this. However, to handle the common case of building and running run against your local workspace,
@@ -66,6 +66,7 @@ services:
         tail -f /dev/null \
         \""
     volumes:
+      - ${PDO_SGX_KEY_ROOT:-./sgx/}:/project/pdo/build/opt/pdo/etc/keys/sgx/
       - ./validator-keys/:/project/pdo/build/opt/pdo/etc/keys/ledger
 
   # PDO Transaction processor
@@ -141,4 +142,3 @@ services:
         \""
     volumes:
        - ./:/mnt/pdo
-


### PR DESCRIPTION
Three big changes in this PR:

1. Dropped the "count" parameter from the service start up script; a service instance will now start for each of the configuration files in the configuration directory. And... the configuration directory is a parameter to startup. That should make it possible to separate "test" configuration from a "production" configuration.
2. Changed all the hard coded localhost references in the configuration files to PDO_HOSTNAME. We have the variable. Its supposed to be used. Now it is used.  And... the configuration files can be placed in an alternate directory. Again, goal is to simplify configuring a set of services for "production".
3. Fixed up a bunch of problems that popped up in docker tests. Turns out that the way we had the dockerfiles the hardcoded localhost was NECESSARY to test correctly. Ughh... Fixed that. Not pretty, but it work.