### PR TITLE
Speed up docker (re-)build by caching pip cache

### DIFF
--- a/docker/pdo_ccf.dockerfile
+++ b/docker/pdo_ccf.dockerfile
@@ -15,6 +15,9 @@
 # ------------------------------------------------------------------------------
 
 # syntax = docker/dockerfile:experimental
+# above enable build-kit extension for 'RUN --mount=type= ..' extension used below
+# to cache pip downloads between builds, cutting down noticeably build time.
+# Note that cache is cleaned with the "uusal" docker prune commans, e.g., docker builder prune.
 
 ARG PDO_VERSION
 FROM pdo_ccf_base:${PDO_VERSION}
@@ -48,7 +51,8 @@ COPY --chown=${UNAME}:${UNAME} tools/*.sh ./
 # build it!!!
 ARG UID=1000
 ARG GID=${UID}
-RUN --mount=type=cache,uid=${UID},gid=${GID},target=/project/pdo/.cache/pip /project/pdo/tools/build_ccf.sh
+RUN --mount=type=cache,uid=${UID},gid=${GID},target=/project/pdo/.cache/pip \
+    /project/pdo/tools/build_ccf.sh
 
 # Network ports for running services
 EXPOSE 6600

--- a/docker/pdo_ccf.dockerfile
+++ b/docker/pdo_ccf.dockerfile
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# syntax = docker/dockerfile:experimental
+
 ARG PDO_VERSION
 FROM pdo_ccf_base:${PDO_VERSION}
 
@@ -44,7 +46,9 @@ WORKDIR /project/pdo/tools
 COPY --chown=${UNAME}:${UNAME} tools/*.sh ./
 
 # build it!!!
-RUN /project/pdo/tools/build_ccf.sh
+ARG UID=1000
+ARG GID=${UID}
+RUN --mount=type=cache,uid=${UID},gid=${GID},target=/project/pdo/.cache/pip /project/pdo/tools/build_ccf.sh
 
 # Network ports for running services
 EXPOSE 6600

--- a/docker/pdo_client.dockerfile
+++ b/docker/pdo_client.dockerfile
@@ -15,6 +15,9 @@
 # ------------------------------------------------------------------------------
 
 # syntax = docker/dockerfile:experimental
+# above enable build-kit extension for 'RUN --mount=type= ..' extension used below
+# to cache pip downloads between builds, cutting down noticeably build time.
+# Note that cache is cleaned with the "uusal" docker prune commans, e.g., docker builder prune.
 
 ARG PDO_VERSION
 FROM pdo_base:${PDO_VERSION}
@@ -67,7 +70,8 @@ COPY --chown=${UNAME}:${UNAME} tools/*.sh ./
 # build it!!!
 ARG UID=1000
 ARG GID=${UID}
-RUN --mount=type=cache,uid=${UID},gid=${GID},target=/project/pdo/.cache/pip /project/pdo/tools/build_client.sh
+RUN --mount=type=cache,uid=${UID},gid=${GID},target=/project/pdo/.cache/pip \
+    /project/pdo/tools/build_client.sh
 
 ARG PDO_HOSTNAME
 ENV PDO_HOSTNAME=$PDO_HOSTNAME

--- a/docker/pdo_client.dockerfile
+++ b/docker/pdo_client.dockerfile
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# syntax = docker/dockerfile:experimental
+
 ARG PDO_VERSION
 FROM pdo_base:${PDO_VERSION}
 
@@ -63,7 +65,9 @@ WORKDIR /project/pdo/tools
 COPY --chown=${UNAME}:${UNAME} tools/*.sh ./
 
 # build it!!!
-RUN /project/pdo/tools/build_client.sh
+ARG UID=1000
+ARG GID=${UID}
+RUN --mount=type=cache,uid=${UID},gid=${GID},target=/project/pdo/.cache/pip /project/pdo/tools/build_client.sh
 
 ARG PDO_HOSTNAME
 ENV PDO_HOSTNAME=$PDO_HOSTNAME

--- a/docker/pdo_services.dockerfile
+++ b/docker/pdo_services.dockerfile
@@ -15,6 +15,9 @@
 # ------------------------------------------------------------------------------
 
 # syntax = docker/dockerfile:experimental
+# above enable build-kit extension for 'RUN --mount=type= ..' extension used below
+# to cache pip downloads between builds, cutting down noticeably build time.
+# Note that cache is cleaned with the "uusal" docker prune commans, e.g., docker builder prune.
 
 ARG PDO_VERSION
 FROM pdo_services_base:${PDO_VERSION}
@@ -52,7 +55,8 @@ COPY --chown=${UNAME}:${UNAME} tools/*.sh ./
 # built it!
 ARG UID=1000
 ARG GID=${UID}
-RUN --mount=type=cache,uid=${UID},gid=${GID},target=/project/pdo/.cache/pip /project/pdo/tools/build_services.sh
+RUN --mount=type=cache,uid=${UID},gid=${GID},target=/project/pdo/.cache/pip \
+    /project/pdo/tools/build_services.sh
 
 # Network ports for running services
 EXPOSE 7001 7002 7003 7004 7005

--- a/docker/pdo_services.dockerfile
+++ b/docker/pdo_services.dockerfile
@@ -14,6 +14,8 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
+# syntax = docker/dockerfile:experimental
+
 ARG PDO_VERSION
 FROM pdo_services_base:${PDO_VERSION}
 
@@ -48,7 +50,9 @@ WORKDIR /project/pdo/tools
 COPY --chown=${UNAME}:${UNAME} tools/*.sh ./
 
 # built it!
-RUN /project/pdo/tools/build_services.sh
+ARG UID=1000
+ARG GID=${UID}
+RUN --mount=type=cache,uid=${UID},gid=${GID},target=/project/pdo/.cache/pip /project/pdo/tools/build_services.sh
 
 # Network ports for running services
 EXPOSE 7001 7002 7003 7004 7005


### PR DESCRIPTION
With warm pip-caches this did reduce docker build time on my laptop in WSL by more than half ...

BTW: mounting a pip-cache volume (`docker run -v $(DOCKER_DIR)/cache/pip:/project/pdo/.cache/pip ...`) also sped up ever more greatly testing of inference contract given the homogenously sized tensorflow packages ... 