### PR TITLE
Clean up 18.04 references

### DIFF
--- a/common/interpreter/wawaka_wasm/README.md
+++ b/common/interpreter/wawaka_wasm/README.md
@@ -157,61 +157,6 @@ make benchmark
 
 Go to [contracts/wawaka/benchmarks](../../../contracts/wawaka/benchmarks/README.md), for more details.
 
-## AoT-Compiled WASM
-
-Running ahead-of-time compiled WASM modules
-can significantly improve the performance of PDO contracts
-to near-native speeds. In internal benchmarks, we measured
-up to a 29x execution time speedup over interpreted WASM
-for some compute-intensive workloads when compiled ahead of
-time.
-
-By default, wawaka will be built for interpreted wasm contracts.
-To enable ahead-of-time (AoT) compiled WASM contracts, set the
-environment variable `PDO_INTERPRETER`:
-
-```bash
-export PDO_INTERPRETER=wawaka-aot
-```
-
-### AoT compiler setup
-
-To download the LLVM dependencies, run:
-
-```bash
-LLVM_VERSION=10.0.0
-LLVM_REPO=https://github.com/llvm/llvm-project/releases/download/llvmorg-$(LLVM_VERSION)
-LLVM_TAR=clang+llvm-$(LLVM_VERSION)-x86_64-linux-gnu-ubuntu-18.04
-LLVM_BIN=$(WASM_SRC)/core/deps/llvm/build/llvm/bin/llvm-lto # proxy for llvm dependency
-
-cd $(WASM_SRC)/core/deps && mkdir -p llvm/build/
-wget -q $(LLVM_REPO)/$(LLVM_TAR).tar.xz
-tar -xf $(LLVM_TAR).tar.xz -C llvm/build/
-cd llvm/build/ && mv $(LLVM_TAR) llvm
-```
-
-The following steps then build the `wamrc` AoT compiler that
-is shipped with WAMR:
-
-```bash
-cd $(WASM_SRC)/wamr-compiler
-mkdir -p build
-cd build
-cmake .. && make
-```
-
-### Building AoT Contracts
-
-To build an AoT contract for wawaka, run:
-
-```bash
-cd ${WASM_SRC}/wamr-compiler/build/
-./wamrc -sgx --format=aot -o <contract code file> <contract bytecode file>
-```
-
-For more options to run `wamrc`, see the
-[documentation](https://github.com/bytecodealliance/wasm-micro-runtime/blob/main/doc/build_wasm_app.md#compile-wasm-to-aot-module).
-
 ## Basics of a Contract ##
 
 Note that compilation into WASM that will run in the contract enclave can be somewhat tricky. Specifically, all symbols whether used or not must be bound. The wawaka interpreter will fail if it attempts to load WASM code with unbound symbols.

--- a/docker/Dockerfile.pdo-dev
+++ b/docker/Dockerfile.pdo-dev
@@ -17,8 +17,8 @@
 #   Builds the environment with all prerequistes needed to build Private Data Objects.
 #
 #  Configuration (build) paramaters
-#  - ubuntu version to use: 	  UBUNTU_VERSION (default: 18.04)
-#  - ubuntu name to use: 	  UBUNTU_NAME (default: bionic)
+#  - ubuntu version to use: 	  UBUNTU_VERSION (default: 20.04)
+#  - ubuntu name to use: 	  UBUNTU_NAME (default: focal)
 #  - sgx sdk/psw version: 	  SGX (default: 2.15.1)
 #  - openssl version: 		  OPENSSL (default: 1.1.1g)
 #  - sgxssl version: 		  SGXSSL  (default: 2.10_1.1.1g)
@@ -26,8 +26,8 @@
 
 # Build:
 #   $ docker build docker -f docker/Dockerfile.pdo-dev -t pdo-dev
-#   - if you want to build with different version than 18.04/bionic, say 20.04/focal,
-#     add --build-arg UBUNTU_VERSION=18.04  --build-arg UBUNTU_NAME=focal
+#   - if you want to build with a different version,
+#     add --build-arg UBUNTU_VERSION=<version>  --build-arg UBUNTU_NAME=<name>
 #   - if behind a proxy, make sure you've configured ~/.docker/config.json with your proxy setting
 #     and the docker daemon itself also has the proxy properly configured, for systemd based hosts
 #     like ubuntu see https://docs.docker.com/config/daemon/systemd/#httphttps-proxy
@@ -51,11 +51,7 @@
 ARG UBUNTU_VERSION=20.04
 ARG UBUNTU_NAME=focal
 # NOTE:
-# - unfortunately, we do need both name (for repo) and version (for sgx directories), only docker image supports both ..
-#   18.04 <-> bionic, 20.04 <-> focal
-# - right now, full sgx support exists only for bionic;
-#   xenial (16.04) has support only PSW but not SDK;
-#   support for focal is still in the making but hopefully will exist soon...
+# - we do need both name (for repo) and version (for sgx directories), only docker image supports both ..
 
 FROM ubuntu:${UBUNTU_VERSION}
 
@@ -75,7 +71,7 @@ ENV TERM=screen-256color
 # Note: ocamlbuild is required by PREREQ but does not exist for xenial. However, the relevant componets are part of 'ocaml' package, later ubuntu split up that package ...
 RUN apt-get update \
  && DEBIAN_FRONTEND="noninteractive" \
-  # above makes sure any install of 'tzdata' or alike (as e.g., pulled in via ubuntu 20.04) does not hang ...
+  # above makes sure any install of 'tzdata' or alike does not hang ...
   apt-get install -y -q\
     autoconf \
     automake \
@@ -167,8 +163,7 @@ RUN SGX_SDK_BIN_REPO=https://download.01.org/intel-sgx/sgx-linux/${SGX}/distro/u
   && echo ". /opt/intel/sgxsdk/environment" >> /etc/profile.d/pdo.sh
 
 # LVI mitigations, needed to compile sgxssl, requires a
-#   recent version of binutils (>= 2.32). Ubuntu 18.04 only
-#   has 2.30 but Intel ships binary distro for 2.32.51.20190719
+#   recent version of binutils (>= 2.32).
 RUN [ "$UBUNTU_VERSION" = "20.04" ] \
   && SGX_SDK_BINUTILS_REPO=https://download.01.org/intel-sgx/sgx-linux/${SGX} \
   && SGX_SDK_BINUTILS_FILE=$(cd /tmp; wget --spider --recursive --level=1 --no-parent ${SGX_SDK_BINUTILS_REPO} 2>&1 | perl  -ne 'if (m|'${SGX_SDK_BINUTILS_REPO}'/(as.ld.objdump.*)|) { print "$1\n"; }') \

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,7 +6,7 @@ https://creativecommons.org/licenses/by/4.0/
 # Overview
 
 This directory contains configurations to run PDO with docker and docker-compose.
-This allows you to develop easily on non-ubuntu 18.04/20.04 machines
+This allows you to develop easily on other machines
 without "polluting" your install.  Additionally, it also enables easy
 end-to-end setups with a local ledger and automated end-to-end tests.
 
@@ -16,7 +16,7 @@ end-to-end setups with a local ledger and automated end-to-end tests.
 ## Installation of dependencies
 
 As prerequisite, you will need docker and docker-compose installed.
-On Ubuntu 18.04/20.04, this simply means running:
+This simply means running:
 ```bash
 	sudo apt install docker-compose
 ```
@@ -25,7 +25,7 @@ On Ubuntu 18.04/20.04, this simply means running:
 
 If you are behind a proxy, there are a few more things to do to configure docker.
 See [docker docu](https://docs.docker.com/config/daemon/systemd/#httphttps-proxy)
-for more info. Assumming you run Ubuntu 18.04 or 20.04 and have the `http_proxy`, `https_proxy`
+for more info. Assumming you run Ubuntu 20.04 and have the `http_proxy`, `https_proxy`
 and `no_proxy` environment variables defined, it essentially means:
 ```bash
   mkdir /etc/systemd/system/docker.service.d
@@ -59,8 +59,7 @@ EOM
 
 If your system runs systemd-resolved (which is now default for
 ubuntu), make sure you are running a version 18.09 of docker or
-greater. Recently refreshed versions of ubuntu 18.04 should meet this
-condition. If you have to use an older version of docker, you also
+greater. If you have to use an older version of docker, you also
 might have to run
 ```bash
   ln -sf ../run/systemd/resolve/resolv.conf /etc/resolv.conf # originally was ../run/systemd/resolve/stub-resolv.conf

--- a/docker/ccf-pdo.proxy.yaml
+++ b/docker/ccf-pdo.proxy.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-# Use this docker-compose file together with sawtoth-pdo.yaml (and other extensions)
+# Use this docker-compose file together with the CCF yaml file
 # if you run behind a proxy and have the corresponding environment variables http_proxy
 # https_proxy and no_proxy defined
 # Note: for vanilla docker >=17.07 you can define proxy in ~/.docker/config.json

--- a/docker/ccf.proxy.yaml
+++ b/docker/ccf.proxy.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-# Use this docker-compose file together with sawtoth-pdo.yaml (and other extensions)
+# Use this docker-compose file together with the CCF yaml file
 # if you run behind a proxy and have the corresponding environment variables http_proxy
 # https_proxy and no_proxy defined
 # Note: for vanilla docker >=17.07 you can define proxy in ~/.docker/config.json

--- a/docs/install.md
+++ b/docs/install.md
@@ -160,7 +160,7 @@ The following commands will download and install the SDK driver version
 ```bash
 UBUNTU_VERS=20.04
 DRIVER_REPO=https://download.01.org/intel-sgx/sgx-linux/2.15.1/distro/ubuntu${UBUNTU_VERS}-server
-DRIVER_FILE=ssgx_linux_x64_driver_2.11.0_2d2b795.bin
+DRIVER_FILE=sgx_linux_x64_driver_2.11.0_2d2b795.bin
 
 wget ${DRIVER_REPO}/${DRIVER_FILE} -P /tmp
 chmod a+x /tmp/${DRIVER_FILE}

--- a/docs/install.md
+++ b/docs/install.md
@@ -30,12 +30,7 @@ The required host-system configuration for Private Data Objects is to
 separate the Private Data Objects components from the ledger components.
 
 Private Data Objects services (specifically the enclave service, provisioning
-service, and the client) can be run on Ubuntu 18.04 and Ubuntu 20.04
-(server or client).
-PDO also has been tested on Ubuntu 16.04 and 17.10. However, for these
-configuration not all standard libraries match the required versions and
-you will have to, e.g., install by hand an openssl version >= 1.1.0g
-(the default libssl-dev on these platforms is still based on 1.0.2).
+service, and the client) can be run on Ubuntu 20.04 (server or client).
 
 If you want to run PDO on a single physical host, either PDO or the
 ledger will have to run in a separate VM or container. In particular, to run
@@ -138,10 +133,10 @@ different drivers.
 ##### HW with support for DCAP / Flexible Launch Control (FLC)
 <!-- DCAP kernel driver installation -->
 The following commands will download and install the driver version 1.41 of
-the DCAP SGX kernel driver (for Ubuntu 18.04 server):
+the DCAP SGX kernel driver:
 
 ```bash
-UBUNTU_VERS=18.04 or 20.04
+UBUNTU_VERS=20.04
 DRIVER_REPO=https://download.01.org/intel-sgx/sgx-linux/2.15.1/distro/ubuntu${UBUNTU_VERS}-server/
 DRIVER_FILE=sgx_linux_x64_driver_1.41.bin
 
@@ -153,6 +148,8 @@ Note:
 - the DCAP driver will _not_ work if your hardware does not supports FLC (Flexible Launch Control).
 - the DCAP driver supports DKMS, so contrary to the sdk driver, you will _not_ have to re-install
   the kernel driver after each kernel update.
+- starting with the 5.11 version, the linux kernel comes with DCAP support; however, this is limited
+  to FLC-capable platforms and does not support EPID attestations.
 
 
 ##### HW which does not support Flexible Launch Control (FLC)
@@ -161,7 +158,7 @@ Note:
 The following commands will download and install the SDK driver version
 2.11 of the SGX kernel driver:
 ```bash
-UBUNTU_VERS=18.04 or 20.04
+UBUNTU_VERS=20.04
 DRIVER_REPO=https://download.01.org/intel-sgx/sgx-linux/2.15.1/distro/ubuntu${UBUNTU_VERS}-server
 DRIVER_FILE=ssgx_linux_x64_driver_2.11.0_2d2b795.bin
 


### PR DESCRIPTION
This PR addresses #381 .

A couple of references still persist in the proxy yaml files.
As detailed in those comments, once we improve the proxy handling, those files should become obsolete and be removed.