### PR TITLE
Extend the contract build cmake script to include custom libraries and headers

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -49,7 +49,15 @@ PDO_USER_UID ?= $(shell id -u)
 PDO_GROUP_UID ?= $(shell id -g)
 
 DOCKER_COMMAND ?= docker
-DOCKER_COMPOSE_COMMAND ?= docker-compose
+
+ifndef DOCKER_COMPOSE_COMMAND
+  DOCKER_COMPOSE_COMMAND := $(shell command -v docker-compose 2> /dev/null)
+  ifndef DOCKER_COMPOSE_COMMAND
+    $(warning "docker-compose command is not available")
+    DOCKER_COMPOSE_COMMAND := $(DOCKER_COMMAND) compose
+  endif
+endif
+
 # to work with upstream docker and docker compose plugin, redefine above
 # as `DOCKER_COMPOSE_COMMAND=docker compose` in your `make.loc`
 


### PR DESCRIPTION
Add HEADERS and LIBRARIES parameters to the contract build script. This makes it possible to customize each contract without changing the global WASM options.

Added some documentation.