### PR TITLE
Update for OpenSSL 3.x, SGXSSL/SGXSDK 2.21

### DIFF
--- a/build/python_requirements.txt
+++ b/build/python_requirements.txt
@@ -14,3 +14,4 @@ Twisted>=22.10.0
 urllib3>=1.26.14
 ccf==1.0.19
 colorama>=0.4.6
+zope.interface>=6.0

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -45,7 +45,7 @@ DOCKER_BUILDARGS += --build-arg PDO_HOSTNAME=$(PDO_HOSTNAME)
 DOCKER_BUILDARGS += --build-arg PDO_LEDGER_URL=$(PDO_LEDGER_URL)
 DOCKER_BUILDARGS += --build-arg UID=$(PDO_USER_UID)
 DOCKER_BUILDARGS += --build-arg GID=$(PDO_GROUP_UID)
-DOCKER_ARGS = --progress=plain $(DOCKER_BUILDARGS)
+DOCKER_ARGS = $(DOCKER_BUILDARGS)
 
 IMAGES=base client services_base services ccf_base ccf
 

--- a/docker/pdo_services_base.dockerfile
+++ b/docker/pdo_services_base.dockerfile
@@ -19,9 +19,9 @@ FROM pdo_base
 ARG UBUNTU_VERSION=20.04
 ARG UBUNTU_NAME=focal
 
-ARG SGX=2.15.1
-ARG OPENSSL=1.1.1g
-ARG SGXSSL=2.10_1.1.1g
+ARG SGX=2.21
+ARG OPENSSL=3.0.10
+ARG SGXSSL=3.0-rc2
 
 ARG SGX_MODE SIM
 ENV SGX_MODE $SGX_MODE
@@ -77,10 +77,10 @@ ENV PATH="/opt/intel/sgxsdk.extras/external/toolset/ubuntu${UBUNTU_VERSION}:${PA
 # -----------------------------------------------------------------
 WORKDIR /tmp
 RUN . /opt/intel/sgxsdk/environment \
-    && git clone --depth 1 --branch lin_${SGXSSL} 'https://github.com/intel/intel-sgx-ssl.git' \
+    && git clone --depth 1 --branch ${SGXSSL} 'https://github.com/intel/intel-sgx-ssl.git' \
     && wget -q -P /tmp/intel-sgx-ssl/openssl_source https://www.openssl.org/source/openssl-${OPENSSL}.tar.gz \
     && cd /tmp/intel-sgx-ssl/Linux \
-    && bash -c "make SGX_MODE=SIM DESTDIR=/opt/intel/sgxssl VERBOSE=0 all &> /dev/null" \
+    && bash -c "make SGX_MODE=SIM NO_THREADS=1 DESTDIR=/opt/intel/sgxssl VERBOSE=0 all &> /dev/null" \
     && make install \
     && make clean \
     && rm -rf /tmp/intel-sgx-ssl

--- a/docs/host_install.md
+++ b/docs/host_install.md
@@ -60,17 +60,17 @@ in `/etc/aesmd.confg` and restart aesmd with `systemctl restart aesmd.
 
 ## Install the SGX SDK
 
-Private Data Objects has been tested with version 2.15.1 of the SGX
+Private Data Objects has been tested with version 2.21 of the SGX
 SDK. You can download prebuilt binaries for the SDK and kernel drivers
-from [01.org](https://download.01.org/intel-sgx/sgx-linux/2.15.1/distro/ubuntu20.04-server/).
+from [01.org](https://download.01.org/intel-sgx/sgx-linux/2.21/distro/ubuntu20.04-server/).
 
-The following commands will download and install version 2.15.1 of the SGX
+The following commands will download and install version 2.21 of the SGX
 SDK. When asked for the installation directory, we suggest that you install
 the SDK into the directory `/opt/intel`.
 
 ```bash
-DRIVER_REPO=https://download.01.org/intel-sgx/sgx-linux/2.15.1/distro/ubuntu20.04-server/
-SDK_FILE=sgx_linux_x64_sdk_2.15.101.1.bin
+DRIVER_REPO=https://download.01.org/intel-sgx/sgx-linux/2.21/distro/ubuntu20.04-server/
+SDK_FILE=sgx_linux_x64_sdk_2.21.100.1.bin
 
 wget ${DRIVER_REPO}/${SDK_FILE} -P /tmp
 chmod a+x /tmp/${SDK_FILE}
