### PR TITLE
Improvements for docker user management and documentation

### DIFF
--- a/docker/base.yaml
+++ b/docker/base.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-version: "3.4"
+
 
 services:
   base_container:

--- a/docker/ccf_base.yaml
+++ b/docker/ccf_base.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
-version: "3.4"
+
 
 services:
   ccf_container:

--- a/docker/client_base.yaml
+++ b/docker/client_base.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
-version: "3.4"
+
 
 services:
   client_container:

--- a/docker/configured_services.yaml
+++ b/docker/configured_services.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-version: "3.4"
+
 
 services:
   services_container:

--- a/docker/pdo_ccf.dockerfile
+++ b/docker/pdo_ccf.dockerfile
@@ -19,7 +19,7 @@
 # to cache pip downloads between builds, cutting down noticeably build time.
 # Note that cache is cleaned with the "uusal" docker prune commans, e.g., docker builder prune.
 
-ARG PDO_VERSION
+ARG PDO_VERSION=latest
 FROM pdo_ccf_base:${PDO_VERSION}
 
 # -----------------------------------------------------------------
@@ -38,6 +38,13 @@ ENV PDO_DEBUG_BUILD=${PDO_DEBUG_BUILD}
 ARG XFER_DIR=/project/pdo/xfer
 ENV XFER_DIR=${XFER_DIR}
 
+# copy the source files into the image using the user
+# identity that was created in the base container
+ARG UNAME=pdo_user
+ENV UNAME=${UNAME}
+
+USER $UNAME
+
 # copy the source files into the image
 WORKDIR /project/pdo
 COPY --chown=${UNAME}:${UNAME} repository /project/pdo/src
@@ -49,9 +56,7 @@ WORKDIR /project/pdo/tools
 COPY --chown=${UNAME}:${UNAME} tools/*.sh ./
 
 # build it!!!
-ARG UID=1000
-ARG GID=${UID}
-RUN --mount=type=cache,uid=${UID},gid=${GID},target=/project/pdo/.cache/pip \
+RUN --mount=type=cache,target=/project/pdo/.cache/pip \
     /project/pdo/tools/build_ccf.sh
 
 # Network ports for running services

--- a/docker/pdo_services_base.dockerfile
+++ b/docker/pdo_services_base.dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-ARG PDO_VERSION
+ARG PDO_VERSION=latest
 FROM pdo_base:${PDO_VERSION}
 
 ARG UBUNTU_VERSION=22.04
@@ -24,7 +24,11 @@ ARG SGX=2.25
 ARG OPENSSL=3.0.14
 ARG SGXSSL=3.0_Rev4
 
-RUN echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu ${UBUNTU_NAME} main" >> /etc/apt/sources.list \
+USER root
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+ echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu ${UBUNTU_NAME} main" >> /etc/apt/sources.list \
  && wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add - \
  && apt-get update \
  && apt-get install -y \
@@ -86,17 +90,9 @@ ENV SGX_SSL="/opt/intel/sgxssl"
 
 # -----------------------------------------------------------------
 # -----------------------------------------------------------------
-WORKDIR /project/pdo
-
-ARG UNAME=pdo_services
+ARG UNAME=pdo_user
 ENV UNAME=${UNAME}
 
-ARG UID=1000
-ARG GID=$UID
-
-RUN groupadd -f -g $GID -o $UNAME
-RUN useradd -m -u $UID -g $GID -d /project/pdo -o -s /bin/bash $UNAME
-RUN chown --recursive $UNAME:$UNAME /project/pdo
 USER $UNAME
-
+WORKDIR /project/pdo
 ENTRYPOINT ["/bin/bash"]

--- a/docker/services_base.yaml
+++ b/docker/services_base.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ------------------------------------------------------------------------------
 
-version: "3.4"
+
 
 services:
   services_container:

--- a/docker/test-sgx.yaml
+++ b/docker/test-sgx.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
-version: "3.4"
+
 
 services:
   ccf_container:

--- a/docker/test.yaml
+++ b/docker/test.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ------------------------------------------------------------------------------
-version: "3.4"
+
 
 # Note that we do not need to specify PDO_HOSTNAME or PDO_LEDGER_URL
 # (or the corresponding --inteface or --ledger switches) for the test


### PR DESCRIPTION
This PR cleans up the user and group creation in the docker build. An account and group are created in the base images and then used more consistently throughout the rest of the build process.

Added documentation for how to build and deploy "reusable" images that might be store, for example, in a public registry. This information should make it easier to use the images being built on github.

There are also some additions the docker cache for apt packages. 

Testing: automated tests should handle the changes to the docker build scripts. The instructions in the docker README.md for building deployable images (the final pattern) should be verified.