### PR TITLE
Add comments to SW to address concerns in Issue 195

### DIFF
--- a/ledgers/ccf/transaction_processor/pdo_tp.cpp
+++ b/ledgers/ccf/transaction_processor/pdo_tp.cpp
@@ -247,6 +247,15 @@ namespace ccfapp
                 6. basename
                 7. user report data
 
+		Note that we do not currently verify whether the enclave debug
+		flag is turned on or not. In order to ensure that the enclave is
+		run in a mode that supports enhanced-confidentiality and
+		execution integrity, the debug flag (SGX_FLAGS_DEBUG /
+		0x0000000000000002ULL in the report's attribute) should be set
+		to 0. For additional details on how we plan to support this
+		check, please see
+		https://github.com/hyperledger-labs/private-data-objects/issues/195.
+
                 */
 
                 ProofData enclave_proof_data;

--- a/pservice/lib/libpdo_enclave/secret_enclave.cpp
+++ b/pservice/lib/libpdo_enclave/secret_enclave.cpp
@@ -676,7 +676,14 @@ pdo_err_t VerifyEnclaveInfo(const std::string& enclaveInfo,
         memcmp(computedReportData.d, expectedReportData.d, SGX_REPORT_DATA_SIZE)  != 0,
         "Invalid Report data: computedReportData does not match expectedReportData");
 
-
+    //Note that we do not currently verify whether the enclave debug flag is
+    //turned on or not. In order to ensure that the enclave is run in a mode
+    //that supports enhanced-confidentiality and execution integrity, the debug
+    //flag (SGX_FLAGS_DEBUG / 0x0000000000000002ULL in the report's attribute)
+    //should be set to 0. For additional details on how we plan to support this
+    //check, please see
+    //https://github.com/hyperledger-labs/private-data-objects/issues/195.
+    //
     return result;
 }// VerifyEnclaveInfo
 


### PR DESCRIPTION
Adding comments to pdo tp and pservice code where enclave ias attesta…tion verification report is checked. Adding notes about the fact that currently we do not check whether the enclave runs in SGX debug mode or not. The corresponding issue can be found at https://github.com/hyperledger-labs/private-data-objects/issues/195