### PR TITLE
Enable tests in SGX HW-mode (locally)

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -45,6 +45,7 @@ DOCKER_BUILDARGS += --build-arg PDO_HOSTNAME=$(PDO_HOSTNAME)
 DOCKER_BUILDARGS += --build-arg PDO_LEDGER_URL=$(PDO_LEDGER_URL)
 DOCKER_BUILDARGS += --build-arg UID=$(PDO_USER_UID)
 DOCKER_BUILDARGS += --build-arg GID=$(PDO_GROUP_UID)
+DOCKER_BUILDARGS += --build-arg SGX_MODE=$(SGX_MODE)
 DOCKER_ARGS = $(DOCKER_BUILDARGS)
 
 IMAGES=base client services_base services ccf_base ccf
@@ -109,14 +110,27 @@ TEST_FILES += -f services_base.yaml
 TEST_FILES += -f ccf_base.yaml
 TEST_FILES += -f test.yaml
 
+DOCKER_COMPOSE_COMMAND=docker-compose
+
+ifeq ($(SGX_MODE),HW)
+	TEST_FILES += -f test-sgx-hw-mode.yaml
+	SGX_DEVICE_PATH=$(shell if [ -e "/dev/isgx" ]; \
+					then echo "/dev/isgx"; \
+					elif [ -e "/dev/sgx/enclave" ]; \
+						then echo "/dev/sgx/enclave"; \
+					else echo "ERROR: NO SGX DEVICE FOUND"; \
+					fi)
+	DOCKER_COMPOSE_COMMAND := env SGX_MODE=$(SGX_MODE) SGX_DEVICE_PATH=${SGX_DEVICE_PATH} ${DOCKER_COMPOSE_COMMAND}
+endif
+
 build_test : repository
 	PDO_USER_UID=$(PDO_USER_UID) PDO_GROUP_UID=$(PDO_GROUP_UID) \
-		docker-compose $(TEST_FILES) build \
+		$(DOCKER_COMPOSE_COMMAND) $(TEST_FILES) build \
 			--build-arg PDO_VERSION=$(shell cd repository; bin/get_version)
 
 test : clean_config clean_repository build_base build_services_base build_ccf_base build_test
-	docker-compose $(TEST_FILES) up --abort-on-container-exit
-	docker-compose $(TEST_FILES) down
+	$(DOCKER_COMPOSE_COMMAND) $(TEST_FILES) up --abort-on-container-exit
+	$(DOCKER_COMPOSE_COMMAND) $(TEST_FILES) down
 
 # -----------------------------------------------------------------
 # Cleaning is a bit interesting because the containers don't go away

--- a/docker/test-sgx-hw-mode.yaml
+++ b/docker/test-sgx-hw-mode.yaml
@@ -1,0 +1,26 @@
+# Copyright 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------------------------
+version: "3.4"
+
+services:
+  services_container:
+    build:
+      args:
+        SGX_MODE: HW
+    volumes:
+      - /var/run/aesmd:/var/run/aesmd
+    devices:
+      - ${SGX_DEVICE_PATH:-/dev/isgx}:${SGX_DEVICE_PATH:-/dev/isgx}
+

--- a/docker/tools/environment.sh
+++ b/docker/tools/environment.sh
@@ -56,7 +56,7 @@ fi
 
 # this variable is needed for the build for signing the
 # eservice and pservice enclaves
-export PDO_ENCLAVE_CODE_SIGN_PEM=${PDO_SGX_KEY_ROOT}/enclave_code_sign.pem
+export PDO_ENCLAVE_CODE_SIGN_PEM=/tmp/enclave_code_sign.pem
 
 # these are only used for configuration and registration
 # they are not used at build or run time

--- a/docker/tools/run_services_tests.sh
+++ b/docker/tools/run_services_tests.sh
@@ -21,7 +21,8 @@ source ${PDO_HOME}/bin/lib/common.sh
 
 export PDO_HOSTNAME=localhost
 export PDO_LEDGER_ADDRESS=$(force_to_ip ${PDO_HOSTNAME})
