### PR TITLE
Updates to github workflows for PDO

### DIFF
--- a/.github/workflows/configured_test.yml
+++ b/.github/workflows/configured_test.yml
@@ -1,0 +1,66 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+name: Run specific PDO tests
+on:
+  workflow_dispatch:
+    inputs:
+      interpreter:
+        description: 'Interpreter'
+        required: true
+        default: 'wawaka'
+        type: choice
+        options:
+        - wawaka
+        - wawaka-opt
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+        type: choice
+        options:
+          - debug
+          - info
+          - warning
+      memoryConfiguration:
+        description: 'Interpreter memory configuration'
+        required: false
+        default: MEDIUM
+        type: choice
+        options:
+          - SMALL
+          - MEDIUM
+          - LARGE
+jobs:
+    pdo_specific_tests:
+        name: Run specific PDO tests
+        runs-on: ubuntu-22.04
+
+        steps:
+            - name: Check out repo
+              uses: actions/checkout@v4
+              with:
+                submodules: recursive
+                fetch-depth: 0
+                fetch-tags: true
+
+            - name: Display branch name
+              run: |
+                echo "Building branch $GITHUB_HEAD_REF"
+                echo PDO VERSION is $(bin/get_version)
+
+            - name: Build and run tests
+              env:
+                  PDO_INTERPRETER: ${{ inputs.interpreter }}
+                  PDO_LOG_LEVEL: ${{ inputs.logLevel }}
+                  PDO_MEMORY_CONFIG: ${{ inputs.memoryConfiguration }}
+                  PDO_DEBUG_BUILD: 1
+              run: |
+                  # The creation of a dummy branch is necessary for the CI tests
+                  # to work on PRs. Based on empirical results, in the absence of
+                  # this command, CI tests work on the main branch and on local
+                  # branches. However, they fail as a PR is created.
+                  git checkout -b ci-test-branch
+                  . build/common-config.sh
+                  make -C docker test

--- a/.github/workflows/configured_test.yml
+++ b/.github/workflows/configured_test.yml
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# This workflow is intended to provide an interactive way of configuring
+# PDO tests. Common configuration variables can be set interactively to
+# debug differences between local and github.
+
 name: Run specific PDO tests
 on:
   workflow_dispatch:
@@ -32,6 +36,7 @@ on:
           - SMALL
           - MEDIUM
           - LARGE
+
 jobs:
     pdo_specific_tests:
         name: Run specific PDO tests

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,63 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+name: Build and Push PDO Docker Images
+
+on:
+  workflow_dispatch:
+
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+
+  docker_build:
+
+    if: >
+      github.event.name == 'workflow_dispatch' ||
+      github.event.name == 'pull_request' && github.event.pull_request.merged == true
+    name: Build PDO Images
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Display branch name
+        run: |
+          echo "Building branch images for $GITHUB_HEAD_REF"
+          echo PDO VERSION is $(bin/get_version)
+          echo "PDO_VERSION=$(bin/get_version)" >> $GITHUB_ENV
+          echo "EVENT NAME: ${{ github.event.name }}"
+          echo "MERGED: ${{ github.event.pull_request.merged }}"
+
+      - name: Build Docker Images
+        env:
+          PDO_INTERPRETER: wawaka
+          PDO_LOG_LEVEL: warning
+        run: |
+          git checkout -b ci-test-branch
+          . build/common-config.sh
+          make -C docker
+
+      - name: Login to the ghcr.io Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag and push the images
+        run: |
+          for image in pdo_services pdo_ccf pdo_client
+          do
+            docker image tag ghcr.io/{{ github.repository_owner }}/$image:$PDO_VERSION
+            docker image tag ghcr.io/{{ github.repository_owner }}/$image:latest
+            docker image push --all-tags ghcr.io/{{ github.repository_owner }}/$image
+          done

--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-name: PDO CI
-on: [pull_request, push]
+name: Run full PDO tests
+on: [ pull_request ]
+
 jobs:
-    pdo_ci:
+    pdo_full_tests:
         if: "!contains(github.event.commits[0].message, '[skip ci]')"
-        name: PDO CI Job
+        name: Run full PDO tests
         runs-on: ubuntu-22.04
 
         strategy:
@@ -25,28 +26,13 @@ jobs:
 
             - name: Display branch name
               run: |
-                echo "Building branch $GITHUB_HEAD_REF"
                 echo PDO VERSION is $(bin/get_version)
+                echo "BRANCH is $GITHUB_HEAD_REF"
 
             - name: Build and run tests
-              if: "!contains(github.event.commits[0].message, '[debug]')"
               env:
                   PDO_INTERPRETER: ${{ matrix.interpreter }}
                   PDO_LOG_LEVEL: warning
-              run: |
-                  # The creation of a dummy branch is necessary for the CI tests
-                  # to work on PRs. Based on empirical results, in the absence of
-                  # this command, CI tests work on the main branch and on local
-                  # branches. However, they fail as a PR is created.
-                  git checkout -b ci-test-branch
-                  . build/common-config.sh
-                  make -C docker test
-
-            - name: Build and run tests (DEBUG MODE)
-              if: "contains(github.event.commits[0].message, '[debug]')"
-              env:
-                  PDO_INTERPRETER: ${{ matrix.interpreter }}
-                  PDO_LOG_LEVEL: debug
               run: |
                   # The creation of a dummy branch is necessary for the CI tests
                   # to work on PRs. Based on empirical results, in the absence of

--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -2,6 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# This workflow is intended to be used as a validity test for any
+# pull request. That is, this is a minimal functionality that must
+# be successfully executed prior to merging a pull request. Note
+# that this can be overridden by adding '[skip ci]' in the commit
+# name. This should not be done on the main PDO branch.
+
 name: Run full PDO tests
 on: [ pull_request ]
 


### PR DESCRIPTION
*EXPERIMENTAL* -- new github workflows will only be visible and runnable when they are attached to the main branch. this commit will enable further testing.

Expand the github workflows associated with the PDO repository. The old "ci" workflow has been moved to a workflow called "full_test" and is used as a condition for merge of PRs. It will no longer be run on every push but only on PR creation and synchronization (when updates are pushed).

Add a "configured_test" workflow that can be dispatched on demand. This workflow allows for different build and run parameters to be set interactively.

Add a "build_docker" workflow that will attempt to build docker images pdo_client, pdo_services and pdo_ccf when a PR is merged successfully. This workflow can also be dispatched interactively.