### PR TITLE
fix broken twisted dependencies

### DIFF
--- a/eservice/setup.py
+++ b/eservice/setup.py
@@ -160,13 +160,6 @@ setup(name='pdo_eservice',
       url = 'http://www.intel.com',
       packages = find_packages(exclude='./eservice'),
       namespace_packages=['pdo'],
-      install_requires = [
-          'colorlog',
-          'lmdb',
-          'requests',
-          'toml',
-          'twisted'
-          ],
       ext_modules = [
           enclave_module
       ],

--- a/pservice/setup.py
+++ b/pservice/setup.py
@@ -137,12 +137,6 @@ setup(name='pdo_pservice',
       url = 'http://www.intel.com',
       packages = find_packages(exclude='./pservice'),
       namespace_packages=['pdo'],
-      install_requires = [
-          'colorlog',
-          'requests',
-          'toml',
-          'twisted'
-          ],
       ext_modules = [
           enclave_module
       ],

--- a/sservice/setup.py
+++ b/sservice/setup.py
@@ -58,13 +58,6 @@ setup(name='pdo_sservice',
       url = 'http://www.intel.com',
       packages = find_packages(),
       namespace_packages=['pdo'],
-      install_requires = [
-          'colorlog',
-          'lmdb',
-          'requests',
-          'toml',
-          'twisted'
-          ],
       ext_modules = [],
       data_files = data_files,
       entry_points = {


### PR DESCRIPTION
Twisted has a dependency on zope-interface. The path to zope-interface appears to have changed (it is now zope.interface). The failed dependencies causes the build to fail. This removes the dependencies from the sservice, pservice, and eservice python packages.