### PR TITLE
Add GHA dependabot alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly


### PR DESCRIPTION
This will keep our GitHub Actions dependencies up to date.