### PR TITLE
Allow replication service to limit the duration of cached blocks

### DIFF
--- a/build/template/sservice.toml
+++ b/build/template/sservice.toml
@@ -22,6 +22,7 @@ HttpPort = ${{7200+_count_}}
 Host = "${host}"
 BlockStore = "${data}/${identity}.mdb"
 GarbageCollectionInterval = 10
+MaxDuration = 0
 
 # --------------------------------------------------
 # Logging -- configuration of service logging

--- a/sservice/etc/sample_sservice.toml
+++ b/sservice/etc/sample_sservice.toml
@@ -30,6 +30,11 @@ BlockStore = "${data}/${identity}.mdb"
 # don't garbage collect at all
 GarbageCollectionInterval = 10
 
+# maximum duration that the storage service will
+# commit to for a specific block; 0 indicates that
+# there is no maximum
+MaxDuration = 0
+
 # --------------------------------------------------
 # Logging -- configuration of service logging
 # --------------------------------------------------

--- a/sservice/pdo/sservice/scripts/SServiceCLI.py
+++ b/sservice/pdo/sservice/scripts/SServiceCLI.py
@@ -223,6 +223,7 @@ def Main() :
     parser.add_argument('--data-dir', help='Path for storing generated files', type=str)
 
     parser.add_argument('--gc-interval', help='Number of seconds between garbage collection', type=int)
+    parser.add_argument('--max-duration', help='Maximum number of seconds to store a block', type=int)
     parser.add_argument('--block-store', help='Name of the file where blocks are stored', type=str)
     parser.add_argument('--create', help='Create the blockstore if it does not exist', action='store_true')
     parser.add_argument('--logfile', help='Name of the log file, __screen__ for standard output', type=str)
@@ -293,6 +294,9 @@ def Main() :
 
     if options.gc_interval :
         config['StorageService']['GarbageCollectionInterval'] = options.gc_interval
+
+    if options.max_duration :
+        config['StorageService']['MaxDuration'] = options.max_duration
 
     # GO!
     LocalMain(config)

--- a/sservice/pdo/sservice/wsgi/info.py
+++ b/sservice/pdo/sservice/wsgi/info.py
@@ -32,12 +32,18 @@ logger = logging.getLogger(__name__)
 class InfoApp(object) :
     def __init__(self, config, service_keys) :
         self.service_keys = service_keys
+        self.gc_interval = config['StorageService'].get('GarbageCollectionInterval', 0)
+        self.max_duration = config['StorageService'].get('MaxDuration', 0)
 
     def __call__(self, environ, start_response) :
         """Return blockstore information
         """
         try :
-            response = {'verifying_key' : self.service_keys.verifying_key }
+            response = {}
+            response['verifying_key'] = self.service_keys.verifying_key
+            response['gc_interval'] = self.gc_interval
+            response['max_duration'] = self.max_duration
+
             result = json.dumps(response).encode()
 
         except Exception as e :

--- a/sservice/pdo/sservice/wsgi/store_blocks.py
+++ b/sservice/pdo/sservice/wsgi/store_blocks.py
@@ -37,6 +37,7 @@ class StoreBlocksApp(object) :
     def __init__(self, config, block_store, service_keys) :
         self.block_store = block_store
         self.service_keys = service_keys
+        self.max_duration = config['StorageService'].get('MaxDuration', 0)
 
     ## -----------------------------------------------------------------
     def block_data_iterator(self, request) :
@@ -70,6 +71,9 @@ class StoreBlocksApp(object) :
             logger.exception('StoreBlocksApp')
             return ErrorResponse(start_response, "unknown exception while unpacking block store request")
 
+        if self.max_duration > 0 :
+            duration = min(duration, self.max_duration)
+
         try :
             # block_list will be an iterator for blocks in the request, this prevents
             # the need to make a copy of the data blocks
@@ -95,6 +99,7 @@ class StoreBlocksApp(object) :
         result = dict()
         result['signature'] = signature
         result['block_ids'] = list(map(encoding_fn, block_hashes))
+        result['duration'] = duration
 
         try :
             result = json.dumps(result).encode('utf8')


### PR DESCRIPTION
The current policy for storage services is that the client determines the length of time a block will be stored. This is rather unrealistic. This makes the maximum duration a configuration parameter in the storage service and enforces the limit. The default value of 0 for the duration perserves the current behavior (the client determines the length of time the storage service will hold the block).

Note that this will require some adaptation when the replication policy is enforced by the ledger.

Also note that the automated tests are insufficient for testing at this point. The simplest test is to edit the test configuration files for sservice[2-5].toml and set the garbage collect interval to 1 and the max duration to 1, then run the services test.