@@ -101,7 +101,7 @@ that contain the necessary LVI mitigations. The following
 commands will download and install these binaries:
 
 ```bash
-wget "https://download.01.org/intel-sgx/sgx-linux/2.15.1/as.ld.objdump.r4.tar.gz" -P /tmp
+wget "https://download.01.org/intel-sgx/sgx-linux/2.21/as.ld.objdump.r4.tar.gz" -P /tmp
 sudo mkdir /opt/intel/sgxsdk.extras
 sudo tar -xzf /tmp/as.ld.objdump.r4.tar.gz -C /opt/intel/sgxsdk.extras
 export PATH=/opt/intel/sgxsdk.extras/external/toolset/ubuntu20.04:${PATH}
@@ -110,13 +110,13 @@ export PATH=/opt/intel/sgxsdk.extras/external/toolset/ubuntu20.04:${PATH}
 ## Build and Install SGX SSL
 
 SGX OpenSSL is a compilation of OpenSSL specifically for use within SGX
-enclaves. We have tested PDO with SGX SSL version `lin_2.10_1.1.1g`
+enclaves. We have tested PDO with SGX SSL version `3.0-rc2`
 
 Detailed instructions for building and installing SGX SSL is available
 from the
 [Intel SGX SSL github repository](https://github.com/intel/intel-sgx-ssl).
 
-Follow these steps to compile and install version `lin_2.10_1.1.1g`:
+Follow these steps to compile and install version `3.0-rc2`:
 
 - Ensure you have the SGX SDK environment variables activated:
 ```bash
@@ -128,11 +128,11 @@ source /opt/intel/sgxsdk/environment
 git clone 'https://github.com/intel/intel-sgx-ssl.git'
 ```
 
-- Check out the recommended version (`lin_2.10_1.1.1g`):
+- Check out the recommended version (`3.0-rc2`):
 
 ```bash
 cd intel-sgx-ssl
-git checkout lin_2.10_1.1.1g
+git checkout 3.0-rc2
 ```
 
 - Download the OpenSSL source package that will form the base of this
@@ -140,7 +140,7 @@ SGX SSL install:
 
 ```bash
 cd openssl_source
-wget 'https://www.openssl.org/source/openssl-1.1.1g.tar.gz'
+wget 'https://www.openssl.org/source/openssl-3.0.10.tar.gz'
 cd ..
 ```
 
@@ -152,8 +152,8 @@ mode you must have installed the [SGX kernel driver](install.md).
 - Compile and install the SGX SSL project.
 ```bash
 cd Linux
-make all
-sudo make DESTDIR=/opt/intel/sgxssl install
+make SGX_MODE=${SGX_MODE} NO_THREADS=1 DESTDIR=/opt/intel/sgxssl all
+sudo make install
 ```
 
 - Export the `SGX_SSL` environment variable to enable the build

--- a/docs/install.md
+++ b/docs/install.md
@@ -137,7 +137,7 @@ the DCAP SGX kernel driver:
 
 ```bash
 UBUNTU_VERS=20.04
-DRIVER_REPO=https://download.01.org/intel-sgx/sgx-linux/2.15.1/distro/ubuntu${UBUNTU_VERS}-server/
+DRIVER_REPO=https://download.01.org/intel-sgx/sgx-linux/2.21/distro/ubuntu${UBUNTU_VERS}-server
 DRIVER_FILE=sgx_linux_x64_driver_1.41.bin
 
 wget ${DRIVER_REPO}/${DRIVER_FILE} -P /tmp
@@ -159,8 +159,8 @@ The following commands will download and install the SDK driver version
 2.11 of the SGX kernel driver:
 ```bash
 UBUNTU_VERS=20.04
-DRIVER_REPO=https://download.01.org/intel-sgx/sgx-linux/2.15.1/distro/ubuntu${UBUNTU_VERS}-server
-DRIVER_FILE=sgx_linux_x64_driver_2.11.0_2d2b795.bin
+DRIVER_REPO=https://download.01.org/intel-sgx/sgx-linux/2.21/distro/ubuntu${UBUNTU_VERS}-server
+DRIVER_FILE=sgx_linux_x64_driver_2.11.54c9c4c.bin
 
 wget ${DRIVER_REPO}/${DRIVER_FILE} -P /tmp
 chmod a+x /tmp/${DRIVER_FILE}

--- a/eservice/lib/libpdo_enclave/enclave.edl
+++ b/eservice/lib/libpdo_enclave/enclave.edl
@@ -21,4 +21,3 @@ enclave {
     from "contract.edl" import *;
     from "block_store.edl" import *;
 };
-

--- a/pservice/lib/libpdo_enclave/enclave.edl
+++ b/pservice/lib/libpdo_enclave/enclave.edl
@@ -19,4 +19,3 @@ enclave {
     from "base.edl" import *;
     from "secret.edl" import *;
 };
-


### PR DESCRIPTION
Update for OpenSSL 3.x. SGXSSL is still RC. Update when the final release is available.