-export PDO_LEDGER_URL="http://${PDO_LEDGER_ADDRESS}:6600"
+export PDO_LEDGER_PORT=6600
+export PDO_LEDGER_URL="http://${PDO_LEDGER_ADDRESS}:${PDO_LEDGER_PORT}"
 
 export no_proxy=$PDO_HOSTNAME,$PDO_LEDGER_ADDRESS,$no_proxy
 export NO_PROXY=$PDO_HOSTNAME,$PDO_LEDGER_ADDRESS,$NO_PROXY

--- a/eservice/bin/register-with-ledger.sh
+++ b/eservice/bin/register-with-ledger.sh
@@ -84,11 +84,14 @@ function Register {
         VAR_BASENAME=$(grep -o 'BASENAME:.*' ${eservice_enclave_info_file} | cut -f2- -d:)
 
         : "${PDO_LEDGER_URL:?Registration failed! PDO_LEDGER_URL environment variable not set}"
+        : "${PDO_LEDGER_ADDRESS:?Registration failed! PDO_LEDGER_ADDRESS environment variable not set}"
+        : "${PDO_LEDGER_PORT:?Registration failed! PDO_LEDGER_PORT environment variable not set}"
         : "PDO_IAS_KEY_PEM" "${PDO_IAS_KEY_PEM:?Registration failed! PDO_IAS_KEY_PEM environment variable not set}"
 
         if [ ${PDO_LEDGER_TYPE} == "ccf" ]; then
             try ${SRCDIR}/ledgers/ccf/scripts/register_enclave_attestation_verification_policy.py --logfile __screen__ --loglevel INFO \
-                --check_attestation --mrenclave ${VAR_MRENCLAVE} --basename  ${VAR_BASENAME} --ias-public-key "$(cat $PDO_IAS_KEY_PEM)"
+                --check-attestation --mrenclave ${VAR_MRENCLAVE} --basename  ${VAR_BASENAME} --ias-public-key "$(cat $PDO_IAS_KEY_PEM)" \
+                --interface ${PDO_LEDGER_ADDRESS} --port ${PDO_LEDGER_PORT}
         else
             die unsupported ledger ${PDO_LEDGER_TYPE}
         fi


### PR DESCRIPTION
This PR enables tests in SGX HW-mode.

Some important points and things to be discussed:

1.  there appears to be some redundancy between (a) `docker build` and (b) `docker-compose build` in the docker Makefile. When testing in HW mode, it's not clear which build is used and there is discrepancy in using args (e.g., (a) does not pass the `SGX_MODE` variable). Ideally we may want to consolidate the build of the images and just use compose for running tests.

2.  this PR passes the `SGX_MODE` variable to all the builds (particularly those that use it). This is necessary when we build the services, and it's also nice to have since we set the relative env var in the docker file, the env var persists in the image, so later the variable can be used to distinguish between SIM/HW-mode images.

3. `environment.sh` sets `PDO_SGX_KEY_ROOT` to a folder within the `XFER` folder. However, the `XFER` is not available during a docker build (it's docker compose that later mounts that). This is a problem during the service build, because PDO uses that folder to store the enclave signing key. Since the key is ephemeral for now, this PR moves the enclave signing key to `/tmp/`.

4. The policy registration script is called in one of two different places, depending on `SGX_MODE`. Namely: `register-with-ledger.sh` in HW-MODE, and `start_ccf_network.sh` in SIM-mode. First, these calls should be consolidated in a single place (probably the former). Second, `start_ccf_network.sh` and (in particular) the CCF images only need the `SGX_MODE` variable to trigger this script.

5. The policy registration script looks for the CCF keys in multiple places. We should discuss whether the XFER folder is the only reasonable place where these could be, and simplify the rest.

6. Among the global user-facing environment variables, PDO defines `PDO_LEDGER_URL`. However, in multiple places now PDO is using a combination of `PDO_LEDGER_ADDRESS` and (hard-coded) port -- because this is what CCF needs. We should discuss whether address and port should be promoted to global envs, or rather be derived from the ledger url.