### PR TITLE
Make CCF HW mode work even with a proxy

### DIFF
--- a/ccf_transaction_processor/scripts/start_cchost.sh
+++ b/ccf_transaction_processor/scripts/start_cchost.sh
@@ -23,5 +23,10 @@ EFILE="${F_SERVICEHOME}/logs/error.log"
 OFILE="${F_SERVICEHOME}/logs/output.log"
 
 cd ${F_SERVICEHOME}/run
-${CCHOST} --config ${F_SERVICEHOME}/etc/cchost.toml --node-pid-file ${F_SERVICEHOME}/run/cchost.pid > $OFILE 2> $EFILE &
+# Notes:
+# - The dnsname for CCF is necessary for adding an alternative subject name to the node certificate.
+#   This allows clients to connect to, and authenticate correctly, the CCF node
+# - The dnsname is assumed to be the same as the one used in the ledger url (or PDO_LEDGER_URL),
+#   e.g., http://<dnsname>:6600
+${CCHOST} --san dNSName:${PDO_HOSTNAME:-${HOSTNAME}} --config ${F_SERVICEHOME}/etc/cchost.toml --node-pid-file ${F_SERVICEHOME}/run/cchost.pid > $OFILE 2> $EFILE &
 echo $! > ${F_SERVICEHOME}/run/cchost.pid

--- a/ccf_transaction_processor/scripts/utils.py
+++ b/ccf_transaction_processor/scripts/utils.py
@@ -17,7 +17,6 @@ utils.py -- common utility routines useful for deploying CCF based pdo ledger
 """
 
 import os
-import socket
 from urllib.parse import urlparse
 
 __all__ = [
@@ -28,14 +27,12 @@ def parse_ledger_url(config = None):
     """Parse Ledger URL into host & port"""
 
     if config:
-        (hostname, port) = config["rpc-address"].split(':')
-        host = socket.gethostbyname(hostname)
+        (host, port) = config["rpc-address"].split(':')
         return host, port
 
     if os.environ.get("PDO_LEDGER_URL") is not None:
        url =  os.environ.get("PDO_LEDGER_URL")
-       (hostname, port) = urlparse(url).netloc.split(':')
-       host = socket.gethostbyname(hostname)
+       (host, port) = urlparse(url).netloc.split(':')
        return host, port
 
     raise Exception("Insufficient info to parse ledger url")

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -94,6 +94,13 @@ test-env-setup-with-no-build:
 	-$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS) down
 	# - start services
 	$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS) up -d
+	# Before registration, it must be ensured that CCF is up and configured.
+	# Otherwise, the registration can encounter two possible scenarios:
+	# 1) CCF is not up, so the registration times out
+	# 2) CCF is up but not configured, so the registration fails with "not a known member"
+	# A wait of a few seconds appears to be enough.
+	@echo "Waiting a few seconds for CCF to be up and configured..."
+	sleep 20
 	$(DOCKER_COMPOSE_COMMAND) $(DOCKER_COMPOSE_OPTS) \
 		exec -T pdo-build bash -c 'source /etc/bash.bashrc && export PDO_SGX_KEY_ROOT=/project/pdo/build/opt/pdo/etc/keys/sgx/ && unset PDO_SPID PDO_SPID_API_KEY PDO_HOSTNAME && source /project/pdo/src/private-data-objects/build/common-config.sh && /project/pdo/build/opt/pdo/etc/keys/ledger/check-for-ccf-keys.sh && make -C /project/pdo/src/private-data-objects/build force-config register'
 

--- a/docker/ccf-pdo.proxy.yaml
+++ b/docker/ccf-pdo.proxy.yaml
@@ -35,7 +35,7 @@ services:
     environment: #used during run time
       http_proxy: "${http_proxy}"
       https_proxy: "${https_proxy}"
-      no_proxy: "${no_proxy},pdo-tp-ccf,pdo-build,ccf-pdo-build"
+      no_proxy: "${no_proxy},pdo-tp-ccf,pdo-build,ccf-pdo-build,172.0.0.0/8,192.0.0.0/8"
 
   # PDO Transaction processor
   pdo-tp-ccf:
@@ -47,4 +47,4 @@ services:
     environment:
       http_proxy: "${http_proxy}"
       https_proxy: "${https_proxy}"
-      no_proxy: "${no_proxy},pdo-tp-ccf,pdo-build,ccf-pdo-build"
+      no_proxy: "${no_proxy},pdo-tp-ccf,pdo-build,ccf-pdo-build,172.0.0.0/8,192.0.0.0/8"

--- a/python/pdo/submitter/ccf/ccf_submitter.py
+++ b/python/pdo/submitter/ccf/ccf_submitter.py
@@ -18,7 +18,6 @@ import logging
 import time
 import os
 import sys
-import socket
 
 from ccf.clients import CCFClient
 from urllib.parse import urlparse
@@ -114,8 +113,7 @@ class CCFSubmitter(sub.Submitter):
 
         try:
             parsed_url = urlparse(self.url)
-            host, port = parsed_url.netloc.split(':')
-            self.host = socket.gethostbyname(host) # convert host name to IP address
+            self.host, port = parsed_url.netloc.split(':')
             self.port = int(port)
             self.endpoint = "{0}:{1}".format(self.host, self.port)
         except Exception as e:


### PR DESCRIPTION
The title is self-explanatory and the PR depends on #406.

Explanation.
(short)
CCF can be configured with a domain name, and the PDO legacy proxy handling works.

(long)
CCF is currently configured to use IPs. The main implication is that CCF generates certificates where x509 Subject Alternative Name is an IP address.
```
X509v3 Subject Alternative Name:
                IP Address:192.168.192.2
```
Because of that, CCF clients have to use the IP address to contact it, otherwise the connection fails with an SSL error.

The PDO legacy proxy handling does not work in this case. The `no_proxy` variables are set up only with the `pdo-tp-ccf` domain name -- since clients are supposed to use the `pdo-tp-ccf:6600` ledger url. However, using the URL as-is would not work, as explained above, because the hostname does not match the certificate subject. For this reason, clients first resolve the hostname into the IP address, and then contact CCF.

Fortunately, CCF can be configured with a domain name, as indicated in the [documentation](https://github.com/microsoft/CCF/blob/ccf-1.0.19/doc/operations/start_network.rst).
This just involves adding an argument (the domain name) in the execution of the `cchost` script.
As a result, the domain name is added to the Subject Alternative Name of the node certificate.
```
X509v3 Subject Alternative Name:
                DNS:pdo-tp-ccf, IP Address:192.168.192.2
```
Due this change, clients do not need to resolve the domain name in an IP address and the PDO legacy proxy handling is already configured to make the connections work as intended.

(a separate timing issue)
A final note regarding a timing issue in the registration step, which is solved by waiting a few seconds.
The PDO docker build (the makefile), at some point starts CCF and immediately triggers the registration.
This has two problems -- which surprisingly were not triggered during the HW mode test without a proxy:
1) if CCF is not up, the registration fails because CCF is unreachable.
2) if CCF is up but not configured, the registration fails because the client is not a known member.
Adding a long-enough sleep before the registration seems to provide a satisfactory mitigation to the issue.
